### PR TITLE
Linting

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/__init__.py
+++ b/src/connectedk8s/azext_connectedk8s/__init__.py
@@ -5,7 +5,7 @@
 
 from azure.cli.core import AzCommandsLoader
 
-from azext_connectedk8s._help import helps  # pylint: disable=unused-import
+from azext_connectedk8s._help import helps
 
 
 class Connectedk8sCommandsLoader(AzCommandsLoader):
@@ -34,3 +34,9 @@ class Connectedk8sCommandsLoader(AzCommandsLoader):
 
 
 COMMAND_LOADER_CLS = Connectedk8sCommandsLoader
+
+__all__ = [
+    "helps",
+    "Connectedk8sCommandsLoader",
+    "COMMAND_LOADER_CLS",
+]

--- a/src/connectedk8s/azext_connectedk8s/__init__.py
+++ b/src/connectedk8s/azext_connectedk8s/__init__.py
@@ -9,22 +9,27 @@ from azext_connectedk8s._help import helps  # pylint: disable=unused-import
 
 
 class Connectedk8sCommandsLoader(AzCommandsLoader):
-
     def __init__(self, cli_ctx=None):
         from azure.cli.core.commands import CliCommandType
         from azext_connectedk8s._client_factory import cf_connectedk8s
+
         connectedk8s_custom = CliCommandType(
-            operations_tmpl='azext_connectedk8s.custom#{}',
-            client_factory=cf_connectedk8s)
-        super(Connectedk8sCommandsLoader, self).__init__(cli_ctx=cli_ctx, custom_command_type=connectedk8s_custom)
+            operations_tmpl="azext_connectedk8s.custom#{}",
+            client_factory=cf_connectedk8s,
+        )
+        super(Connectedk8sCommandsLoader, self).__init__(
+            cli_ctx=cli_ctx, custom_command_type=connectedk8s_custom
+        )
 
     def load_command_table(self, args):
         from azext_connectedk8s.commands import load_command_table
+
         load_command_table(self, args)
         return self.command_table
 
     def load_arguments(self, command):
         from azext_connectedk8s._params import load_arguments
+
         load_arguments(self, command)
 
 

--- a/src/connectedk8s/azext_connectedk8s/_client_factory.py
+++ b/src/connectedk8s/azext_connectedk8s/_client_factory.py
@@ -5,12 +5,8 @@
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.profiles import ResourceType
-from azure.cli.core._profile import Profile
 from azure.cli.core import telemetry
 from azure.cli.core.azclierror import ValidationError
-from azure.cli.core.commands.client_factory import configure_common_settings
-from azure.cli.core.commands.client_factory import get_subscription_id
-from azure.graphrbac import GraphRbacManagementClient
 
 import os
 import requests
@@ -133,8 +129,6 @@ def cf_resource_groups(cli_ctx, subscription_id=None):
 
 
 def _resource_client_factory(cli_ctx, subscription_id=None):
-    from azure.mgmt.resource import ResourceManagementClient
-
     if os.getenv(consts.Azure_Access_Token_Variable):
         credential = AccessTokenCredential(
             access_token=os.getenv(consts.Azure_Access_Token_Variable)

--- a/src/connectedk8s/azext_connectedk8s/_client_factory.py
+++ b/src/connectedk8s/azext_connectedk8s/_client_factory.py
@@ -22,12 +22,18 @@ AccessToken = namedtuple("AccessToken", ["token", "expires_on"])
 
 def cf_connectedk8s(cli_ctx, *_):
     from azext_connectedk8s.vendored_sdks import ConnectedKubernetesClient
+
     if os.getenv(consts.Azure_Access_Token_Variable):
         validate_custom_token()
-        credential = AccessTokenCredential(access_token=os.getenv(consts.Azure_Access_Token_Variable))
-        return get_mgmt_service_client(cli_ctx, ConnectedKubernetesClient,
-                                       subscription_id=os.getenv('AZURE_SUBSCRIPTION_ID'),
-                                       credential=credential)
+        credential = AccessTokenCredential(
+            access_token=os.getenv(consts.Azure_Access_Token_Variable)
+        )
+        return get_mgmt_service_client(
+            cli_ctx,
+            ConnectedKubernetesClient,
+            subscription_id=os.getenv("AZURE_SUBSCRIPTION_ID"),
+            credential=credential,
+        )
     return get_mgmt_service_client(cli_ctx, ConnectedKubernetesClient)
 
 
@@ -36,13 +42,21 @@ def cf_connected_cluster(cli_ctx, _):
 
 
 def cf_connectedk8s_prev_2022_10_01(cli_ctx, *_):
-    from azext_connectedk8s.vendored_sdks.preview_2022_10_01 import ConnectedKubernetesClient
+    from azext_connectedk8s.vendored_sdks.preview_2022_10_01 import (
+        ConnectedKubernetesClient,
+    )
+
     if os.getenv(consts.Azure_Access_Token_Variable):
         validate_custom_token()
-        credential = AccessTokenCredential(access_token=os.getenv(consts.Azure_Access_Token_Variable))
-        return get_mgmt_service_client(cli_ctx, ConnectedKubernetesClient,
-                                       subscription_id=os.getenv('AZURE_SUBSCRIPTION_ID'),
-                                       credential=credential)
+        credential = AccessTokenCredential(
+            access_token=os.getenv(consts.Azure_Access_Token_Variable)
+        )
+        return get_mgmt_service_client(
+            cli_ctx,
+            ConnectedKubernetesClient,
+            subscription_id=os.getenv("AZURE_SUBSCRIPTION_ID"),
+            credential=credential,
+        )
     return get_mgmt_service_client(cli_ctx, ConnectedKubernetesClient)
 
 
@@ -51,13 +65,21 @@ def cf_connected_cluster_prev_2022_10_01(cli_ctx, _):
 
 
 def cf_connectedk8s_prev_2023_11_01(cli_ctx, *_):
-    from azext_connectedk8s.vendored_sdks.preview_2023_11_01 import ConnectedKubernetesClient
+    from azext_connectedk8s.vendored_sdks.preview_2023_11_01 import (
+        ConnectedKubernetesClient,
+    )
+
     if os.getenv(consts.Azure_Access_Token_Variable):
         validate_custom_token()
-        credential = AccessTokenCredential(access_token=os.getenv(consts.Azure_Access_Token_Variable))
-        return get_mgmt_service_client(cli_ctx, ConnectedKubernetesClient,
-                                       subscription_id=os.getenv('AZURE_SUBSCRIPTION_ID'),
-                                       credential=credential)
+        credential = AccessTokenCredential(
+            access_token=os.getenv(consts.Azure_Access_Token_Variable)
+        )
+        return get_mgmt_service_client(
+            cli_ctx,
+            ConnectedKubernetesClient,
+            subscription_id=os.getenv("AZURE_SUBSCRIPTION_ID"),
+            credential=credential,
+        )
     return get_mgmt_service_client(cli_ctx, ConnectedKubernetesClient)
 
 
@@ -66,13 +88,21 @@ def cf_connected_cluster_prev_2023_11_01(cli_ctx, _):
 
 
 def cf_connectedk8s_prev_2024_07_01(cli_ctx, *_):
-    from azext_connectedk8s.vendored_sdks.preview_2024_07_01 import ConnectedKubernetesClient
+    from azext_connectedk8s.vendored_sdks.preview_2024_07_01 import (
+        ConnectedKubernetesClient,
+    )
+
     if os.getenv(consts.Azure_Access_Token_Variable):
         validate_custom_token()
-        credential = AccessTokenCredential(access_token=os.getenv(consts.Azure_Access_Token_Variable))
-        return get_mgmt_service_client(cli_ctx, ConnectedKubernetesClient,
-                                       subscription_id=os.getenv('AZURE_SUBSCRIPTION_ID'),
-                                       credential=credential)
+        credential = AccessTokenCredential(
+            access_token=os.getenv(consts.Azure_Access_Token_Variable)
+        )
+        return get_mgmt_service_client(
+            cli_ctx,
+            ConnectedKubernetesClient,
+            subscription_id=os.getenv("AZURE_SUBSCRIPTION_ID"),
+            credential=credential,
+        )
     return get_mgmt_service_client(cli_ctx, ConnectedKubernetesClient)
 
 
@@ -82,13 +112,20 @@ def cf_connected_cluster_prev_2024_07_01(cli_ctx, _):
 
 def cf_connectedmachine(cli_ctx, subscription_id):
     from azure.mgmt.hybridcompute import HybridComputeManagementClient
+
     if os.getenv(consts.Azure_Access_Token_Variable):
-        credential = AccessTokenCredential(access_token=os.getenv(consts.Azure_Access_Token_Variable))
-        return get_mgmt_service_client(cli_ctx, HybridComputeManagementClient,
-                                       subscription_id=subscription_id,
-                                       credential=credential).private_link_scopes
-    return get_mgmt_service_client(cli_ctx, HybridComputeManagementClient,
-                                   subscription_id=subscription_id).private_link_scopes
+        credential = AccessTokenCredential(
+            access_token=os.getenv(consts.Azure_Access_Token_Variable)
+        )
+        return get_mgmt_service_client(
+            cli_ctx,
+            HybridComputeManagementClient,
+            subscription_id=subscription_id,
+            credential=credential,
+        ).private_link_scopes
+    return get_mgmt_service_client(
+        cli_ctx, HybridComputeManagementClient, subscription_id=subscription_id
+    ).private_link_scopes
 
 
 def cf_resource_groups(cli_ctx, subscription_id=None):
@@ -97,12 +134,20 @@ def cf_resource_groups(cli_ctx, subscription_id=None):
 
 def _resource_client_factory(cli_ctx, subscription_id=None):
     from azure.mgmt.resource import ResourceManagementClient
+
     if os.getenv(consts.Azure_Access_Token_Variable):
-        credential = AccessTokenCredential(access_token=os.getenv(consts.Azure_Access_Token_Variable))
-        return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,
-                                       subscription_id=subscription_id, credential=credential)
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,
-                                   subscription_id=subscription_id)
+        credential = AccessTokenCredential(
+            access_token=os.getenv(consts.Azure_Access_Token_Variable)
+        )
+        return get_mgmt_service_client(
+            cli_ctx,
+            ResourceType.MGMT_RESOURCE_RESOURCES,
+            subscription_id=subscription_id,
+            credential=credential,
+        )
+    return get_mgmt_service_client(
+        cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES, subscription_id=subscription_id
+    )
 
 
 def resource_providers_client(cli_ctx, subscription_id=None):
@@ -115,30 +160,34 @@ def resource_providers_client(cli_ctx, subscription_id=None):
 
 
 class AccessTokenCredential:
-    """Simple access token Authentication. Returns the access token as-is.
-    """
+    """Simple access token Authentication. Returns the access token as-is."""
 
     def __init__(self, access_token):
         self.access_token = access_token
 
     def get_token(self, *arg, **kwargs):
         import time
+
         # Assume the access token expires in 60 minutes
         return AccessToken(self.access_token, int(time.time()) + 3600)
 
     def signed_session(self, session=None):
         session = session or requests.Session()
-        header = "{} {}".format('Bearer', self.access_token)
-        session.headers['Authorization'] = header
+        header = "{} {}".format("Bearer", self.access_token)
+        session.headers["Authorization"] = header
         return session
 
 
 def validate_custom_token():
-    if os.getenv('AZURE_SUBSCRIPTION_ID') is None:
-        telemetry.set_exception(exception='Required environment variable \'AZURE_SUBSCRIPTION_ID\' is not set, when '
-                                          'using Custom Access Token.',
-                                fault_type=consts.Custom_Token_Env_Var_Sub_Id_Missing_Fault_Type,
-                                summary='Required environment variable \'AZURE_SUBSCRIPTION_ID\' is not set, when '
-                                        'using Custom Access Token.')
-        raise ValidationError("Environment variable 'AZURE_SUBSCRIPTION_ID' should be set when custom access token "
-                              "is enabled.")
+    if os.getenv("AZURE_SUBSCRIPTION_ID") is None:
+        telemetry.set_exception(
+            exception="Required environment variable 'AZURE_SUBSCRIPTION_ID' is not set, when "
+            "using Custom Access Token.",
+            fault_type=consts.Custom_Token_Env_Var_Sub_Id_Missing_Fault_Type,
+            summary="Required environment variable 'AZURE_SUBSCRIPTION_ID' is not set, when "
+            "using Custom Access Token.",
+        )
+        raise ValidationError(
+            "Environment variable 'AZURE_SUBSCRIPTION_ID' should be set when custom access token "
+            "is enabled."
+        )

--- a/src/connectedk8s/azext_connectedk8s/_clientproxyutils.py
+++ b/src/connectedk8s/azext_connectedk8s/_clientproxyutils.py
@@ -16,22 +16,32 @@ from base64 import b64encode, b64decode
 from azure.cli.core._profile import Profile
 from azure.cli.core import telemetry
 from azure.cli.core.azclierror import CLIInternalError
-from psutil import process_iter, NoSuchProcess, AccessDenied, ZombieProcess, net_connections
+from psutil import (
+    process_iter,
+    NoSuchProcess,
+    AccessDenied,
+    ZombieProcess,
+    net_connections,
+)
 from knack.log import get_logger
 from azure.cli.core.auth.msal_authentication import ServicePrincipalCredential
+
 logger = get_logger(__name__)
 
 
 def check_if_port_is_open(port):
     try:
-        connections = net_connections(kind='inet')
+        connections = net_connections(kind="inet")
         for tup in connections:
             if int(tup[3][1]) == int(port):
                 return True
     except Exception as e:
-        telemetry.set_exception(exception=e, fault_type=consts.Port_Check_Fault_Type,
-                                summary='Failed to check if port is in use.')
-        if platform.system() != 'Darwin':
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Port_Check_Fault_Type,
+            summary="Failed to check if port is in use.",
+        )
+        if platform.system() != "Darwin":
             logger.info("Failed to check if port is in use. " + str(e))
         return False
     return False
@@ -43,10 +53,12 @@ def close_subprocess_and_raise_cli_error(proc_subprocess, msg):
 
 
 def check_if_csp_is_running(clientproxy_process):
-    return (clientproxy_process.poll() is None)
+    return clientproxy_process.poll() is None
 
 
-def make_api_call_with_retries(uri, data, method, tls_verify, fault_type, summary, cli_error, clientproxy_process):
+def make_api_call_with_retries(
+    uri, data, method, tls_verify, fault_type, summary, cli_error, clientproxy_process
+):
     for i in range(consts.API_CALL_RETRIES):
         try:
             response = requests.request(method, uri, json=data, verify=tls_verify)
@@ -56,86 +68,115 @@ def make_api_call_with_retries(uri, data, method, tls_verify, fault_type, summar
             if i != consts.API_CALL_RETRIES - 1:
                 pass
             else:
-                telemetry.set_exception(exception=e, fault_type=fault_type, summary=summary)
-                close_subprocess_and_raise_cli_error(clientproxy_process, cli_error + str(e))
+                telemetry.set_exception(
+                    exception=e, fault_type=fault_type, summary=summary
+                )
+                close_subprocess_and_raise_cli_error(
+                    clientproxy_process, cli_error + str(e)
+                )
 
 
 def fetch_pop_publickey_kid(api_server_port, clientproxy_process):
     requestbody = {}
-    poppublickey_uri = f'https://localhost:{api_server_port}/identity/poppublickey'
+    poppublickey_uri = f"https://localhost:{api_server_port}/identity/poppublickey"
     # Needed to prevent skip tls warning from printing to the console
     original_stderr = sys.stderr
-    f = open(os.devnull, 'w')
+    f = open(os.devnull, "w")
     sys.stderr = f
 
-    get_publickey_response = make_api_call_with_retries(poppublickey_uri, requestbody, "get", False,
-                                                        consts.Get_PublicKey_Info_Fault_Type,
-                                                        'Failed to fetch public key info from clientproxy',
-                                                        "Failed to fetch public key info from client proxy",
-                                                        clientproxy_process)
+    get_publickey_response = make_api_call_with_retries(
+        poppublickey_uri,
+        requestbody,
+        "get",
+        False,
+        consts.Get_PublicKey_Info_Fault_Type,
+        "Failed to fetch public key info from clientproxy",
+        "Failed to fetch public key info from client proxy",
+        clientproxy_process,
+    )
 
     sys.stderr = original_stderr
     publickey_info = json.loads(get_publickey_response.text)
-    kid = publickey_info['publicKey']['kid']
+    kid = publickey_info["publicKey"]["kid"]
 
     return kid
 
 
 def fetch_and_post_at_to_csp(cmd, api_server_port, tenant_id, kid, clientproxy_process):
     req_cnfJSON = {"kid": kid, "xms_ksl": "sw"}
-    req_cnf = base64.urlsafe_b64encode(json.dumps(req_cnfJSON).encode('utf-8')).decode('utf-8')
+    req_cnf = base64.urlsafe_b64encode(json.dumps(req_cnfJSON).encode("utf-8")).decode(
+        "utf-8"
+    )
 
     # remove padding '=' character
-    if req_cnf[len(req_cnf) - 1] == '=':
+    if req_cnf[len(req_cnf) - 1] == "=":
         req_cnf = req_cnf[:-1]
 
     token_data = {"token_type": "pop", "key_id": kid, "req_cnf": req_cnf}
     profile = Profile(cli_ctx=cmd.cli_ctx)
     try:
-        credential, _, _ = profile.get_login_credentials(subscription_id=profile.get_subscription()["id"],
-                                                         resource=consts.KAP_1P_Server_App_Scope)
+        credential, _, _ = profile.get_login_credentials(
+            subscription_id=profile.get_subscription()["id"],
+            resource=consts.KAP_1P_Server_App_Scope,
+        )
         if isinstance(credential._credential, ServicePrincipalCredential):
             # This is a workaround to fix the issue where the token is not being refreshed
             # https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/692
             credential._credential.remove_tokens_for_client()
-        accessToken = credential.get_token(consts.KAP_1P_Server_App_Scope, data=token_data)
+        accessToken = credential.get_token(
+            consts.KAP_1P_Server_App_Scope, data=token_data
+        )
         jwtToken = accessToken.token
     except Exception as e:
-        telemetry.set_exception(exception=e, fault_type=consts.Post_AT_To_ClientProxy_Failed_Fault_Type,
-                                summary='Failed to fetch access token using the PoP public key sent by client proxy')
-        close_subprocess_and_raise_cli_error(clientproxy_process,
-                                             'Failed to post access token to client proxy' + str(e))
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Post_AT_To_ClientProxy_Failed_Fault_Type,
+            summary="Failed to fetch access token using the PoP public key sent by client proxy",
+        )
+        close_subprocess_and_raise_cli_error(
+            clientproxy_process, "Failed to post access token to client proxy" + str(e)
+        )
 
-    jwtTokenData = {"accessToken": jwtToken, "serverId": consts.KAP_1P_Server_AppId, "tenantID": tenant_id, "kid": kid}
-    post_at_uri = f'https://localhost:{api_server_port}/identity/at'
+    jwtTokenData = {
+        "accessToken": jwtToken,
+        "serverId": consts.KAP_1P_Server_AppId,
+        "tenantID": tenant_id,
+        "kid": kid,
+    }
+    post_at_uri = f"https://localhost:{api_server_port}/identity/at"
     # Needed to prevent skip tls warning from printing to the console
     original_stderr = sys.stderr
-    f = open(os.devnull, 'w')
+    f = open(os.devnull, "w")
     sys.stderr = f
-    post_at_response = make_api_call_with_retries(post_at_uri, jwtTokenData, "post", False,
-                                                  consts.PublicKey_Export_Fault_Type,
-                                                  'Failed to post access token to client proxy',
-                                                  "Failed to post access token to client proxy",
-                                                  clientproxy_process)
+    post_at_response = make_api_call_with_retries(
+        post_at_uri,
+        jwtTokenData,
+        "post",
+        False,
+        consts.PublicKey_Export_Fault_Type,
+        "Failed to post access token to client proxy",
+        "Failed to post access token to client proxy",
+        clientproxy_process,
+    )
 
     sys.stderr = original_stderr
     return post_at_response
 
 
 def insert_token_in_kubeconfig(data, token):
-    b64kubeconfig = data['kubeconfigs'][0]['value']
+    b64kubeconfig = data["kubeconfigs"][0]["value"]
     decoded_kubeconfig_str = b64decode(b64kubeconfig).decode("utf-8")
     dict_yaml = yaml.safe_load(decoded_kubeconfig_str)
-    dict_yaml['users'][0]['user']['token'] = token
+    dict_yaml["users"][0]["user"]["token"] = token
     kubeconfig = yaml.dump(dict_yaml).encode("utf-8")
     b64kubeconfig = b64encode(kubeconfig).decode("utf-8")
     return b64kubeconfig
 
 
 def check_process(processName):
-    '''
+    """
     Check if there is any running process that contains the given name processName.
-    '''
+    """
     for proc in process_iter():
         try:
             if proc.name().startswith(processName):

--- a/src/connectedk8s/azext_connectedk8s/_constants.py
+++ b/src/connectedk8s/azext_connectedk8s/_constants.py
@@ -154,6 +154,7 @@ Failed_To_Merge_Kubeconfig_File = "failed-to-merge-kubeconfig-file"
 Download_Helm_Fault_Type = "helm-client-download-error"
 Create_HelmExe_Fault_Type = "helm-client-create-error"
 Extract_HelmExe_Fault_Type = "helm-client-extract-error"
+DP_Health_Check_Fault_Type = "dp-health-check-error"
 Different_Object_With_Same_Name_Fault_Type = "Kubeconfig has an object with same name"
 Download_Exe_Fault_Type = (
     "Error while downloading client proxy executable from storage account"

--- a/src/connectedk8s/azext_connectedk8s/_constants.py
+++ b/src/connectedk8s/azext_connectedk8s/_constants.py
@@ -6,97 +6,147 @@
 
 # pylint: disable=line-too-long
 
-Distribution_Enum_Values = ["generic", "openshift", "rancher_rke", "kind", "k3s", "minikube", "gke", "eks", "aks",
-                            "aks_management", "aks_workload", "capz", "aks_engine", "tkg", "canonical", "karbon",
-                            "aks_edge_k3s", "aks_edge_k8s"]
-Infrastructure_Enum_Values = ["generic", "azure", "aws", "gcp", "azure_stack_hci", "azure_stack_hub",
-                              "azure_stack_edge", "vsphere", "windows_server", "Windows 11 Enterprise",
-                              "Windows 11 Enterprise N", "Windows 11 IoT Enterprise", "Windows 11 Pro",
-                              "Windows 10 Enterprise", "Windows 10 Enterprise N", "Windows 10 Enterprise LTSC 2021",
-                              "Windows 10 Enterprise N LTSC 2021", "Windows 10 IoT Enterprise",
-                              "Windows 10 IoT Enterprise LTSC 2021", "Windows 10 Pro",
-                              "Windows 10 Enterprise LTSC 2019", "Windows 10 Enterprise N LTSC 2019",
-                              "Windows 10 IoT Enterprise LTSC 2019", "Windows Server 2022",
-                              "Windows Server 2022 Datacenter", "Windows Server 2022 Standard", "Windows Server 2019",
-                              "Windows Server 2019 Datacenter", "Windows Server 2019 Standard",
-                              "Windows 10 IoT Enterprise", "LTSCWindows 10 Enterprise LTSC"]
+Distribution_Enum_Values = [
+    "generic",
+    "openshift",
+    "rancher_rke",
+    "kind",
+    "k3s",
+    "minikube",
+    "gke",
+    "eks",
+    "aks",
+    "aks_management",
+    "aks_workload",
+    "capz",
+    "aks_engine",
+    "tkg",
+    "canonical",
+    "karbon",
+    "aks_edge_k3s",
+    "aks_edge_k8s",
+]
+Infrastructure_Enum_Values = [
+    "generic",
+    "azure",
+    "aws",
+    "gcp",
+    "azure_stack_hci",
+    "azure_stack_hub",
+    "azure_stack_edge",
+    "vsphere",
+    "windows_server",
+    "Windows 11 Enterprise",
+    "Windows 11 Enterprise N",
+    "Windows 11 IoT Enterprise",
+    "Windows 11 Pro",
+    "Windows 10 Enterprise",
+    "Windows 10 Enterprise N",
+    "Windows 10 Enterprise LTSC 2021",
+    "Windows 10 Enterprise N LTSC 2021",
+    "Windows 10 IoT Enterprise",
+    "Windows 10 IoT Enterprise LTSC 2021",
+    "Windows 10 Pro",
+    "Windows 10 Enterprise LTSC 2019",
+    "Windows 10 Enterprise N LTSC 2019",
+    "Windows 10 IoT Enterprise LTSC 2019",
+    "Windows Server 2022",
+    "Windows Server 2022 Datacenter",
+    "Windows Server 2022 Standard",
+    "Windows Server 2019",
+    "Windows Server 2019 Datacenter",
+    "Windows Server 2019 Standard",
+    "Windows 10 IoT Enterprise",
+    "LTSCWindows 10 Enterprise LTSC",
+]
 AHB_Enum_Values = ["True", "False", "NotApplicable"]
 Feature_Values = ["cluster-connect", "azure-rbac", "custom-locations"]
-CRD_FOR_FORCE_DELETE = \
-    ["arccertificates.clusterconfig.azure.com", "azureclusteridentityrequests.clusterconfig.azure.com",
-     "azureextensionidentities.clusterconfig.azure.com", "connectedclusters.arc.azure.com",
-     "customlocationsettings.clusterconfig.azure.com", "extensionconfigs.clusterconfig.azure.com",
-     "gitconfigs.clusterconfig.azure.com"]
-Helm_Install_Release_Userfault_Messages = ['forbidden', 'timed out waiting for the condition', 'connection refused']
-Custom_Locations_Provider_Namespace = 'Microsoft.ExtendedLocation'
-Connected_Cluster_Provider_Namespace = 'Microsoft.Kubernetes'
-Kubernetes_Configuration_Provider_Namespace = 'Microsoft.KubernetesConfiguration'
-Hybrid_Compute_Provider_Namespace = 'Microsoft.HybridCompute'
-Arc_Namespace = 'azure-arc'
-Azure_PublicCloudName = 'AZUREPUBLICCLOUD'
-Azure_USGovCloudName = 'AZUREUSGOVERNMENTCLOUD'
-Azure_ChinaCloudName = 'AZURECHINACLOUD'
-Azure_DogfoodCloudName = 'AZUREDOGFOOD'
-PublicCloud_OriginalName = 'AZURECLOUD'
-MSI_Certificate_Secret_Name = 'azure-identity-certificate'
-KAP_Certificate_Secret_Name = 'kube-aad-proxy-certificate'
-USGovCloud_OriginalName = 'AZUREUSGOVERNMENT'
-Dogfood_RMEndpoint = 'https://api-dogfood.resources.windows-int.net/'
-Client_Request_Id_Header = 'x-ms-client-request-id'
+CRD_FOR_FORCE_DELETE = [
+    "arccertificates.clusterconfig.azure.com",
+    "azureclusteridentityrequests.clusterconfig.azure.com",
+    "azureextensionidentities.clusterconfig.azure.com",
+    "connectedclusters.arc.azure.com",
+    "customlocationsettings.clusterconfig.azure.com",
+    "extensionconfigs.clusterconfig.azure.com",
+    "gitconfigs.clusterconfig.azure.com",
+]
+Helm_Install_Release_Userfault_Messages = [
+    "forbidden",
+    "timed out waiting for the condition",
+    "connection refused",
+]
+Custom_Locations_Provider_Namespace = "Microsoft.ExtendedLocation"
+Connected_Cluster_Provider_Namespace = "Microsoft.Kubernetes"
+Kubernetes_Configuration_Provider_Namespace = "Microsoft.KubernetesConfiguration"
+Hybrid_Compute_Provider_Namespace = "Microsoft.HybridCompute"
+Arc_Namespace = "azure-arc"
+Azure_PublicCloudName = "AZUREPUBLICCLOUD"
+Azure_USGovCloudName = "AZUREUSGOVERNMENTCLOUD"
+Azure_ChinaCloudName = "AZURECHINACLOUD"
+Azure_DogfoodCloudName = "AZUREDOGFOOD"
+PublicCloud_OriginalName = "AZURECLOUD"
+MSI_Certificate_Secret_Name = "azure-identity-certificate"
+KAP_Certificate_Secret_Name = "kube-aad-proxy-certificate"
+USGovCloud_OriginalName = "AZUREUSGOVERNMENT"
+Dogfood_RMEndpoint = "https://api-dogfood.resources.windows-int.net/"
+Client_Request_Id_Header = "x-ms-client-request-id"
 Default_Onboarding_Source_Tracking_Guid = "77ade16b-0f55-403b-b7d2-739554a897f2"
-Custom_Access_Token_Env_Var_Sub_Id_Missing_Fault_Type = \
-    'Required environment variable SubscriptionId not set, for custom Azure access token'
-Custom_Access_Token_Env_Var_Tenant_Id_Missing_Fault_Type = \
-    'Required environment variable TenantId not set, for custom Azure access token'
-Custom_Token_Env_Var_Sub_Id_Missing_Fault_Type = \
-    'Required environment variable \'AZURE_SUBSCRIPTION_ID\' is not set, when using Custom Acces Token.'
+Custom_Access_Token_Env_Var_Sub_Id_Missing_Fault_Type = "Required environment variable SubscriptionId not set, for custom Azure access token"
+Custom_Access_Token_Env_Var_Tenant_Id_Missing_Fault_Type = (
+    "Required environment variable TenantId not set, for custom Azure access token"
+)
+Custom_Token_Env_Var_Sub_Id_Missing_Fault_Type = "Required environment variable 'AZURE_SUBSCRIPTION_ID' is not set, when using Custom Acces Token."
 Release_Install_Namespace = "azure-arc-release"
 Workload_Identity_Release_Name = "wiextension"
 Workload_Identity_Release_Namespace = "arc-workload-identity"
-Helm_Environment_File_Fault_Type = 'helm-environment-file-error'
-Invalid_Location_Fault_Type = 'location-validation-error'
-Location_Fetch_Fault_Type = 'location-fetch-error'
-Pls_Location_Mismatch_Fault_Type = 'pls-location-mismatch-error'
-Pls_Resource_Not_Found = 'pls-resource-not-found'
-Invalid_Argument_Fault_Type = 'argument-validation-error'
-Load_Kubeconfig_Fault_Type = 'kubeconfig-load-error'
-Read_ConfigMap_Fault_Type = 'configmap-read-error'
-Get_ResourceProvider_Fault_Type = 'resource-provider-fetch-error'
-Get_ConnectedCluster_Fault_Type = 'connected-cluster-fetch-error'
-Create_ConnectedCluster_Fault_Type = 'connected-cluster-create-error'
-Update_ConnectedCluster_Fault_Type = 'connected-cluster-update-error'
-Delete_ConnectedCluster_Fault_Type = 'connected-cluster-delete-error'
-Bad_DeleteRequest_Fault_Type = 'bad-delete-request-error'
-Cluster_Already_Onboarded_Fault_Type = 'cluster-already-onboarded-error'
-Resource_Already_Exists_Fault_Type = 'resource-already-exists-error'
-Resource_Does_Not_Exist_Fault_Type = 'resource-does-not-exist-error'
-Create_ResourceGroup_Fault_Type = 'resource-group-creation-error'
-Add_HelmRepo_Fault_Type = 'helm-repo-add-error'
-List_HelmRelease_Fault_Type = 'helm-list-release-error'
-KeyPair_Generate_Fault_Type = 'keypair-generation-error'
-PublicKey_Export_Fault_Type = 'publickey-export-error'
-PrivateKey_Export_Fault_Type = 'privatekey-export-error'
-Install_HelmRelease_Fault_Type = 'helm-release-install-error'
-Delete_HelmRelease_Fault_Type = 'helm-release-delete-error'
-Check_PodStatus_Fault_Type = 'check-pod-status-error'
-Kubernetes_Connectivity_FaultType = 'kubernetes-cluster-connection-error'
-Helm_Version_Fault_Type = 'helm-not-updated-error'
-Check_HelmVersion_Fault_Type = 'helm-version-check-error'
-Helm_Installation_Fault_Type = 'helm-not-installed-error'
-Check_HelmInstallation_Fault_Type = 'check-helm-installed-error'
-Get_HelmRegistery_Path_Fault_Type = 'helm-registry-path-fetch-error'
-Pull_HelmChart_Fault_Type = 'helm-chart-pull-error'
-Export_HelmChart_Fault_Type = 'helm-chart-export-error'
-Get_Kubernetes_Distro_Fault_Type = 'kubernetes-get-distribution-error'
-Get_Kubernetes_Namespace_Fault_Type = 'kubernetes-get-namespace-error'
-Get_Kubernetes_Helm_Release_Namespace_Fault_Type = 'kubernetes-get-helm-release-namespace-error'
-Delete_Kubernetes_Helm_Release_Namespace_Fault_Type = 'kubernetes-delete-helm-release-namespace-error'
-Update_Agent_Success = 'Agents for Connected Cluster {} have been updated successfully'
-Update_Agent_Failure = 'Error while updating agents. Please run \"kubectl get pods -n azure-arc\" to check the pods in case of timeout error. Error: {}'
+Helm_Environment_File_Fault_Type = "helm-environment-file-error"
+Invalid_Location_Fault_Type = "location-validation-error"
+Location_Fetch_Fault_Type = "location-fetch-error"
+Pls_Location_Mismatch_Fault_Type = "pls-location-mismatch-error"
+Pls_Resource_Not_Found = "pls-resource-not-found"
+Invalid_Argument_Fault_Type = "argument-validation-error"
+Load_Kubeconfig_Fault_Type = "kubeconfig-load-error"
+Read_ConfigMap_Fault_Type = "configmap-read-error"
+Get_ResourceProvider_Fault_Type = "resource-provider-fetch-error"
+Get_ConnectedCluster_Fault_Type = "connected-cluster-fetch-error"
+Create_ConnectedCluster_Fault_Type = "connected-cluster-create-error"
+Update_ConnectedCluster_Fault_Type = "connected-cluster-update-error"
+Delete_ConnectedCluster_Fault_Type = "connected-cluster-delete-error"
+Bad_DeleteRequest_Fault_Type = "bad-delete-request-error"
+Cluster_Already_Onboarded_Fault_Type = "cluster-already-onboarded-error"
+Resource_Already_Exists_Fault_Type = "resource-already-exists-error"
+Resource_Does_Not_Exist_Fault_Type = "resource-does-not-exist-error"
+Create_ResourceGroup_Fault_Type = "resource-group-creation-error"
+Add_HelmRepo_Fault_Type = "helm-repo-add-error"
+List_HelmRelease_Fault_Type = "helm-list-release-error"
+KeyPair_Generate_Fault_Type = "keypair-generation-error"
+PublicKey_Export_Fault_Type = "publickey-export-error"
+PrivateKey_Export_Fault_Type = "privatekey-export-error"
+Install_HelmRelease_Fault_Type = "helm-release-install-error"
+Delete_HelmRelease_Fault_Type = "helm-release-delete-error"
+Check_PodStatus_Fault_Type = "check-pod-status-error"
+Kubernetes_Connectivity_FaultType = "kubernetes-cluster-connection-error"
+Helm_Version_Fault_Type = "helm-not-updated-error"
+Check_HelmVersion_Fault_Type = "helm-version-check-error"
+Helm_Installation_Fault_Type = "helm-not-installed-error"
+Check_HelmInstallation_Fault_Type = "check-helm-installed-error"
+Get_HelmRegistery_Path_Fault_Type = "helm-registry-path-fetch-error"
+Pull_HelmChart_Fault_Type = "helm-chart-pull-error"
+Export_HelmChart_Fault_Type = "helm-chart-export-error"
+Get_Kubernetes_Distro_Fault_Type = "kubernetes-get-distribution-error"
+Get_Kubernetes_Namespace_Fault_Type = "kubernetes-get-namespace-error"
+Get_Kubernetes_Helm_Release_Namespace_Fault_Type = (
+    "kubernetes-get-helm-release-namespace-error"
+)
+Delete_Kubernetes_Helm_Release_Namespace_Fault_Type = (
+    "kubernetes-delete-helm-release-namespace-error"
+)
+Update_Agent_Success = "Agents for Connected Cluster {} have been updated successfully"
+Update_Agent_Failure = 'Error while updating agents. Please run "kubectl get pods -n azure-arc" to check the pods in case of timeout error. Error: {}'
 Agent_State_Succeeded = "Succeeded"
 Agent_State_Failed = "Failed"
 Agent_State_Timeout = 15
-Get_Credentials_Failed_Fault_Type = 'failed-to-get-list-cluster-user-credentials'
+Get_Credentials_Failed_Fault_Type = "failed-to-get-list-cluster-user-credentials"
 Failed_To_Merge_Credentials_Fault_Type = "failed-to-merge-credentials"
 Kubeconfig_Failed_To_Load_Fault_Type = "failed-to-load-kubeconfig-file"
 Failed_To_Load_K8s_Configuration_Fault_Type = "failed-to-load-kubernetes-configuration"
@@ -105,11 +155,19 @@ Download_Helm_Fault_Type = "helm-client-download-error"
 Create_HelmExe_Fault_Type = "helm-client-create-error"
 Extract_HelmExe_Fault_Type = "helm-client-extract-error"
 Different_Object_With_Same_Name_Fault_Type = "Kubeconfig has an object with same name"
-Download_Exe_Fault_Type = "Error while downloading client proxy executable from storage account"
-Create_Directory_Fault_Type = "Error while creating directory for placing the executable"
+Download_Exe_Fault_Type = (
+    "Error while downloading client proxy executable from storage account"
+)
+Create_Directory_Fault_Type = (
+    "Error while creating directory for placing the executable"
+)
 Run_Clientproxy_Fault_Type = "Error while starting client proxy process."
-Post_Hybridconn_Fault_Type = "Error while posting hybrid connection details to proxy process"
-Post_RefreshToken_Fault_Type = "Error while posting refresh token details to proxy process"
+Post_Hybridconn_Fault_Type = (
+    "Error while posting hybrid connection details to proxy process"
+)
+Post_RefreshToken_Fault_Type = (
+    "Error while posting refresh token details to proxy process"
+)
 Merge_Kubeconfig_Fault_Type = "Error while merging kubeconfig."
 Create_CSPExe_Fault_Type = "Error while creating csp executable"
 Remove_Config_Fault_Type = "Error while removing old csp config"
@@ -120,95 +178,190 @@ Run_RefreshThread_Fault_Type = "Error while starting refresh thread"
 Run_Check_CSP_Thread_Fault_Type = "Error while starting 'check csp thread'."
 Proxy_Closed_Externally_Fault_Type = "Proxy closed externally."
 Client_Proxy_Port_Fault_Type = "Client proxy port was in use."
-Unsupported_Fault_Type = "Error while checking operating system.Unsupported OS detected."
+Unsupported_Fault_Type = (
+    "Error while checking operating system.Unsupported OS detected."
+)
 Helm_Unsupported_OS_Fault_Type = "helm-client-unsupported-os-error."
 Port_Check_Fault_Type = "Error while checking if port is in use."
-Proxy_Cert_Path_Does_Not_Exist_Fault_Type = 'proxy-cert-path-does-not-exist-error'
-Proxy_Cert_Path_Does_Not_Exist_Error = 'Proxy cert path {} does not exist. Please check the path provided'
-Get_Kubernetes_Infra_Fault_Type = 'kubernetes-get-infrastructure-error'
-No_Param_Error = 'No parameters were specified with update command. Please run az connectedk8s update --help to check parameters available for update'
+Proxy_Cert_Path_Does_Not_Exist_Fault_Type = "proxy-cert-path-does-not-exist-error"
+Proxy_Cert_Path_Does_Not_Exist_Error = (
+    "Proxy cert path {} does not exist. Please check the path provided"
+)
+Get_Kubernetes_Infra_Fault_Type = "kubernetes-get-infrastructure-error"
+No_Param_Error = "No parameters were specified with update command. Please run az connectedk8s update --help to check parameters available for update"
 Gateway_ArmId_Is_Invalid = "The provided Gateway ArmID in --gateway-resource-id  {} is invalid. Please provide a valid Gateway ArmID."
-EnableProxy_Conflict_Error = 'Conflict detected: --disable-proxy can not be set with --https-proxy, --http-proxy, --proxy-skip-range and --proxy-cert at the same time. Please run az connectedk8s update --help for more information about the parameters'
-Manual_Upgrade_Called_In_Auto_Update_Enabled = 'Manual Upgrade was called while in auto_Update enabled mode'
-Upgrade_Agent_Success = 'Agents for Connected Cluster {} have been upgraded successfully'
-Upgrade_Agent_Failure = \
-    'Error while upgrading agents. Please run \"kubectl get pods -n azure-arc\" to check the pods in case of ' \
-    'timeout error. Error: {}'
-Release_Namespace_Not_Found = 'Error while getting azure-arc releasenamespace'
-Get_Helm_Values_Failed = 'Error while doing helm get values azure-arc'
-Helm_Existing_User_Supplied_Value_Get_Fault = 'Error while loading the user supplied helm values'
-Error_Flattening_User_Supplied_Value_Dict = 'Error while flattening the user supplied helm values dict'
-Upgrade_RG_Cluster_Name_Conflict = 'The provided cluster name and rg correspond to different cluster'
-Corresponding_CC_Resource_Deleted_Fault = 'CC resource corresponding to this cluster has been deleted by the customer'
-Kubernetes_Node_Type_Fetch_Fault_OS = 'Error while trying to find a linux node for scheduling pods'
-Kubernetes_Node_Type_Fetch_Fault_Arch = 'Error while trying to find an arm64 node for scheduling pods'
-Linux_Node_Not_Exists = 'Kubernetes cluster doesnt have linux node'
-Operate_RG_Cluster_Name_Conflict = 'The provided cluster name and rg correspond to different cluster being operated on'
-Custom_Locations_Registration_Check_Fault_Type = \
+EnableProxy_Conflict_Error = "Conflict detected: --disable-proxy can not be set with --https-proxy, --http-proxy, --proxy-skip-range and --proxy-cert at the same time. Please run az connectedk8s update --help for more information about the parameters"
+Manual_Upgrade_Called_In_Auto_Update_Enabled = (
+    "Manual Upgrade was called while in auto_Update enabled mode"
+)
+Upgrade_Agent_Success = (
+    "Agents for Connected Cluster {} have been upgraded successfully"
+)
+Upgrade_Agent_Failure = (
+    'Error while upgrading agents. Please run "kubectl get pods -n azure-arc" to check the pods in case of '
+    "timeout error. Error: {}"
+)
+Release_Namespace_Not_Found = "Error while getting azure-arc releasenamespace"
+Get_Helm_Values_Failed = "Error while doing helm get values azure-arc"
+Helm_Existing_User_Supplied_Value_Get_Fault = (
+    "Error while loading the user supplied helm values"
+)
+Error_Flattening_User_Supplied_Value_Dict = (
+    "Error while flattening the user supplied helm values dict"
+)
+Upgrade_RG_Cluster_Name_Conflict = (
+    "The provided cluster name and rg correspond to different cluster"
+)
+Corresponding_CC_Resource_Deleted_Fault = (
+    "CC resource corresponding to this cluster has been deleted by the customer"
+)
+Kubernetes_Node_Type_Fetch_Fault_OS = (
+    "Error while trying to find a linux node for scheduling pods"
+)
+Kubernetes_Node_Type_Fetch_Fault_Arch = (
+    "Error while trying to find an arm64 node for scheduling pods"
+)
+Linux_Node_Not_Exists = "Kubernetes cluster doesnt have linux node"
+Operate_RG_Cluster_Name_Conflict = (
+    "The provided cluster name and rg correspond to different cluster being operated on"
+)
+Custom_Locations_Registration_Check_Fault_Type = (
     "Error while checking resource provider registration of custom locations."
-Custom_Locations_OID_Fetch_Fault_Type_CLOid_None = "Error while fetching oid for custom locations. CL_Oid is None"
-Custom_Locations_OID_Fetch_Fault_Type_Exception = "Exception while fetching oid for custom locations."
-Successfully_Enabled_Features = 'Successsfully enabled features: {} for the Connected Cluster {}'
-Successfully_Disabled_Features = 'Successsfully disabled features: {} for the Connected Cluster {}'
-Error_enabling_Features = \
-    'Error while updating agents for enabling features. Please run \"kubectl get pods -n azure-arc\" to check the ' \
-    'pods in case of timeout error. Error: {}'
-Error_disabling_Features = 'Error while updating agents for disabling features. Please run \"kubectl get pods -n ' \
-    'azure-arc\" to check the pods in case of timeout error. Error: {}'
-Proxy_Kubeconfig_During_Deletion_Fault_Type = 'Encountered proxy kubeconfig during deletion.'
-Cannot_Create_ClusterRoleBindings_Fault_Type = 'Cannot create cluster role bindings on this Kubernets cluster'
-CC_Provider_Namespace_Not_Registered_Fault_Type = "Connected Cluster Provider MS.K8 namespace not registered"
-Kubernetes_Configuration_Provider_Namespace_Not_Registered_Fault_Type = \
-    "Kubernetes Configuration Provider MS.KubernetesConfiguration namespace not registered"
-HC_Provider_Namespace_Not_Registered_Fault_Type = "Hybrid Compute Provider MS.HybridCompute namespace not registered"
-Default_Namespace_Does_Not_Exist_Fault_Type = \
-    "The default namespace defined in the kubeconfig doesn't exist on the kubernetes cluster."
+)
+Custom_Locations_OID_Fetch_Fault_Type_CLOid_None = (
+    "Error while fetching oid for custom locations. CL_Oid is None"
+)
+Custom_Locations_OID_Fetch_Fault_Type_Exception = (
+    "Exception while fetching oid for custom locations."
+)
+Successfully_Enabled_Features = (
+    "Successsfully enabled features: {} for the Connected Cluster {}"
+)
+Successfully_Disabled_Features = (
+    "Successsfully disabled features: {} for the Connected Cluster {}"
+)
+Error_enabling_Features = (
+    'Error while updating agents for enabling features. Please run "kubectl get pods -n azure-arc" to check the '
+    "pods in case of timeout error. Error: {}"
+)
+Error_disabling_Features = (
+    'Error while updating agents for disabling features. Please run "kubectl get pods -n '
+    'azure-arc" to check the pods in case of timeout error. Error: {}'
+)
+Proxy_Kubeconfig_During_Deletion_Fault_Type = (
+    "Encountered proxy kubeconfig during deletion."
+)
+Cannot_Create_ClusterRoleBindings_Fault_Type = (
+    "Cannot create cluster role bindings on this Kubernets cluster"
+)
+CC_Provider_Namespace_Not_Registered_Fault_Type = (
+    "Connected Cluster Provider MS.K8 namespace not registered"
+)
+Kubernetes_Configuration_Provider_Namespace_Not_Registered_Fault_Type = "Kubernetes Configuration Provider MS.KubernetesConfiguration namespace not registered"
+HC_Provider_Namespace_Not_Registered_Fault_Type = (
+    "Hybrid Compute Provider MS.HybridCompute namespace not registered"
+)
+Default_Namespace_Does_Not_Exist_Fault_Type = "The default namespace defined in the kubeconfig doesn't exist on the kubernetes cluster."
 KAP_1P_Server_App_Scope = "6256c85f-0aad-4d50-b960-e6e9b21efe35/.default"
 KAP_1P_Server_AppId = "6256c85f-0aad-4d50-b960-e6e9b21efe35"
-Get_PublicKey_Info_Fault_Type = 'Error while fetching the PoP publickey information from client proxy'
-PoP_Public_Key_Expried_Fault_Type = 'The PoP public key used to generate the at has expired'
-Post_AT_To_ClientProxy_Failed_Fault_Type = 'Failed to post access token to client proxy'
+Get_PublicKey_Info_Fault_Type = (
+    "Error while fetching the PoP publickey information from client proxy"
+)
+PoP_Public_Key_Expried_Fault_Type = (
+    "The PoP public key used to generate the at has expired"
+)
+Post_AT_To_ClientProxy_Failed_Fault_Type = "Failed to post access token to client proxy"
 Kubectl_Get_Events_Failed_Fault_Type = "Error occured while doing kubectl get events"
 Kubectl_Get_Secrets_Failed_Fault_Type = "Error occured while doing kubectl get secrets"
-Fetch_Kubectl_Get_Secrets_Fault_Type = "Exception occured while doing kubectl get secrets"
-Helm_Values_Save_Failed_Fault_Type = "Error occured while doing helm get values for azure-arc release"
-Fetch_Helm_Values_Save_Failed_Fault_Type = "Exception occured while doing helm get values for azure-arc release"
-Wiextension_Helm_Values_Save_Failed_Fault_Type = "Error occured while doing helm get values for wiextension release"
-Fetch_Wiextension_Helm_Values_Save_Failed_Fault_Type = "Exception occured while doing helm get values for wiextension release"
+Fetch_Kubectl_Get_Secrets_Fault_Type = (
+    "Exception occured while doing kubectl get secrets"
+)
+Helm_Values_Save_Failed_Fault_Type = (
+    "Error occured while doing helm get values for azure-arc release"
+)
+Fetch_Helm_Values_Save_Failed_Fault_Type = (
+    "Exception occured while doing helm get values for azure-arc release"
+)
+Wiextension_Helm_Values_Save_Failed_Fault_Type = (
+    "Error occured while doing helm get values for wiextension release"
+)
+Fetch_Wiextension_Helm_Values_Save_Failed_Fault_Type = (
+    "Exception occured while doing helm get values for wiextension release"
+)
 Metadata_CR_Save_Failed_Fault_Type = "Error occured while fetching metadata CR snapshot"
-Fetch_Metadata_CR_Save_Failed_Fault_Type = "Exception occured while fetching metadata CR snapshot"
-Signingkey_CR_Save_Failed_Fault_Type = "Error occured while fetching signingkey CR snapshot"
-Fetch_Signingkey_CR_Save_Failed_Fault_Type = "Exception occured while fetching signingkey CR snapshot"
+Fetch_Metadata_CR_Save_Failed_Fault_Type = (
+    "Exception occured while fetching metadata CR snapshot"
+)
+Signingkey_CR_Save_Failed_Fault_Type = (
+    "Error occured while fetching signingkey CR snapshot"
+)
+Fetch_Signingkey_CR_Save_Failed_Fault_Type = (
+    "Exception occured while fetching signingkey CR snapshot"
+)
 KAP_CR_Save_Failed_Fault_Type = "Error occured while fetching KAP CR snapshot"
 Fetch_KAP_CR_Save_Failed_Fault_Type = "Exception occured while fetching KAP CR snapshot"
 Fetch_Arc_Agent_Logs_Failed_Fault_Type = "Error occured in arc agents logger"
-Fetch_Arc_Agents_Events_Logs_Failed_Fault_Type = "Error occured in arc agents events logger"
+Fetch_Arc_Agents_Events_Logs_Failed_Fault_Type = (
+    "Error occured in arc agents events logger"
+)
 Fetch_Arc_Deployment_Logs_Failed_Fault_Type = "Error occured in deployments logger"
-Fetch_Arc_Workload_Identity_Pod_Logs_Failed_Fault_Type = "Error occured in arc agents logger"
-Fetch_Arc_Workload_Identity_Events_Logs_Failed_Fault_Type = "Error occured in arc agents events logger"
-Fetch_Arc_Workload_Identity_Deployment_Logs_Failed_Fault_Type = "Error occured in deployments logger"
+Fetch_Arc_Workload_Identity_Pod_Logs_Failed_Fault_Type = (
+    "Error occured in arc agents logger"
+)
+Fetch_Arc_Workload_Identity_Events_Logs_Failed_Fault_Type = (
+    "Error occured in arc agents events logger"
+)
+Fetch_Arc_Workload_Identity_Deployment_Logs_Failed_Fault_Type = (
+    "Error occured in deployments logger"
+)
 Agent_State_Check_Fault_Type = "Error occured while performing the agent state check"
-Agent_Version_Check_Fault_Type = "Error occured while performing the agent version check"
+Agent_Version_Check_Fault_Type = (
+    "Error occured while performing the agent version check"
+)
 Diagnoser_Job_Failed_Fault_Type = "Error while executing Diagnoser Job"
-Diagnoser_Container_Check_Failed_Fault_Type = "Error occured while performing the diagnoser container checks"
+Diagnoser_Container_Check_Failed_Fault_Type = (
+    "Error occured while performing the diagnoser container checks"
+)
 Cluster_DNS_Check_Fault_Type = "Error occured while performing cluster DNS check"
-Outbound_Connectivity_Check_Fault_Type = "Error occured while performing outbound connectivity check in the cluster"
-Outbound_Connectivity_Failed_Fault_Type = "Outbound network connectivity failed in cluster diagnostic checks"
+Outbound_Connectivity_Check_Fault_Type = (
+    "Error occured while performing outbound connectivity check in the cluster"
+)
+Outbound_Connectivity_Failed_Fault_Type = (
+    "Outbound network connectivity failed in cluster diagnostic checks"
+)
 DNS_Failed_Fault_Type = "DNS resolution failed in cluster diagnostic checks"
-MSI_Cert_Check_Fault_Type = "Error occurred while trying to perform MSI ceritificate presence check"
-Cluster_Security_Policy_Check_Fault_Type = "Error occured while performing cluster security policy check"
-KAP_Cert_Check_Fault_Type = "Error occurred while trying to perform KAP ceritificate presence check"
-MSI_Cert_Expiry_Check_Fault_Type = "Error occured while trying to perform the MSI cert expiry check"
-Diagnostics_Folder_Creation_Failed_Fault_Type = "Error while trying to create diagnostic logs folder"
-Describe_Stuck_Agents_Fault_Type = "Error occured while storing the description of non running agents"
+MSI_Cert_Check_Fault_Type = (
+    "Error occurred while trying to perform MSI ceritificate presence check"
+)
+Cluster_Security_Policy_Check_Fault_Type = (
+    "Error occured while performing cluster security policy check"
+)
+KAP_Cert_Check_Fault_Type = (
+    "Error occurred while trying to perform KAP ceritificate presence check"
+)
+MSI_Cert_Expiry_Check_Fault_Type = (
+    "Error occured while trying to perform the MSI cert expiry check"
+)
+Diagnostics_Folder_Creation_Failed_Fault_Type = (
+    "Error while trying to create diagnostic logs folder"
+)
+Describe_Stuck_Agents_Fault_Type = (
+    "Error occured while storing the description of non running agents"
+)
 No_Storage_Space_Available_Fault_Type = "No space left on device"
-Connected_Cluster_Resource_Fetch_Fault_Type = "Error occured while fetching the Get output of connected cluster"
+Connected_Cluster_Resource_Fetch_Fault_Type = (
+    "Error occured while fetching the Get output of connected cluster"
+)
 Diagnoser_Result_Fault_Type = "Error while storing the diagnoser results"
 Kubectl_Cluster_Info_Failed_Fault_Type = "Error while doing kubectl cluster-info"
 Fetch_Kubectl_Cluster_Info_Fault_Type = "Error occured while fetching cluster-info"
 Fetch_Kubectl_Cluster_Info = "kubectl_cluster_info"
-Operation_Not_Supported_Fault_Type = "This CLI version does not support this operation for Agents older than v1.14"
-Failed_To_Change_Telemetry_Push_Interval = "Failed to change the telemetry push interval to 1 hr"
+Operation_Not_Supported_Fault_Type = (
+    "This CLI version does not support this operation for Agents older than v1.14"
+)
+Failed_To_Change_Telemetry_Push_Interval = (
+    "Failed to change the telemetry push interval to 1 hr"
+)
 Diagnostic_Check_Passed = "Passed"
 Diagnostic_Check_Failed = "Failed"
 Diagnostic_Check_Incomplete = "Incomplete"
@@ -216,9 +369,13 @@ Diagnostic_Check_Incomplete = "Incomplete"
 Retrieve_Arc_Agents_Event_Logs = "retrieved_arc_agents_event_logs"
 Retrieve_Arc_Agents_Logs = "retrieved_arc_agents_logs"
 Retrieve_Deployments_Logs = "retrieved_deployments_logs"
-Retrieve_Arc_Workload_Identity_Events_Logs = "retrieved_arc_workload_identity_event_logs"
+Retrieve_Arc_Workload_Identity_Events_Logs = (
+    "retrieved_arc_workload_identity_event_logs"
+)
 Retrieve_Arc_Workload_Identity_Pod_Logs = "retrieved_arc_workload_identity_pod_logs"
-Retrieve_Arc_Workload_Identity_Deployments_Logs = "retrieved_arc_workload_identity_deployments_logs"
+Retrieve_Arc_Workload_Identity_Deployments_Logs = (
+    "retrieved_arc_workload_identity_deployments_logs"
+)
 Fetch_Connected_Cluster_Resource = "fetch_connected_cluster_resource"
 Storing_Diagnoser_Results_Logs = "storing_diagnoser_results_logs"
 MSI_Cert_Expiry_Check = "msi_cert_expiry_check"
@@ -235,8 +392,8 @@ Arc_Diagnostic_Logs = "arc_diagnostic_logs"
 Arc_Workload_Identity_Pod_Logs = "arc_workload_identity_pod_logs"
 Arc_Workload_Identity_Deployment_Logs = "arc_workload_identity_deployment_logs"
 Pre_Onboarding_Check_Logs = "pre_onboarding_check_logs"
-Pre_Onboarding_Helm_Charts_Folder_Name = 'PreOnboardingChecksCharts'
-Pre_Onboarding_Helm_Charts_Release_Name = 'clusterdiagnosticchecks'
+Pre_Onboarding_Helm_Charts_Folder_Name = "PreOnboardingChecksCharts"
+Pre_Onboarding_Helm_Charts_Release_Name = "clusterdiagnosticchecks"
 Describe_Non_Ready_Arc_Agents = "describe_non_ready_arc_agents"
 Agent_State = "agent_state.txt"
 Arc_Agents_Events = "arc_agent_events.txt"
@@ -246,46 +403,69 @@ Connected_Cluster_Resource = "connected_cluster_resource_snapshot.txt"
 DNS_Check = "dns_check.txt"
 K8s_Cluster_Info = "k8s_cluster_info.txt"
 Outbound_Network_Connectivity_Check = "outbound_network_connectivity_check.txt"
-Outbound_Network_Connectivity_Check_for_onboarding = "outbound_network_connectivity_check_for_onboarding.txt"
-Outbound_Network_Connectivity_Check_for_cluster_connect = "outbound_network_connectivity_check_for_cluster_connect.txt"
+Outbound_Network_Connectivity_Check_for_onboarding = (
+    "outbound_network_connectivity_check_for_onboarding.txt"
+)
+Outbound_Network_Connectivity_Check_for_cluster_connect = (
+    "outbound_network_connectivity_check_for_cluster_connect.txt"
+)
 Events_of_Incomplete_Diagnoser_Job = "diagnoser_failure_events.txt"
 Wiextension_Helm_Values = "helm_values_arc_workload_identity.txt"
 SigningKey_CR_Snapshot = "signingkey_cr_snapshot.txt"
 
 # Connect Precheck Diagnoser constants
-Cluster_Diagnostic_Checks_Job_Registry_Path = \
+Cluster_Diagnostic_Checks_Job_Registry_Path = (
     "mcr.microsoft.com/azurearck8s/helmchart/stable/clusterdiagnosticchecks:0.2.2"
-Cluster_Diagnostic_Checks_Helm_Install_Failed_Fault_Type = \
+)
+Cluster_Diagnostic_Checks_Helm_Install_Failed_Fault_Type = (
     "Error while installing cluster diagnostic checks helm release"
-Cluster_Diagnostic_Checks_Execution_Failed_Fault_Type = "Error occured while executing cluster diagnostic checks"
-Cluster_Diagnostic_Checks_Release_Cleanup_Failed = \
+)
+Cluster_Diagnostic_Checks_Execution_Failed_Fault_Type = (
+    "Error occured while executing cluster diagnostic checks"
+)
+Cluster_Diagnostic_Checks_Release_Cleanup_Failed = (
     "Error occured while cleaning up the cluster diagnostic checks helm release"
-Cluster_Diagnostic_Checks_Job_Not_Scheduled = 'Unable to schedule cluster-diagnostic-checks job'
-Cluster_Diagnostic_Checks_Job_Not_Complete = 'Unable to complete cluster-diagnostic-checks job after scheduling'
-Pre_Onboarding_Diagnostic_Checks_Execution_Failed = \
-    'Exception occured while trying to execute pre-onboarding diagnostic checks'
+)
+Cluster_Diagnostic_Checks_Job_Not_Scheduled = (
+    "Unable to schedule cluster-diagnostic-checks job"
+)
+Cluster_Diagnostic_Checks_Job_Not_Complete = (
+    "Unable to complete cluster-diagnostic-checks job after scheduling"
+)
+Pre_Onboarding_Diagnostic_Checks_Execution_Failed = (
+    "Exception occured while trying to execute pre-onboarding diagnostic checks"
+)
 Outbound_Connectivity_Check_Failed = "Outbound network connectivity check failed"
-Outbound_Connectivity_Check_Failed_For_Onboarding = "Outbound network connectivity check failed for onboarding"
+Outbound_Connectivity_Check_Failed_For_Onboarding = (
+    "Outbound network connectivity check failed for onboarding"
+)
 DNS_Check_Failed = "DNS Resolution failed"
 Cluster_Diagnostic_Prechecks_Failed = "Cluster diagnostic prechecks failed"
-Cluster_Diagnostic_Prechecks_Incomplete = "Cluster diagnostic prechecks failed to complete"
-Cluster_Diagnostic_Checks_Pod_Description_Save_Failed = 'Failed to save cluster diagnostic checks pod description'
-Cluster_Diagnostic_Checks_Job_Log_Save_Failed = 'Failed to save cluster diagnostic checks job log'
+Cluster_Diagnostic_Prechecks_Incomplete = (
+    "Cluster diagnostic prechecks failed to complete"
+)
+Cluster_Diagnostic_Checks_Pod_Description_Save_Failed = (
+    "Failed to save cluster diagnostic checks pod description"
+)
+Cluster_Diagnostic_Checks_Job_Log_Save_Failed = (
+    "Failed to save cluster diagnostic checks job log"
+)
 
 # Diagnostic Results Name
 Outbound_Connectivity_Check_Result_String = "Outbound Network Connectivity"
-Outbound_Connectivity_Check_Failed_For_Cluster_Connect = \
+Outbound_Connectivity_Check_Failed_For_Cluster_Connect = (
     "Outbound network connectivity check failed for Cluster Connect"
+)
 DNS_Check_Result_String = "DNS Result:"
-AZ_CLI_ADAL_TO_MSAL_MIGRATE_VERSION = '2.30.0'
-CLIENT_PROXY_VERSION = '1.3.022011'
+AZ_CLI_ADAL_TO_MSAL_MIGRATE_VERSION = "2.30.0"
+CLIENT_PROXY_VERSION = "1.3.022011"
 API_SERVER_PORT = 47011
 CLIENT_PROXY_PORT = 47010
-CLIENTPROXY_CLIENT_ID = '04b07795-8ddb-461a-bbee-02f9e1bf7b46'
+CLIENTPROXY_CLIENT_ID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 API_CALL_RETRIES = 12
 DEFAULT_REQUEST_TIMEOUT = 10  # seconds
-RELEASE_DATE_WINDOWS = 'release12-01-23'
-RELEASE_DATE_LINUX = 'release12-01-23'
+RELEASE_DATE_WINDOWS = "release12-01-23"
+RELEASE_DATE_LINUX = "release12-01-23"
 CSP_REFRESH_TIME = 300
 
 # Default timeout in seconds for Onboarding Helm Install
@@ -296,28 +476,31 @@ CSP_Storage_Url = "https://k8sconnectcsp.azureedge.net"
 CSP_Storage_Url_Mooncake = "https://k8sconnectcsp.blob.core.chinacloudapi.cn"
 CSP_Storage_Url_Fairfax = "https://k8sconnectcsp.azureedge.us"
 HELM_STORAGE_URL = "https://k8connecthelm.azureedge.net"
-HELM_VERSION = 'v3.12.2'
+HELM_VERSION = "v3.12.2"
 Download_And_Install_Kubectl_Fault_Type = "Failed to download and install kubectl"
-Azure_Access_Token_Variable = 'AZURE_ACCESS_TOKEN'
-Provisioned_Cluster_Kind = 'provisionedcluster'
-Helm_Values_Fetch_isProxyEnabled_Failed_Fault_Type = "Helm Values Fetch isProxyEnabled Failed"
-Helm_Values_Fetch_isCustomCert_Failed_Fault_Type = "Helm Values Fetch isCustomCert Failed"
+Azure_Access_Token_Variable = "AZURE_ACCESS_TOKEN"
+Provisioned_Cluster_Kind = "provisionedcluster"
+Helm_Values_Fetch_isProxyEnabled_Failed_Fault_Type = (
+    "Helm Values Fetch isProxyEnabled Failed"
+)
+Helm_Values_Fetch_isCustomCert_Failed_Fault_Type = (
+    "Helm Values Fetch isCustomCert Failed"
+)
 Helm_Values_Fetch_proxyCert_Failed_Fault_Type = "Helm Values Fetch proxyCert Failed"
-Doc_Onboarding_PreRequisites_Url = "'https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/quickstart-"\
+Doc_Onboarding_PreRequisites_Url = (
+    "'https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/quickstart-"
     "connect-cluster?tabs=azure-cli%2Cazure-cloud#prerequisites'"
-Doc_Network_Requirements_Url = \
-    "https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/network-requirements?tabs=azure-cloud"
-Doc_Quick_Start_NW_Requirements_Url = \
-    "https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/quickstart-connect-cluster?" \
+)
+Doc_Network_Requirements_Url = "https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/network-requirements?tabs=azure-cloud"
+Doc_Quick_Start_NW_Requirements_Url = (
+    "https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/quickstart-connect-cluster?"
     "tabs=azure-cli#meet-network-requirements"
-Doc_Quick_Start_Outbound_Proxy_Url = \
-    "https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/quickstart-connect-cluster?" \
+)
+Doc_Quick_Start_Outbound_Proxy_Url = (
+    "https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/quickstart-connect-cluster?"
     "tabs=azure-cli#connect-using-an-outbound-proxy-server"
-Doc_Provisioned_Cluster_Delete_Url = \
-    "https://learn.microsoft.com/en-us/cli/azure/aksarc?view=azure-cli-latest#az-aksarc-delete"
-Doc_Provisioned_Cluster_Update_Url = \
-    "https://learn.microsoft.com/en-us/cli/azure/aksarc?view=azure-cli-latest#az-aksarc-update"
-Doc_Provisioned_Cluster_Upgrade_Url = \
-    "https://learn.microsoft.com/en-us/cli/azure/aksarc?view=azure-cli-latest#az-aksarc-upgrade"
-Doc_Agent_Version_Support_Policy_Url = \
-    "https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/agent-upgrade#version-support-policy"
+)
+Doc_Provisioned_Cluster_Delete_Url = "https://learn.microsoft.com/en-us/cli/azure/aksarc?view=azure-cli-latest#az-aksarc-delete"
+Doc_Provisioned_Cluster_Update_Url = "https://learn.microsoft.com/en-us/cli/azure/aksarc?view=azure-cli-latest#az-aksarc-update"
+Doc_Provisioned_Cluster_Upgrade_Url = "https://learn.microsoft.com/en-us/cli/azure/aksarc?view=azure-cli-latest#az-aksarc-upgrade"
+Doc_Agent_Version_Support_Policy_Url = "https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/agent-upgrade#version-support-policy"

--- a/src/connectedk8s/azext_connectedk8s/_help.py
+++ b/src/connectedk8s/azext_connectedk8s/_help.py
@@ -7,12 +7,12 @@
 from knack.help_files import helps  # pylint: disable=unused-import
 
 
-helps['connectedk8s'] = """
+helps["connectedk8s"] = """
     type: group
     short-summary: Commands to manage connected kubernetes clusters.
 """
 
-helps['connectedk8s connect'] = """
+helps["connectedk8s connect"] = """
     type: command
     short-summary: Onboard a connected kubernetes cluster to azure.
     examples:
@@ -39,7 +39,7 @@ helps['connectedk8s connect'] = """
 
 """
 
-helps['connectedk8s update'] = """
+helps["connectedk8s update"] = """
     type: command
     short-summary: Update properties of the arc onboarded kubernetes cluster.
     examples:
@@ -61,7 +61,7 @@ helps['connectedk8s update'] = """
       text: az connectedk8s update -g resourceGroupName -n connectedClusterName --disable-gateway
 """
 
-helps['connectedk8s upgrade'] = """
+helps["connectedk8s upgrade"] = """
     type: command
     short-summary: Atomically upgrade onboarded agents to the specific version or default to the latest version.
     examples:
@@ -73,7 +73,7 @@ helps['connectedk8s upgrade'] = """
       text: az connectedk8s upgrade -g resourceGroupName -n connectedClusterName --upgrade-timeout 600
 """
 
-helps['connectedk8s list'] = """
+helps["connectedk8s list"] = """
     type: command
     short-summary: List connected kubernetes clusters.
     examples:
@@ -84,7 +84,7 @@ helps['connectedk8s list'] = """
 
 """
 
-helps['connectedk8s delete'] = """
+helps["connectedk8s delete"] = """
     type: command
     short-summary: Delete a connected kubernetes cluster along with connected cluster agents.
     examples:
@@ -94,7 +94,7 @@ helps['connectedk8s delete'] = """
       text: az connectedk8s delete -g resourceGroupName -n connectedClusterName --kube-config /path/to/kubeconfig --kube-context kubeContextName
 """
 
-helps['connectedk8s show'] = """
+helps["connectedk8s show"] = """
     type: command
     short-summary: Show details of a connected kubernetes cluster.
     examples:
@@ -102,7 +102,7 @@ helps['connectedk8s show'] = """
       text: az connectedk8s show -g resourceGroupName -n connectedClusterName
 """
 
-helps['connectedk8s proxy'] = """
+helps["connectedk8s proxy"] = """
   type: command
   short-summary: Get access to a connected kubernetes cluster.
   examples:
@@ -118,7 +118,7 @@ helps['connectedk8s proxy'] = """
     text: az connectedk8s proxy -n clusterName -g resourceGroupName --kube-context contextName
 """
 
-helps['connectedk8s enable-features'] = """
+helps["connectedk8s enable-features"] = """
   type: command
   short-summary: Enables the selective features on the connected cluster.
   examples:
@@ -130,7 +130,7 @@ helps['connectedk8s enable-features'] = """
     text: az connectedk8s enable-features -n clusterName -g resourceGroupName --features cluster-connect custom-locations
 """
 
-helps['connectedk8s disable-features'] = """
+helps["connectedk8s disable-features"] = """
   type: command
   short-summary: Disables the selective features on the connected cluster.
   examples:
@@ -140,7 +140,7 @@ helps['connectedk8s disable-features'] = """
     text: az connectedk8s disable-features -n clusterName -g resourceGroupName --features custom-locations azure-rbac
 """
 
-helps['connectedk8s troubleshoot'] = """
+helps["connectedk8s troubleshoot"] = """
   type: command
   short-summary: Perform diagnostic checks on an Arc enabled Kubernetes cluster.
   examples:

--- a/src/connectedk8s/azext_connectedk8s/_params.py
+++ b/src/connectedk8s/azext_connectedk8s/_params.py
@@ -6,142 +6,571 @@
 
 import os.path
 from argcomplete.completers import FilesCompleter
-from azure.cli.core.commands.parameters import get_location_type, get_enum_type, file_type, tags_type, get_three_state_flag
+from azure.cli.core.commands.parameters import (
+    get_location_type,
+    get_enum_type,
+    file_type,
+    tags_type,
+    get_three_state_flag,
+)
 from azure.cli.core.commands.validators import get_default_location_from_resource_group
-from azext_connectedk8s._constants import Distribution_Enum_Values, Infrastructure_Enum_Values, Feature_Values, AHB_Enum_Values
-from knack.arguments import (CLIArgumentType, CaseInsensitiveList)
+from azext_connectedk8s._constants import (
+    Distribution_Enum_Values,
+    Infrastructure_Enum_Values,
+    Feature_Values,
+    AHB_Enum_Values,
+)
+from knack.arguments import CLIArgumentType, CaseInsensitiveList
 
 from ._validators import (
     validate_private_link_properties,
     override_client_request_id_header,
-    validate_gateway_updates
+    validate_gateway_updates,
 )
 from .action import (
     AddConfigurationSettings,
     AddConfigurationProtectedSettings,
 )
 
-features_types = CLIArgumentType(
-    nargs='+',
-    choices=CaseInsensitiveList(Feature_Values)
-)
+features_types = CLIArgumentType(nargs="+", choices=CaseInsensitiveList(Feature_Values))
 
 
 def load_arguments(self, _):
+    pls_arm_id_type = CLIArgumentType(
+        options_list=["--private-link-scope-resource-id", "--pls-arm-id"],
+        arg_group="PrivateLink",
+        help="ARM resource id of the private link scope resource to which this connected cluster is associated.",
+        is_preview=True,
+    )
 
-    pls_arm_id_type = CLIArgumentType(options_list=['--private-link-scope-resource-id', '--pls-arm-id'], arg_group='PrivateLink', help='ARM resource id of the private link scope resource to which this connected cluster is associated.', is_preview=True)
-
-    with self.argument_context('connectedk8s connect') as c:
-        c.argument('tags', tags_type)
-        if os.getenv('AZURE_ACCESS_TOKEN'):
-            c.argument('location', arg_type=get_location_type(self.cli_ctx))
+    with self.argument_context("connectedk8s connect") as c:
+        c.argument("tags", tags_type)
+        if os.getenv("AZURE_ACCESS_TOKEN"):
+            c.argument("location", arg_type=get_location_type(self.cli_ctx))
         else:
-            c.argument('location', arg_type=get_location_type(self.cli_ctx), validator=get_default_location_from_resource_group)
-        c.argument('cluster_name', options_list=['--name', '-n'], help='The name of the connected cluster.')
-        c.argument('kube_config', options_list=['--kube-config'], help='Path to the kube config file.')
-        c.argument('kube_context', options_list=['--kube-context'], help='Kubconfig context from current machine.')
-        c.argument('https_proxy', options_list=['--proxy-https'], arg_group='Proxy', help='Https proxy URL to be used.')
-        c.argument('http_proxy', options_list=['--proxy-http'], arg_group='Proxy', help='Http proxy URL to be used.')
-        c.argument('no_proxy', options_list=['--proxy-skip-range'], arg_group='Proxy', help='List of URLs/CIDRs for which proxy should not to be used.')
-        c.argument('proxy_cert', options_list=['--proxy-cert', '--custom-ca-cert'], arg_group='Proxy', type=file_type, completer=FilesCompleter(), help='Path to the certificate file for proxy or custom Certificate Authority')
-        c.argument('distribution', options_list=['--distribution'], help='The Kubernetes distribution which will be running on this connected cluster.', arg_type=get_enum_type(Distribution_Enum_Values))
-        c.argument('distribution_version', help='The Kubernetes distribution version of the connected cluster.')
-        c.argument('infrastructure', options_list=['--infrastructure'], help='The infrastructure on which the Kubernetes cluster represented by this connected cluster will be running on.', arg_type=get_enum_type(Infrastructure_Enum_Values))
-        c.argument('azure_hybrid_benefit', help='Flag to enable/disable Azure Hybrid Benefit feature.', arg_type=get_enum_type(AHB_Enum_Values))
-        c.argument('disable_auto_upgrade', options_list=['--disable-auto-upgrade'], action='store_true', help='Flag to disable auto upgrade of arc agents.')
-        c.argument('cl_oid', options_list=['--custom-locations-oid'], help="OID of 'custom-locations' app")
-        c.argument('enable_private_link', arg_type=get_three_state_flag(), arg_group='PrivateLink', help='Flag to enable/disable private link support on a connected cluster resource. Allowed values: false, true.', is_preview=True, validator=validate_private_link_properties)
-        c.argument('private_link_scope_resource_id', pls_arm_id_type)
-        c.argument('onboarding_timeout', options_list=['--onboarding-timeout'], arg_group='Timeout', help='Time required (in seconds) for the arc-agent pods to be installed on the kubernetes cluster. Override this value if the hardware/network constraints on your cluster requires more time for installing the arc-agent pods.')
-        c.argument('no_wait', options_list=['--no-wait'], arg_group='Timeout', help="Do not wait for the long-running operation to finish.")
-        c.argument('correlation_id', options_list=['--correlation-id'], help='A guid that is used to internally track the source of cluster onboarding. Please do not modify it unless advised', validator=override_client_request_id_header)
-        c.argument('container_log_path', help='Override the default container log path to enable fluent-bit logging')
-        c.argument('skip_ssl_verification', action='store_true', help='Skip SSL verification for any cluster connection.')
-        c.argument('yes', options_list=['--yes', '-y'], help='Do not prompt for confirmation.', action='store_true')
-        c.argument('enable_oidc_issuer', arg_type=get_three_state_flag(), help="Enable creation of OIDC issuer url used for workload identity", is_preview=True)
-        c.argument('self_hosted_issuer', options_list=['--self-hosted-issuer'], help="Self hosted issuer url for public cloud clusters - AKS, GKE, EKS", is_preview=True)
-        c.argument('enable_workload_identity', options_list=["--enable-workload-identity", "--enable-wi"], arg_type=get_three_state_flag(), help="Enable workload identity webhook", is_preview=True)
-        c.argument('gateway_resource_id', options_list=['--gateway-resource-id'], arg_group='Gateway', help='ArmID of the Arc Gateway resource.')
-        c.argument('configuration_settings', options_list=['--configuration-settings', '--config'], action=AddConfigurationSettings, nargs='+', help='Configuration Settings as key=value pair.  Repeat parameter for each setting. Do not use this for secrets, as this value is returned in response.', is_preview=True)
-        c.argument('configuration_protected_settings', options_list=['--config-protected-settings', '--config-protected'], action=AddConfigurationProtectedSettings, nargs='+', help='Configuration Protected Settings as key=value pair.  Repeat parameter for each setting.  Only the key is returned in response, the value is not.', is_preview=True)
+            c.argument(
+                "location",
+                arg_type=get_location_type(self.cli_ctx),
+                validator=get_default_location_from_resource_group,
+            )
+        c.argument(
+            "cluster_name",
+            options_list=["--name", "-n"],
+            help="The name of the connected cluster.",
+        )
+        c.argument(
+            "kube_config",
+            options_list=["--kube-config"],
+            help="Path to the kube config file.",
+        )
+        c.argument(
+            "kube_context",
+            options_list=["--kube-context"],
+            help="Kubconfig context from current machine.",
+        )
+        c.argument(
+            "https_proxy",
+            options_list=["--proxy-https"],
+            arg_group="Proxy",
+            help="Https proxy URL to be used.",
+        )
+        c.argument(
+            "http_proxy",
+            options_list=["--proxy-http"],
+            arg_group="Proxy",
+            help="Http proxy URL to be used.",
+        )
+        c.argument(
+            "no_proxy",
+            options_list=["--proxy-skip-range"],
+            arg_group="Proxy",
+            help="List of URLs/CIDRs for which proxy should not to be used.",
+        )
+        c.argument(
+            "proxy_cert",
+            options_list=["--proxy-cert", "--custom-ca-cert"],
+            arg_group="Proxy",
+            type=file_type,
+            completer=FilesCompleter(),
+            help="Path to the certificate file for proxy or custom Certificate Authority",
+        )
+        c.argument(
+            "distribution",
+            options_list=["--distribution"],
+            help="The Kubernetes distribution which will be running on this connected cluster.",
+            arg_type=get_enum_type(Distribution_Enum_Values),
+        )
+        c.argument(
+            "distribution_version",
+            help="The Kubernetes distribution version of the connected cluster.",
+        )
+        c.argument(
+            "infrastructure",
+            options_list=["--infrastructure"],
+            help="The infrastructure on which the Kubernetes cluster represented by this connected cluster will be running on.",
+            arg_type=get_enum_type(Infrastructure_Enum_Values),
+        )
+        c.argument(
+            "azure_hybrid_benefit",
+            help="Flag to enable/disable Azure Hybrid Benefit feature.",
+            arg_type=get_enum_type(AHB_Enum_Values),
+        )
+        c.argument(
+            "disable_auto_upgrade",
+            options_list=["--disable-auto-upgrade"],
+            action="store_true",
+            help="Flag to disable auto upgrade of arc agents.",
+        )
+        c.argument(
+            "cl_oid",
+            options_list=["--custom-locations-oid"],
+            help="OID of 'custom-locations' app",
+        )
+        c.argument(
+            "enable_private_link",
+            arg_type=get_three_state_flag(),
+            arg_group="PrivateLink",
+            help="Flag to enable/disable private link support on a connected cluster resource. Allowed values: false, true.",
+            is_preview=True,
+            validator=validate_private_link_properties,
+        )
+        c.argument("private_link_scope_resource_id", pls_arm_id_type)
+        c.argument(
+            "onboarding_timeout",
+            options_list=["--onboarding-timeout"],
+            arg_group="Timeout",
+            help="Time required (in seconds) for the arc-agent pods to be installed on the kubernetes cluster. Override this value if the hardware/network constraints on your cluster requires more time for installing the arc-agent pods.",
+        )
+        c.argument(
+            "no_wait",
+            options_list=["--no-wait"],
+            arg_group="Timeout",
+            help="Do not wait for the long-running operation to finish.",
+        )
+        c.argument(
+            "correlation_id",
+            options_list=["--correlation-id"],
+            help="A guid that is used to internally track the source of cluster onboarding. Please do not modify it unless advised",
+            validator=override_client_request_id_header,
+        )
+        c.argument(
+            "container_log_path",
+            help="Override the default container log path to enable fluent-bit logging",
+        )
+        c.argument(
+            "skip_ssl_verification",
+            action="store_true",
+            help="Skip SSL verification for any cluster connection.",
+        )
+        c.argument(
+            "yes",
+            options_list=["--yes", "-y"],
+            help="Do not prompt for confirmation.",
+            action="store_true",
+        )
+        c.argument(
+            "enable_oidc_issuer",
+            arg_type=get_three_state_flag(),
+            help="Enable creation of OIDC issuer url used for workload identity",
+            is_preview=True,
+        )
+        c.argument(
+            "self_hosted_issuer",
+            options_list=["--self-hosted-issuer"],
+            help="Self hosted issuer url for public cloud clusters - AKS, GKE, EKS",
+            is_preview=True,
+        )
+        c.argument(
+            "enable_workload_identity",
+            options_list=["--enable-workload-identity", "--enable-wi"],
+            arg_type=get_three_state_flag(),
+            help="Enable workload identity webhook",
+            is_preview=True,
+        )
+        c.argument(
+            "gateway_resource_id",
+            options_list=["--gateway-resource-id"],
+            arg_group="Gateway",
+            help="ArmID of the Arc Gateway resource.",
+        )
+        c.argument(
+            "configuration_settings",
+            options_list=["--configuration-settings", "--config"],
+            action=AddConfigurationSettings,
+            nargs="+",
+            help="Configuration Settings as key=value pair.  Repeat parameter for each setting. Do not use this for secrets, as this value is returned in response.",
+            is_preview=True,
+        )
+        c.argument(
+            "configuration_protected_settings",
+            options_list=["--config-protected-settings", "--config-protected"],
+            action=AddConfigurationProtectedSettings,
+            nargs="+",
+            help="Configuration Protected Settings as key=value pair.  Repeat parameter for each setting.  Only the key is returned in response, the value is not.",
+            is_preview=True,
+        )
 
-    with self.argument_context('connectedk8s update') as c:
-        c.argument('tags', tags_type)
-        c.argument('cluster_name', options_list=['--name', '-n'], id_part='name', help='The name of the connected cluster.')
-        c.argument('kube_config', options_list=['--kube-config'], help='Path to the kube config file.')
-        c.argument('kube_context', options_list=['--kube-context'], help='Kubconfig context from current machine.')
-        c.argument('https_proxy', options_list=['--proxy-https'], arg_group='Proxy', help='Https proxy URL to be used.')
-        c.argument('http_proxy', options_list=['--proxy-http'], arg_group='Proxy', help='Http proxy URL to be used.')
-        c.argument('no_proxy', options_list=['--proxy-skip-range'], arg_group='Proxy', help='List of URLs/CIDRs for which proxy should not to be used.')
-        c.argument('distribution', help='The Kubernetes distribution which will be running on this connected cluster.', arg_type=get_enum_type(Distribution_Enum_Values))
-        c.argument('distribution_version', help='The Kubernetes distribution version of the connected cluster.')
-        c.argument('azure_hybrid_benefit', help='Flag to enable/disable Azure Hybrid Benefit feature.', arg_type=get_enum_type(AHB_Enum_Values))
-        c.argument('proxy_cert', options_list=['--proxy-cert', '--custom-ca-cert'], arg_group='Proxy', type=file_type, completer=FilesCompleter(), help='Path to the certificate file for proxy or custom Certificate Authority')
-        c.argument('disable_proxy', options_list=['--disable-proxy'], arg_group='Proxy', action='store_true', help='Disables proxy settings for agents')
-        c.argument('auto_upgrade', options_list=['--auto-upgrade'], help='Flag to enable/disable auto upgrade of arc agents. By default, auto upgrade of agents is enabled.', arg_type=get_enum_type(["true", "false"]))
-        c.argument('container_log_path', help='Override the default container log path to enable fluent-bit logging')
-        c.argument('skip_ssl_verification', action='store_true', help='Skip SSL verification for any cluster connection.')
-        c.argument('yes', options_list=['--yes', '-y'], help='Do not prompt for confirmation.', action='store_true')
-        c.argument('enable_oidc_issuer', arg_type=get_three_state_flag(), help="Enable creation of OIDC issuer url used for workload identity", is_preview=True)
-        c.argument('self_hosted_issuer', options_list=["--self-hosted-issuer"], help="Self hosted issuer url for public cloud clusters - AKS, GKE, EKS", is_preview=True)
-        c.argument('enable_workload_identity', options_list=["--enable-workload-identity", "--enable-wi"], arg_type=get_three_state_flag(), help="Enable workload identity webhook", is_preview=True)
-        c.argument('disable_workload_identity', options_list=["--disable-workload-identity", "--disable-wi"], arg_type=get_three_state_flag(), help="Disable workload identity webhook", is_preview=True)
-        c.argument('gateway_resource_id', options_list=['--gateway-resource-id'], arg_group='Gateway', help='ArmID of the Arc Gateway resource.', validator=validate_gateway_updates)
-        c.argument('disable_gateway', options_list=['--disable-gateway'], arg_group='Gateway', help='Flag to disable Arc Gateway', validator=validate_gateway_updates)
-        c.argument('configuration_settings', options_list=['--configuration-settings', '--config'], action=AddConfigurationSettings, nargs='+', help='Configuration Settings as key=value pair.  Repeat parameter for each setting. Do not use this for secrets, as this value is returned in response.', is_preview=True)
-        c.argument('configuration_protected_settings', options_list=['--config-protected-settings', '--config-protected'], action=AddConfigurationProtectedSettings, nargs='+', help='Configuration Protected Settings as key=value pair.  Repeat parameter for each setting.  Only the key is returned in response, the value is not.', is_preview=True)
+    with self.argument_context("connectedk8s update") as c:
+        c.argument("tags", tags_type)
+        c.argument(
+            "cluster_name",
+            options_list=["--name", "-n"],
+            id_part="name",
+            help="The name of the connected cluster.",
+        )
+        c.argument(
+            "kube_config",
+            options_list=["--kube-config"],
+            help="Path to the kube config file.",
+        )
+        c.argument(
+            "kube_context",
+            options_list=["--kube-context"],
+            help="Kubconfig context from current machine.",
+        )
+        c.argument(
+            "https_proxy",
+            options_list=["--proxy-https"],
+            arg_group="Proxy",
+            help="Https proxy URL to be used.",
+        )
+        c.argument(
+            "http_proxy",
+            options_list=["--proxy-http"],
+            arg_group="Proxy",
+            help="Http proxy URL to be used.",
+        )
+        c.argument(
+            "no_proxy",
+            options_list=["--proxy-skip-range"],
+            arg_group="Proxy",
+            help="List of URLs/CIDRs for which proxy should not to be used.",
+        )
+        c.argument(
+            "distribution",
+            help="The Kubernetes distribution which will be running on this connected cluster.",
+            arg_type=get_enum_type(Distribution_Enum_Values),
+        )
+        c.argument(
+            "distribution_version",
+            help="The Kubernetes distribution version of the connected cluster.",
+        )
+        c.argument(
+            "azure_hybrid_benefit",
+            help="Flag to enable/disable Azure Hybrid Benefit feature.",
+            arg_type=get_enum_type(AHB_Enum_Values),
+        )
+        c.argument(
+            "proxy_cert",
+            options_list=["--proxy-cert", "--custom-ca-cert"],
+            arg_group="Proxy",
+            type=file_type,
+            completer=FilesCompleter(),
+            help="Path to the certificate file for proxy or custom Certificate Authority",
+        )
+        c.argument(
+            "disable_proxy",
+            options_list=["--disable-proxy"],
+            arg_group="Proxy",
+            action="store_true",
+            help="Disables proxy settings for agents",
+        )
+        c.argument(
+            "auto_upgrade",
+            options_list=["--auto-upgrade"],
+            help="Flag to enable/disable auto upgrade of arc agents. By default, auto upgrade of agents is enabled.",
+            arg_type=get_enum_type(["true", "false"]),
+        )
+        c.argument(
+            "container_log_path",
+            help="Override the default container log path to enable fluent-bit logging",
+        )
+        c.argument(
+            "skip_ssl_verification",
+            action="store_true",
+            help="Skip SSL verification for any cluster connection.",
+        )
+        c.argument(
+            "yes",
+            options_list=["--yes", "-y"],
+            help="Do not prompt for confirmation.",
+            action="store_true",
+        )
+        c.argument(
+            "enable_oidc_issuer",
+            arg_type=get_three_state_flag(),
+            help="Enable creation of OIDC issuer url used for workload identity",
+            is_preview=True,
+        )
+        c.argument(
+            "self_hosted_issuer",
+            options_list=["--self-hosted-issuer"],
+            help="Self hosted issuer url for public cloud clusters - AKS, GKE, EKS",
+            is_preview=True,
+        )
+        c.argument(
+            "enable_workload_identity",
+            options_list=["--enable-workload-identity", "--enable-wi"],
+            arg_type=get_three_state_flag(),
+            help="Enable workload identity webhook",
+            is_preview=True,
+        )
+        c.argument(
+            "disable_workload_identity",
+            options_list=["--disable-workload-identity", "--disable-wi"],
+            arg_type=get_three_state_flag(),
+            help="Disable workload identity webhook",
+            is_preview=True,
+        )
+        c.argument(
+            "gateway_resource_id",
+            options_list=["--gateway-resource-id"],
+            arg_group="Gateway",
+            help="ArmID of the Arc Gateway resource.",
+            validator=validate_gateway_updates,
+        )
+        c.argument(
+            "disable_gateway",
+            options_list=["--disable-gateway"],
+            arg_group="Gateway",
+            help="Flag to disable Arc Gateway",
+            validator=validate_gateway_updates,
+        )
+        c.argument(
+            "configuration_settings",
+            options_list=["--configuration-settings", "--config"],
+            action=AddConfigurationSettings,
+            nargs="+",
+            help="Configuration Settings as key=value pair.  Repeat parameter for each setting. Do not use this for secrets, as this value is returned in response.",
+            is_preview=True,
+        )
+        c.argument(
+            "configuration_protected_settings",
+            options_list=["--config-protected-settings", "--config-protected"],
+            action=AddConfigurationProtectedSettings,
+            nargs="+",
+            help="Configuration Protected Settings as key=value pair.  Repeat parameter for each setting.  Only the key is returned in response, the value is not.",
+            is_preview=True,
+        )
 
-    with self.argument_context('connectedk8s upgrade') as c:
-        c.argument('cluster_name', options_list=['--name', '-n'], id_part='name', help='The name of the connected cluster.')
-        c.argument('kube_config', options_list=['--kube-config'], help='Path to the kube config file.')
-        c.argument('kube_context', options_list=['--kube-context'], help='Kubconfig context from current machine.')
-        c.argument('arc_agent_version', options_list=['--agent-version'], help='Version of agent to update the helm charts to.')
-        c.argument('skip_ssl_verification', action='store_true', help='Skip SSL verification for any cluster connection.')
-        c.argument('upgrade_timeout', options_list=['--upgrade-timeout'], help='Time required (in seconds) for the arc-agent pods to be upgraded on the kubernetes cluster. Override this value if the hardware/network constraints on your cluster requires more time for upgrading the arc-agent pods.')
+    with self.argument_context("connectedk8s upgrade") as c:
+        c.argument(
+            "cluster_name",
+            options_list=["--name", "-n"],
+            id_part="name",
+            help="The name of the connected cluster.",
+        )
+        c.argument(
+            "kube_config",
+            options_list=["--kube-config"],
+            help="Path to the kube config file.",
+        )
+        c.argument(
+            "kube_context",
+            options_list=["--kube-context"],
+            help="Kubconfig context from current machine.",
+        )
+        c.argument(
+            "arc_agent_version",
+            options_list=["--agent-version"],
+            help="Version of agent to update the helm charts to.",
+        )
+        c.argument(
+            "skip_ssl_verification",
+            action="store_true",
+            help="Skip SSL verification for any cluster connection.",
+        )
+        c.argument(
+            "upgrade_timeout",
+            options_list=["--upgrade-timeout"],
+            help="Time required (in seconds) for the arc-agent pods to be upgraded on the kubernetes cluster. Override this value if the hardware/network constraints on your cluster requires more time for upgrading the arc-agent pods.",
+        )
 
-    with self.argument_context('connectedk8s enable-features') as c:
-        c.argument('cluster_name', options_list=['--name', '-n'], id_part='name', help='The name of the connected cluster.')
-        c.argument('kube_config', options_list=['--kube-config'], help='Path to the kube config file.')
-        c.argument('kube_context', options_list=['--kube-context'], help='Kubconfig context from current machine.')
-        c.argument('features', features_types, options_list=['--features'], help='Space-separated list of features you want to enable.')
-        c.argument('azrbac_client_id', options_list=['--app-id'], arg_group='Azure RBAC', help='Application ID for enabling Azure RBAC.', deprecate_info=c.deprecate(hide=True))
-        c.argument('azrbac_client_secret', options_list=['--app-secret'], arg_group='Azure RBAC', help='Application secret for enabling Azure RBAC.', deprecate_info=c.deprecate(hide=True))
-        c.argument('azrbac_skip_authz_check', options_list=['--skip-azure-rbac-list'], arg_group='Azure RBAC', help='Comma separated list of names of usernames/email/oid. Azure RBAC will be skipped for these users. Specify when enabling azure-rbac.')
-        c.argument('cl_oid', options_list=['--custom-locations-oid'], help="OID of 'custom-locations' app")
-        c.argument('skip_ssl_verification', action='store_true', help='Skip SSL verification for any cluster connection.')
+    with self.argument_context("connectedk8s enable-features") as c:
+        c.argument(
+            "cluster_name",
+            options_list=["--name", "-n"],
+            id_part="name",
+            help="The name of the connected cluster.",
+        )
+        c.argument(
+            "kube_config",
+            options_list=["--kube-config"],
+            help="Path to the kube config file.",
+        )
+        c.argument(
+            "kube_context",
+            options_list=["--kube-context"],
+            help="Kubconfig context from current machine.",
+        )
+        c.argument(
+            "features",
+            features_types,
+            options_list=["--features"],
+            help="Space-separated list of features you want to enable.",
+        )
+        c.argument(
+            "azrbac_client_id",
+            options_list=["--app-id"],
+            arg_group="Azure RBAC",
+            help="Application ID for enabling Azure RBAC.",
+            deprecate_info=c.deprecate(hide=True),
+        )
+        c.argument(
+            "azrbac_client_secret",
+            options_list=["--app-secret"],
+            arg_group="Azure RBAC",
+            help="Application secret for enabling Azure RBAC.",
+            deprecate_info=c.deprecate(hide=True),
+        )
+        c.argument(
+            "azrbac_skip_authz_check",
+            options_list=["--skip-azure-rbac-list"],
+            arg_group="Azure RBAC",
+            help="Comma separated list of names of usernames/email/oid. Azure RBAC will be skipped for these users. Specify when enabling azure-rbac.",
+        )
+        c.argument(
+            "cl_oid",
+            options_list=["--custom-locations-oid"],
+            help="OID of 'custom-locations' app",
+        )
+        c.argument(
+            "skip_ssl_verification",
+            action="store_true",
+            help="Skip SSL verification for any cluster connection.",
+        )
 
-    with self.argument_context('connectedk8s disable-features') as c:
-        c.argument('cluster_name', options_list=['--name', '-n'], id_part='name', help='The name of the connected cluster.')
-        c.argument('kube_config', options_list=['--kube-config'], help='Path to the kube config file.')
-        c.argument('kube_context', options_list=['--kube-context'], help='Kubconfig context from current machine.')
-        c.argument('features', features_types, options_list=['--features'], help='Space-separated list of features you want to disable.')
-        c.argument('skip_ssl_verification', action='store_true', help='Skip SSL verification for any cluster connection.')
-        c.argument('yes', options_list=['--yes', '-y'], help='Do not prompt for confirmation.', action='store_true')
+    with self.argument_context("connectedk8s disable-features") as c:
+        c.argument(
+            "cluster_name",
+            options_list=["--name", "-n"],
+            id_part="name",
+            help="The name of the connected cluster.",
+        )
+        c.argument(
+            "kube_config",
+            options_list=["--kube-config"],
+            help="Path to the kube config file.",
+        )
+        c.argument(
+            "kube_context",
+            options_list=["--kube-context"],
+            help="Kubconfig context from current machine.",
+        )
+        c.argument(
+            "features",
+            features_types,
+            options_list=["--features"],
+            help="Space-separated list of features you want to disable.",
+        )
+        c.argument(
+            "skip_ssl_verification",
+            action="store_true",
+            help="Skip SSL verification for any cluster connection.",
+        )
+        c.argument(
+            "yes",
+            options_list=["--yes", "-y"],
+            help="Do not prompt for confirmation.",
+            action="store_true",
+        )
 
-    with self.argument_context('connectedk8s list') as c:
+    with self.argument_context("connectedk8s list") as c:
         pass
 
-    with self.argument_context('connectedk8s show') as c:
-        c.argument('cluster_name', options_list=['--name', '-n'], id_part='name', help='The name of the connected cluster.')
+    with self.argument_context("connectedk8s show") as c:
+        c.argument(
+            "cluster_name",
+            options_list=["--name", "-n"],
+            id_part="name",
+            help="The name of the connected cluster.",
+        )
 
-    with self.argument_context('connectedk8s delete') as c:
-        c.argument('cluster_name', options_list=['--name', '-n'], id_part='name', help='The name of the connected cluster.')
-        c.argument('kube_config', options_list=['--kube-config'], help='Path to the kube config file.')
-        c.argument('kube_context', options_list=['--kube-context'], help='Kubconfig context from current machine.')
-        c.argument('force_delete', options_list=['--force'], help='Force delete to remove all azure-arc resources from the cluster.', action='store_true')
-        c.argument('skip_ssl_verification', action='store_true', help='Skip SSL verification for any cluster connection.')
-        c.argument('yes', options_list=['--yes', '-y'], help='Do not prompt for confirmation.', action='store_true')
+    with self.argument_context("connectedk8s delete") as c:
+        c.argument(
+            "cluster_name",
+            options_list=["--name", "-n"],
+            id_part="name",
+            help="The name of the connected cluster.",
+        )
+        c.argument(
+            "kube_config",
+            options_list=["--kube-config"],
+            help="Path to the kube config file.",
+        )
+        c.argument(
+            "kube_context",
+            options_list=["--kube-context"],
+            help="Kubconfig context from current machine.",
+        )
+        c.argument(
+            "force_delete",
+            options_list=["--force"],
+            help="Force delete to remove all azure-arc resources from the cluster.",
+            action="store_true",
+        )
+        c.argument(
+            "skip_ssl_verification",
+            action="store_true",
+            help="Skip SSL verification for any cluster connection.",
+        )
+        c.argument(
+            "yes",
+            options_list=["--yes", "-y"],
+            help="Do not prompt for confirmation.",
+            action="store_true",
+        )
 
-    with self.argument_context('connectedk8s proxy') as c:
-        c.argument('cluster_name', options_list=['--name', '-n'], id_part='name', help='The name of the connected cluster.')
-        c.argument('token', options_list=['--token'], help='Service account token to use to authenticate to the kubernetes cluster.')
-        c.argument('context_name', options_list=['--kube-context'], help='If specified, overwrite the default context name.')
-        c.argument('path', options_list=['--file', '-f'], type=file_type, completer=FilesCompleter(), default=os.path.join(os.path.expanduser('~'), '.kube', 'config'), help="Kubernetes configuration file to update. If not provided, updates the file '~/.kube/config'. Use '-' to print YAML to stdout instead.")
-        c.argument('api_server_port', options_list=['--port'], help='Port used for accessing connected cluster.')
+    with self.argument_context("connectedk8s proxy") as c:
+        c.argument(
+            "cluster_name",
+            options_list=["--name", "-n"],
+            id_part="name",
+            help="The name of the connected cluster.",
+        )
+        c.argument(
+            "token",
+            options_list=["--token"],
+            help="Service account token to use to authenticate to the kubernetes cluster.",
+        )
+        c.argument(
+            "context_name",
+            options_list=["--kube-context"],
+            help="If specified, overwrite the default context name.",
+        )
+        c.argument(
+            "path",
+            options_list=["--file", "-f"],
+            type=file_type,
+            completer=FilesCompleter(),
+            default=os.path.join(os.path.expanduser("~"), ".kube", "config"),
+            help="Kubernetes configuration file to update. If not provided, updates the file '~/.kube/config'. Use '-' to print YAML to stdout instead.",
+        )
+        c.argument(
+            "api_server_port",
+            options_list=["--port"],
+            help="Port used for accessing connected cluster.",
+        )
 
-    with self.argument_context('connectedk8s troubleshoot') as c:
-        c.argument('tags', tags_type)
-        c.argument('cluster_name', options_list=['--name', '-n'], help='The name of the connected cluster.')
-        c.argument('kube_config', options_list=['--kube-config'], help='Path to the kube config file.')
-        c.argument('kube_context', options_list=['--kube-context'], help='Kubeconfig context from current machine.')
-        c.argument('skip_ssl_verification', action='store_true', help='Skip SSL verification for any cluster connection.')
+    with self.argument_context("connectedk8s troubleshoot") as c:
+        c.argument("tags", tags_type)
+        c.argument(
+            "cluster_name",
+            options_list=["--name", "-n"],
+            help="The name of the connected cluster.",
+        )
+        c.argument(
+            "kube_config",
+            options_list=["--kube-config"],
+            help="Path to the kube config file.",
+        )
+        c.argument(
+            "kube_context",
+            options_list=["--kube-context"],
+            help="Kubeconfig context from current machine.",
+        )
+        c.argument(
+            "skip_ssl_verification",
+            action="store_true",
+            help="Skip SSL verification for any cluster connection.",
+        )

--- a/src/connectedk8s/azext_connectedk8s/_precheckutils.py
+++ b/src/connectedk8s/azext_connectedk8s/_precheckutils.py
@@ -27,8 +27,15 @@ import azext_connectedk8s._constants as consts
 import azext_connectedk8s._utils as azext_utils
 from kubernetes import client as kube_client
 from azure.cli.core import get_default_cli
-from azure.cli.core.azclierror import CLIInternalError, ClientRequestError, ArgumentUsageError, ManualInterrupt, \
-    AzureResponseError, AzureInternalError, ValidationError
+from azure.cli.core.azclierror import (
+    CLIInternalError,
+    ClientRequestError,
+    ArgumentUsageError,
+    ManualInterrupt,
+    AzureResponseError,
+    AzureInternalError,
+    ValidationError,
+)
 from argparse import Namespace
 from pydoc import cli
 from logging import exception
@@ -40,6 +47,7 @@ import shutil
 from knack.log import get_logger
 from azure.cli.core import telemetry
 import azext_connectedk8s._constants as consts
+
 logger = get_logger(__name__)
 # pylint: disable=unused-argument, too-many-locals, too-many-branches, too-many-statements, line-too-long
 # pylint: disable
@@ -47,24 +55,54 @@ logger = get_logger(__name__)
 diagnoser_output = []
 
 
-def fetch_diagnostic_checks_results(corev1_api_instance, batchv1_api_instance, helm_client_location,
-                                    kubectl_client_location, kube_config, kube_context, location, http_proxy,
-                                    https_proxy, no_proxy, proxy_cert, azure_cloud, filepath_with_timestamp,
-                                    storage_space_available):
+def fetch_diagnostic_checks_results(
+    corev1_api_instance,
+    batchv1_api_instance,
+    helm_client_location,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+    location,
+    http_proxy,
+    https_proxy,
+    no_proxy,
+    proxy_cert,
+    azure_cloud,
+    filepath_with_timestamp,
+    storage_space_available,
+):
     global diagnoser_output
     try:
         # Setting DNS and Outbound Check as working
         dns_check = "Starting"
         outbound_connectivity_check = "Starting"
         # Executing the cluster_diagnostic_checks job and fetching the logs obtained
-        cluster_diagnostic_checks_container_log = \
-            executing_cluster_diagnostic_checks_job(corev1_api_instance, batchv1_api_instance, helm_client_location,
-                                                    kubectl_client_location, kube_config, kube_context, location,
-                                                    http_proxy, https_proxy, no_proxy, proxy_cert, azure_cloud,
-                                                    filepath_with_timestamp, storage_space_available)
+        cluster_diagnostic_checks_container_log = (
+            executing_cluster_diagnostic_checks_job(
+                corev1_api_instance,
+                batchv1_api_instance,
+                helm_client_location,
+                kubectl_client_location,
+                kube_config,
+                kube_context,
+                location,
+                http_proxy,
+                https_proxy,
+                no_proxy,
+                proxy_cert,
+                azure_cloud,
+                filepath_with_timestamp,
+                storage_space_available,
+            )
+        )
         # If cluster_diagnostic_checks_container_log is not empty there were errors.  Try to read the logs.
-        if (cluster_diagnostic_checks_container_log is not None and cluster_diagnostic_checks_container_log != ""):
-            cluster_diagnostic_checks_container_log_list = cluster_diagnostic_checks_container_log.split("\n")
+        if (
+            cluster_diagnostic_checks_container_log is not None
+            and cluster_diagnostic_checks_container_log != ""
+        ):
+            cluster_diagnostic_checks_container_log_list = (
+                cluster_diagnostic_checks_container_log.split("\n")
+            )
             cluster_diagnostic_checks_container_log_list.pop(-1)
             dns_check_log = ""
             outbound_connectivity_check_log = ""
@@ -82,43 +120,77 @@ def fetch_diagnostic_checks_results(corev1_api_instance, batchv1_api_instance, h
                     counter_container_logs = 0
                 elif counter_container_logs == 0:
                     dns_check_log += "  " + outputs
-            dns_check, storage_space_available = \
-                azext_utils.check_cluster_DNS(dns_check_log, filepath_with_timestamp,
-                                              storage_space_available, diagnoser_output)
-            outbound_connectivity_check, storage_space_available = \
-                azext_utils.check_cluster_outbound_connectivity(outbound_connectivity_check_log,
-                                                                filepath_with_timestamp, storage_space_available,
-                                                                diagnoser_output)
+            dns_check, storage_space_available = azext_utils.check_cluster_DNS(
+                dns_check_log,
+                filepath_with_timestamp,
+                storage_space_available,
+                diagnoser_output,
+            )
+            outbound_connectivity_check, storage_space_available = (
+                azext_utils.check_cluster_outbound_connectivity(
+                    outbound_connectivity_check_log,
+                    filepath_with_timestamp,
+                    storage_space_available,
+                    diagnoser_output,
+                )
+            )
         else:
             return consts.Diagnostic_Check_Passed, storage_space_available
 
         # If any of the check remain Incomplete than we will return Incomplete
-        if (dns_check == consts.Diagnostic_Check_Incomplete or
-                outbound_connectivity_check == consts.Diagnostic_Check_Incomplete):
+        if (
+            dns_check == consts.Diagnostic_Check_Incomplete
+            or outbound_connectivity_check == consts.Diagnostic_Check_Incomplete
+        ):
             return consts.Diagnostic_Check_Incomplete, storage_space_available
         else:
             return consts.Diagnostic_Check_Failed, storage_space_available
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to execute cluster diagnostic checks container on the "
-                       "cluster. Exception: {}".format(str(e)) + "\n")
-        telemetry.set_exception(exception=e, fault_type=consts.Cluster_Diagnostic_Checks_Execution_Failed_Fault_Type,
-                                summary="Error occured while executing the cluster diagnostic checks container")
+        logger.warning(
+            "An exception has occured while trying to execute cluster diagnostic checks container on the "
+            "cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Cluster_Diagnostic_Checks_Execution_Failed_Fault_Type,
+            summary="Error occured while executing the cluster diagnostic checks container",
+        )
 
     return consts.Diagnostic_Check_Incomplete, storage_space_available
 
 
-def executing_cluster_diagnostic_checks_job(corev1_api_instance, batchv1_api_instance, helm_client_location,
-                                            kubectl_client_location, kube_config, kube_context, location,
-                                            http_proxy, https_proxy, no_proxy, proxy_cert, azure_cloud,
-                                            filepath_with_timestamp, storage_space_available):
+def executing_cluster_diagnostic_checks_job(
+    corev1_api_instance,
+    batchv1_api_instance,
+    helm_client_location,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+    location,
+    http_proxy,
+    https_proxy,
+    no_proxy,
+    proxy_cert,
+    azure_cloud,
+    filepath_with_timestamp,
+    storage_space_available,
+):
     job_name = "cluster-diagnostic-checks-job"
     # Setting the log output as Empty
     cluster_diagnostic_checks_container_log = ""
-    release_namespace = azext_utils.get_release_namespace(kube_config, kube_context, helm_client_location,
-                                                          "cluster-diagnostic-checks")
-    cmd_helm_delete = [helm_client_location, "delete", "cluster-diagnostic-checks", "-n", "azure-arc-release"]
+    release_namespace = azext_utils.get_release_namespace(
+        kube_config, kube_context, helm_client_location, "cluster-diagnostic-checks"
+    )
+    cmd_helm_delete = [
+        helm_client_location,
+        "delete",
+        "cluster-diagnostic-checks",
+        "-n",
+        "azure-arc-release",
+    ]
     if kube_config:
         cmd_helm_delete.extend(["--kubeconfig", kube_config])
     if kube_context:
@@ -132,10 +204,14 @@ def executing_cluster_diagnostic_checks_job(corev1_api_instance, batchv1_api_ins
         if release_namespace is not None:
             # Attempting deletion of cluster diagnostic checks resources to handle the scenario if any stale
             # resources are present
-            response_kubectl_delete_helm = Popen(cmd_helm_delete, stdout=PIPE, stderr=PIPE)
-            output_kubectl_delete_helm, error_kubectl_delete_helm = response_kubectl_delete_helm.communicate()
+            response_kubectl_delete_helm = Popen(
+                cmd_helm_delete, stdout=PIPE, stderr=PIPE
+            )
+            output_kubectl_delete_helm, error_kubectl_delete_helm = (
+                response_kubectl_delete_helm.communicate()
+            )
             # If any error occured while execution of delete command
-            if (response_kubectl_delete_helm.returncode != 0):
+            if response_kubectl_delete_helm.returncode != 0:
                 # Converting the string of multiple errors to list
                 error_msg_list = error_kubectl_delete_helm.decode("ascii").split("\n")
                 error_msg_list.pop(-1)
@@ -143,132 +219,218 @@ def executing_cluster_diagnostic_checks_job(corev1_api_instance, batchv1_api_ins
                 # Checking if any exception occured or not
                 exception_occured_counter = 0
                 for ind_errors in error_msg_list:
-                    if ('not found' in ind_errors or 'deleted' in ind_errors):
+                    if "not found" in ind_errors or "deleted" in ind_errors:
                         pass
                     else:
                         valid_exception_list.append(ind_errors)
                         exception_occured_counter = 1
                 # If any exception occured we will print the exception and return
                 if exception_occured_counter == 1:
-                    logger.warning("Cleanup of previous diagnostic checks helm release failed and hence couldn't "
-                                   "install the new helm release. Please cleanup older release using \"helm delete "
-                                   "cluster-diagnostic-checks -n azure-arc-release\" and try onboarding again")
-                    telemetry.set_exception(exception=error_kubectl_delete_helm.decode("ascii"),
-                                            fault_type=consts.Cluster_Diagnostic_Checks_Release_Cleanup_Failed,
-                                            summary="Error while executing Cluster Diagnostic Checks Job")
+                    logger.warning(
+                        "Cleanup of previous diagnostic checks helm release failed and hence couldn't "
+                        'install the new helm release. Please cleanup older release using "helm delete '
+                        'cluster-diagnostic-checks -n azure-arc-release" and try onboarding again'
+                    )
+                    telemetry.set_exception(
+                        exception=error_kubectl_delete_helm.decode("ascii"),
+                        fault_type=consts.Cluster_Diagnostic_Checks_Release_Cleanup_Failed,
+                        summary="Error while executing Cluster Diagnostic Checks Job",
+                    )
                     return
 
-        chart_path = azext_utils.get_chart_path(consts.Cluster_Diagnostic_Checks_Job_Registry_Path, kube_config,
-                                                kube_context, helm_client_location,
-                                                consts.Pre_Onboarding_Helm_Charts_Folder_Name,
-                                                consts.Pre_Onboarding_Helm_Charts_Release_Name, False)
+        chart_path = azext_utils.get_chart_path(
+            consts.Cluster_Diagnostic_Checks_Job_Registry_Path,
+            kube_config,
+            kube_context,
+            helm_client_location,
+            consts.Pre_Onboarding_Helm_Charts_Folder_Name,
+            consts.Pre_Onboarding_Helm_Charts_Release_Name,
+            False,
+        )
 
-        print("Step: {}: Chart path for Cluster Diagnostic Checks Job: {}".format(azext_utils.get_utctimestring(),
-                                                                                  chart_path))
-        print("Step: {}: Creating Cluster Diagnostic Checks job".format(azext_utils.get_utctimestring()))
-        helm_install_release_cluster_diagnostic_checks(chart_path, location, http_proxy, https_proxy, no_proxy,
-                                                       proxy_cert, azure_cloud, kube_config, kube_context,
-                                                       helm_client_location)
+        print(
+            "Step: {}: Chart path for Cluster Diagnostic Checks Job: {}".format(
+                azext_utils.get_utctimestring(), chart_path
+            )
+        )
+        print(
+            "Step: {}: Creating Cluster Diagnostic Checks job".format(
+                azext_utils.get_utctimestring()
+            )
+        )
+        helm_install_release_cluster_diagnostic_checks(
+            chart_path,
+            location,
+            http_proxy,
+            https_proxy,
+            no_proxy,
+            proxy_cert,
+            azure_cloud,
+            kube_config,
+            kube_context,
+            helm_client_location,
+        )
 
         # Watching for cluster diagnostic checks container to reach in completed stage
         w = watch.Watch()
         is_job_complete = False
         is_job_scheduled = False
         # To watch for changes in pods' states till it reach completed state or exit if it takes more than 180 seconds
-        for job in w.stream(batchv1_api_instance.list_namespaced_job, namespace='azure-arc-release',
-                            label_selector="", timeout_seconds=60):
-            logger.debug("Watching Cluster Diagnostic Checks Job to reach completed state")
+        for job in w.stream(
+            batchv1_api_instance.list_namespaced_job,
+            namespace="azure-arc-release",
+            label_selector="",
+            timeout_seconds=60,
+        ):
+            logger.debug(
+                "Watching Cluster Diagnostic Checks Job to reach completed state"
+            )
             try:
                 # Checking if job get scheduled or not
                 if job["object"].metadata.name == "cluster-diagnostic-checks-job":
                     is_job_scheduled = True
 
                 if job["object"].metadata.name == "cluster-diagnostic-checks-job":
-                    if job["object"].status.failed is not None and job["object"].status.failed >= 3:
+                    if (
+                        job["object"].status.failed is not None
+                        and job["object"].status.failed >= 3
+                    ):
                         logger.debug("Cluster Diagnostic Checks job Failed")
                         w.stop()
                         break
                     elif job["object"].status.conditions is not None:
-                        is_complete = any(condition.type == "Complete" for condition in job["object"].status.conditions)
+                        is_complete = any(
+                            condition.type == "Complete"
+                            for condition in job["object"].status.conditions
+                        )
                         if is_complete:
                             is_job_complete = True
-                            logger.debug("Cluster Diagnostic Checks Job reached completed state")
+                            logger.debug(
+                                "Cluster Diagnostic Checks Job reached completed state"
+                            )
                             w.stop()
             except Exception:
-                logger.debug("Caught Exception, executing Cluster Diagnostic Checks job: ", Exception)
+                logger.debug(
+                    "Caught Exception, executing Cluster Diagnostic Checks job: ",
+                    Exception,
+                )
                 continue
 
         # If job is not completed then we will save the pod description for debugging
         if is_job_complete is False:
-            logger.debug("Saving Pod Description of Cluster Diagnostic Checks Job at: %s", filepath_with_timestamp)
+            logger.debug(
+                "Saving Pod Description of Cluster Diagnostic Checks Job at: %s",
+                filepath_with_timestamp,
+            )
             azext_utils.save_cluster_diagnostic_checks_pod_description(
-                corev1_api_instance, batchv1_api_instance, helm_client_location, kubectl_client_location,
-                kube_config, kube_context, filepath_with_timestamp, storage_space_available)
+                corev1_api_instance,
+                batchv1_api_instance,
+                helm_client_location,
+                kubectl_client_location,
+                kube_config,
+                kube_context,
+                filepath_with_timestamp,
+                storage_space_available,
+            )
 
         # If job is not scheduled then we will delete the helm release
-        if (is_job_scheduled is False):
-            telemetry.set_exception(exception="Couldn't schedule Cluster Diagnostic Checks Job in the cluster",
-                                    fault_type=consts.Cluster_Diagnostic_Checks_Job_Not_Scheduled,
-                                    summary="Couldn't schedule Cluster Diagnostic Checks Job in the cluster")
-            logger.warning("Unable to schedule the Cluster Diagnostic Checks Job in the kubernetes cluster. The "
-                           "possible reasons can be presence of a security policy or security context constraint "
-                           "(SCC) or it may happen becuase of lack of ResourceQuota.\n")
-            logger.debug("Cluster diagnostic Job couldn't be scheduled.  Deleting the helm release in the cluster")
+        if is_job_scheduled is False:
+            telemetry.set_exception(
+                exception="Couldn't schedule Cluster Diagnostic Checks Job in the cluster",
+                fault_type=consts.Cluster_Diagnostic_Checks_Job_Not_Scheduled,
+                summary="Couldn't schedule Cluster Diagnostic Checks Job in the cluster",
+            )
+            logger.warning(
+                "Unable to schedule the Cluster Diagnostic Checks Job in the kubernetes cluster. The "
+                "possible reasons can be presence of a security policy or security context constraint "
+                "(SCC) or it may happen becuase of lack of ResourceQuota.\n"
+            )
+            logger.debug(
+                "Cluster diagnostic Job couldn't be scheduled.  Deleting the helm release in the cluster"
+            )
             Popen(cmd_helm_delete, stdout=PIPE, stderr=PIPE)
             return
 
-        if (is_job_scheduled is True and is_job_complete is False):
+        if is_job_scheduled is True and is_job_complete is False:
             # Job was scheduled successfully, but didn't complete. We will fetch the logs and delete helm release.
-            logger.debug("Cluster Diagnostic Checks Job Failed.  Fetch results and delete Helm release in the cluster")
+            logger.debug(
+                "Cluster Diagnostic Checks Job Failed.  Fetch results and delete Helm release in the cluster"
+            )
 
             # Fetching the cluster diagnostic checks Container logs
-            all_pods = corev1_api_instance.list_namespaced_pod('azure-arc-release')
+            all_pods = corev1_api_instance.list_namespaced_pod("azure-arc-release")
             # Traversing through all agents
             for each_pod in all_pods.items:
                 # Fetching the current Pod name and creating a folder with that name inside the timestamp folder
                 pod_name = each_pod.metadata.name
-                if (pod_name.startswith(job_name)):
+                if pod_name.startswith(job_name):
                     # Creating a text file with the name of the container and adding that containers logs in it
-                    cluster_diagnostic_checks_container_log = \
-                        corev1_api_instance.read_namespaced_pod_log(name=pod_name,
-                                                                    container="cluster-diagnostic-checks-container",
-                                                                    namespace='azure-arc-release')
+                    cluster_diagnostic_checks_container_log = (
+                        corev1_api_instance.read_namespaced_pod_log(
+                            name=pod_name,
+                            container="cluster-diagnostic-checks-container",
+                            namespace="azure-arc-release",
+                        )
+                    )
                     try:
                         if storage_space_available:
-                            dns_check_path = os.path.join(filepath_with_timestamp,
-                                                          "cluster_diagnostic_checks_job_log.txt")
-                            with open(dns_check_path, 'w+') as f:
+                            dns_check_path = os.path.join(
+                                filepath_with_timestamp,
+                                "cluster_diagnostic_checks_job_log.txt",
+                            )
+                            with open(dns_check_path, "w+") as f:
                                 f.write(cluster_diagnostic_checks_container_log)
                     except OSError as e:
                         if "[Errno 28]" in str(e):
                             storage_space_available = False
-                            telemetry.set_exception(exception=e,
-                                                    fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                                                    summary="No space left on device")
-                            shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
+                            telemetry.set_exception(
+                                exception=e,
+                                fault_type=consts.No_Storage_Space_Available_Fault_Type,
+                                summary="No space left on device",
+                            )
+                            shutil.rmtree(
+                                filepath_with_timestamp,
+                                ignore_errors=False,
+                                onerror=None,
+                            )
                         else:
-                            logger.warning("An exception has occured while saving the Cluster Diagnostic Checks Job "
-                                           "logs in the local machine. Exception: {}".format(str(e)) + "\n")
-                            telemetry.set_exception(exception=e,
-                                                    fault_type=consts.Cluster_Diagnostic_Checks_Job_Log_Save_Failed,
-                                                    summary="Error occured while saving the cluster diagnostic "
-                                                            "checks job logs in the local machine")
+                            logger.warning(
+                                "An exception has occured while saving the Cluster Diagnostic Checks Job "
+                                "logs in the local machine. Exception: {}".format(
+                                    str(e)
+                                )
+                                + "\n"
+                            )
+                            telemetry.set_exception(
+                                exception=e,
+                                fault_type=consts.Cluster_Diagnostic_Checks_Job_Log_Save_Failed,
+                                summary="Error occured while saving the cluster diagnostic "
+                                "checks job logs in the local machine",
+                            )
 
                     # To handle any exception that may occur during the execution
                     except Exception as e:
-                        logger.warning("An exception has occured while saving the Cluster Diagnostic Checks Job logs "
-                                       "in the local machine. Exception: {}".format(str(e)) + "\n")
-                        telemetry.set_exception(exception=e,
-                                                fault_type=consts.Cluster_Diagnostic_Checks_Job_Log_Save_Failed,
-                                                summary="Error occured while saving the cluster diagnostic checks "
-                                                        "job logs in the local machine")
+                        logger.warning(
+                            "An exception has occured while saving the Cluster Diagnostic Checks Job logs "
+                            "in the local machine. Exception: {}".format(str(e))
+                            + "\n"
+                        )
+                        telemetry.set_exception(
+                            exception=e,
+                            fault_type=consts.Cluster_Diagnostic_Checks_Job_Log_Save_Failed,
+                            summary="Error occured while saving the cluster diagnostic checks "
+                            "job logs in the local machine",
+                        )
 
             telemetry.set_exception(
                 exception="Couldn't complete Cluster Diagnostic Checks Job after scheduling in the cluster",
                 fault_type=consts.Cluster_Diagnostic_Checks_Job_Not_Complete,
-                summary="Couldn't complete Cluster Diagnostic Checks Job after scheduling in the cluster")
-            logger.warning("Cluster diagnostics job didn't reach completed state in the kubernetes cluster. The "
-                           "possible reasons can be resource constraints on the cluster.\n")
+                summary="Couldn't complete Cluster Diagnostic Checks Job after scheduling in the cluster",
+            )
+            logger.warning(
+                "Cluster diagnostics job didn't reach completed state in the kubernetes cluster. The "
+                "possible reasons can be resource constraints on the cluster.\n"
+            )
 
         # Clearing all the resources after fetching the cluster diagnostic checks container logs
         Popen(cmd_helm_delete, stdout=PIPE, stderr=PIPE)
@@ -276,17 +438,38 @@ def executing_cluster_diagnostic_checks_job(corev1_api_instance, batchv1_api_ins
     # To handle any exception that may occur during the execution
     except Exception as e:
         Popen(cmd_helm_delete, stdout=PIPE, stderr=PIPE)
-        raise CLIInternalError("Failed to execute Cluster Diagnostic Checks Job: {}".format(str(e)))
+        raise CLIInternalError(
+            "Failed to execute Cluster Diagnostic Checks Job: {}".format(str(e))
+        )
 
     return cluster_diagnostic_checks_container_log
 
 
-def helm_install_release_cluster_diagnostic_checks(chart_path, location, http_proxy, https_proxy, no_proxy, proxy_cert,
-                                                   azure_cloud, kube_config, kube_context, helm_client_location,
-                                                   onboarding_timeout="60"):
-    cmd_helm_install = [helm_client_location, "upgrade", "--install", "cluster-diagnostic-checks", chart_path,
-                        "--namespace", "{}".format(consts.Release_Install_Namespace), "--create-namespace",
-                        "--output", "json"]
+def helm_install_release_cluster_diagnostic_checks(
+    chart_path,
+    location,
+    http_proxy,
+    https_proxy,
+    no_proxy,
+    proxy_cert,
+    azure_cloud,
+    kube_config,
+    kube_context,
+    helm_client_location,
+    onboarding_timeout="60",
+):
+    cmd_helm_install = [
+        helm_client_location,
+        "upgrade",
+        "--install",
+        "cluster-diagnostic-checks",
+        chart_path,
+        "--namespace",
+        "{}".format(consts.Release_Install_Namespace),
+        "--create-namespace",
+        "--output",
+        "json",
+    ]
     # To set some other helm parameters through file
     cmd_helm_install.extend(["--set", "global.location={}".format(location)])
     cmd_helm_install.extend(["--set", "global.azureCloud={}".format(azure_cloud)])
@@ -297,7 +480,9 @@ def helm_install_release_cluster_diagnostic_checks(chart_path, location, http_pr
     if no_proxy:
         cmd_helm_install.extend(["--set", "global.noProxy={}".format(no_proxy)])
     if proxy_cert:
-        cmd_helm_install.extend(["--set-file", "global.proxyCert={}".format(proxy_cert)])
+        cmd_helm_install.extend(
+            ["--set-file", "global.proxyCert={}".format(proxy_cert)]
+        )
 
     if kube_config:
         cmd_helm_install.extend(["--kubeconfig", kube_config])
@@ -311,18 +496,24 @@ def helm_install_release_cluster_diagnostic_checks(chart_path, location, http_pr
     response_helm_install = Popen(cmd_helm_install, stdout=PIPE, stderr=PIPE)
     _, error_helm_install = response_helm_install.communicate()
     if response_helm_install.returncode != 0:
-        if ('forbidden' in error_helm_install.decode("ascii") or
-                'timed out waiting for the condition' in error_helm_install.decode("ascii")):
+        if "forbidden" in error_helm_install.decode(
+            "ascii"
+        ) or "timed out waiting for the condition" in error_helm_install.decode(
+            "ascii"
+        ):
             telemetry.set_user_fault()
-        telemetry.set_exception(exception=error_helm_install.decode("ascii"),
-                                fault_type=consts.Cluster_Diagnostic_Checks_Helm_Install_Failed_Fault_Type,
-                                summary='Unable to install cluster diagnostic checks helm release')
-        raise CLIInternalError("Unable to install cluster diagnostic checks helm release: "
-                               + error_helm_install.decode("ascii"))
+        telemetry.set_exception(
+            exception=error_helm_install.decode("ascii"),
+            fault_type=consts.Cluster_Diagnostic_Checks_Helm_Install_Failed_Fault_Type,
+            summary="Unable to install cluster diagnostic checks helm release",
+        )
+        raise CLIInternalError(
+            "Unable to install cluster diagnostic checks helm release: "
+            + error_helm_install.decode("ascii")
+        )
 
 
 def fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, flag):
-
     # This function is used to store the output that is obtained throughout the Diagnoser process
 
     global diagnoser_output
@@ -330,10 +521,12 @@ def fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, f
         # If storage space is available then only we store the output
         if storage_space_available:
             # Path to store the diagnoser results
-            cli_output_logger_path = os.path.join(filepath_with_timestamp, consts.Diagnoser_Results)
+            cli_output_logger_path = os.path.join(
+                filepath_with_timestamp, consts.Diagnoser_Results
+            )
             # If any results are obtained during the process than we will add it to the text file.
             if len(diagnoser_output) > 0:
-                with open(cli_output_logger_path, 'w+') as cli_output_writer:
+                with open(cli_output_logger_path, "w+") as cli_output_writer:
                     for output in diagnoser_output:
                         cli_output_writer.write(output + "\n")
                     # If flag is 0 that means that process was terminated using the Keyboard Interrupt so adding that
@@ -343,11 +536,13 @@ def fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, f
 
             # If no issues was found during the whole troubleshoot execution
             elif flag:
-                with open(cli_output_logger_path, 'w+') as cli_output_writer:
-                    cli_output_writer.write("The diagnoser didn't find any issues on the cluster.\n")
+                with open(cli_output_logger_path, "w+") as cli_output_writer:
+                    cli_output_writer.write(
+                        "The diagnoser didn't find any issues on the cluster.\n"
+                    )
             # If process was terminated by user
             else:
-                with open(cli_output_logger_path, 'w+') as cli_output_writer:
+                with open(cli_output_logger_path, "w+") as cli_output_writer:
                     cli_output_writer.write("Process terminated externally.\n")
 
         return consts.Diagnostic_Check_Passed
@@ -356,17 +551,24 @@ def fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, f
     except OSError as e:
         if "[Errno 28]" in str(e):
             storage_space_available = False
-            telemetry.set_exception(exception=e, fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                                    summary="No space left on device")
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.No_Storage_Space_Available_Fault_Type,
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to store the diagnoser results. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to store the diagnoser results. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Diagnoser_Result_Fault_Type,
-            summary="Error while storing the diagnoser results")
+            summary="Error while storing the diagnoser results",
+        )
 
     return consts.Diagnostic_Check_Failed

--- a/src/connectedk8s/azext_connectedk8s/_precheckutils.py
+++ b/src/connectedk8s/azext_connectedk8s/_precheckutils.py
@@ -5,48 +5,15 @@
 
 import os
 import shutil
-import subprocess
 from subprocess import Popen, PIPE
-import time
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-import json
-from kubernetes import client, config, watch, utils
-from knack.util import CLIError
+from kubernetes import config, watch
 from knack.log import get_logger
-from knack.prompting import NoTTYException, prompt_y_n
-from azure.cli.core.commands.client_factory import get_subscription_id
-from azure.cli.core.util import send_raw_request
 from azure.cli.core import telemetry
-from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
-from msrest.exceptions import AuthenticationError, HttpOperationError, TokenExpiredError
-from msrest.exceptions import ValidationError as MSRestValidationError
-from kubernetes.client.rest import ApiException
 import azext_connectedk8s._constants as consts
 import azext_connectedk8s._utils as azext_utils
-from kubernetes import client as kube_client
-from azure.cli.core import get_default_cli
 from azure.cli.core.azclierror import (
     CLIInternalError,
-    ClientRequestError,
-    ArgumentUsageError,
-    ManualInterrupt,
-    AzureResponseError,
-    AzureInternalError,
-    ValidationError,
 )
-from argparse import Namespace
-from pydoc import cli
-from logging import exception
-import yaml
-import json
-import datetime
-from subprocess import Popen, PIPE, run, STDOUT, call, DEVNULL
-import shutil
-from knack.log import get_logger
-from azure.cli.core import telemetry
-import azext_connectedk8s._constants as consts
 
 logger = get_logger(__name__)
 # pylint: disable=unused-argument, too-many-locals, too-many-branches, too-many-statements, line-too-long

--- a/src/connectedk8s/azext_connectedk8s/_troubleshootutils.py
+++ b/src/connectedk8s/azext_connectedk8s/_troubleshootutils.py
@@ -3,15 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from argparse import Namespace
-from pydoc import cli
 from kubernetes import client, config, watch, utils
-from logging import exception
 import os
 import yaml
 import json
 import datetime
-from subprocess import Popen, PIPE, run, STDOUT, call, DEVNULL
+from subprocess import Popen, PIPE
 import shutil
 from knack.log import get_logger
 from azure.cli.core import telemetry

--- a/src/connectedk8s/azext_connectedk8s/_troubleshootutils.py
+++ b/src/connectedk8s/azext_connectedk8s/_troubleshootutils.py
@@ -18,14 +18,20 @@ from azure.cli.core import telemetry
 import azext_connectedk8s._constants as consts
 import azext_connectedk8s._utils as azext_utils
 from azext_connectedk8s._utils import get_utctimestring
+
 logger = get_logger(__name__)
 # pylint: disable=unused-argument, too-many-locals, too-many-branches, too-many-statements, line-too-long
 
 diagnoser_output = []
 
 
-def fetch_kubectl_cluster_info(filepath_with_timestamp, storage_space_available,
-                               kubectl_client_location, kube_config, kube_context):
+def fetch_kubectl_cluster_info(
+    filepath_with_timestamp,
+    storage_space_available,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+):
     print("Step: {}: Capture cluster-info logs".format(get_utctimestring()))
     global diagnoser_output
     try:
@@ -38,19 +44,28 @@ def fetch_kubectl_cluster_info(filepath_with_timestamp, storage_space_available,
             if kube_context:
                 kubect_cluster_info_command.extend(["--context", kube_context])
             # Using Popen to execute the command and fetching the output
-            response_cluster_info = Popen(kubect_cluster_info_command, stdout=PIPE, stderr=PIPE)
-            output_cluster_info, error_cluster_info = response_cluster_info.communicate()
+            response_cluster_info = Popen(
+                kubect_cluster_info_command, stdout=PIPE, stderr=PIPE
+            )
+            output_cluster_info, error_cluster_info = (
+                response_cluster_info.communicate()
+            )
             if response_cluster_info.returncode != 0:
                 telemetry.set_exception(
                     exception=error_cluster_info.decode("ascii"),
                     fault_type=consts.Kubectl_Cluster_Info_Failed_Fault_Type,
-                    summary="Error while doing kubectl cluster-info")
-                logger.warning("Error while doing 'kubectl cluster-info'. We were not able to capture cluster-info "
-                               "logs in arc_diagnostic_logs folder. Exception: ",
-                               error_cluster_info.decode("ascii"))
-                diagnoser_output.append("Error while doing 'kubectl cluster-info'. We were not able to capture "
-                                        "cluster-info logs in arc_diganostic_logs folder. Exception: ",
-                                        error_cluster_info.decode("ascii"))
+                    summary="Error while doing kubectl cluster-info",
+                )
+                logger.warning(
+                    "Error while doing 'kubectl cluster-info'. We were not able to capture cluster-info "
+                    "logs in arc_diagnostic_logs folder. Exception: ",
+                    error_cluster_info.decode("ascii"),
+                )
+                diagnoser_output.append(
+                    "Error while doing 'kubectl cluster-info'. We were not able to capture "
+                    "cluster-info logs in arc_diganostic_logs folder. Exception: ",
+                    error_cluster_info.decode("ascii"),
+                )
                 return consts.Diagnostic_Check_Failed, storage_space_available
             output_cluster_info_decoded = output_cluster_info.decode()
             # Converting the output to list and remove the extra message(To further debug and diagnose cluster problems,
@@ -61,8 +76,10 @@ def fetch_kubectl_cluster_info(filepath_with_timestamp, storage_space_available,
             # Merging the list into string
             formatted_cluster_info = "\n".join(map(str, list_output_cluster_info))
             # Path to add the K8s cluster-info
-            cluster_info_path = os.path.join(filepath_with_timestamp, consts.K8s_Cluster_Info)
-            with open(cluster_info_path, 'w+') as cluster_info:
+            cluster_info_path = os.path.join(
+                filepath_with_timestamp, consts.K8s_Cluster_Info
+            )
+            with open(cluster_info_path, "w+") as cluster_info:
                 cluster_info.write(str(formatted_cluster_info) + "\n")
             return consts.Diagnostic_Check_Passed, storage_space_available
         else:
@@ -75,46 +92,67 @@ def fetch_kubectl_cluster_info(filepath_with_timestamp, storage_space_available,
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while trying to store the cluster info in the "
-                           "arc_diagnostic_logs folder. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to store the cluster info in the "
+                "arc_diagnostic_logs folder. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Kubectl_Cluster_Info_Fault_Type,
-                summary="Error occured while fetching cluster-info")
-            diagnoser_output.append("An exception has occured while trying to store the cluster info in the "
-                                    "arc_diagnostic_logs folder. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured while fetching cluster-info",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to store the cluster info in the "
+                "arc_diagnostic_logs folder. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to store the cluster info in the "
-                       "arc_diagnostic_logs folder. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to store the cluster info in the "
+            "arc_diagnostic_logs folder. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Kubectl_Cluster_Info_Fault_Type,
-            summary="Error occured while fetching cluster-info")
-        diagnoser_output.append("An exception has occured while trying to store the cluster info in the "
-                                "arc_diagnostic_logs folder. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured while fetching cluster-info",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to store the cluster info in the "
+            "arc_diagnostic_logs folder. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Failed, storage_space_available
 
 
-def fetch_connected_cluster_resource(filepath_with_timestamp, connected_cluster, storage_space_available):
+def fetch_connected_cluster_resource(
+    filepath_with_timestamp, connected_cluster, storage_space_available
+):
     print("Step: {}: Fetch connected cluster resource".format(get_utctimestring()))
     global diagnoser_output
     try:
         # Path to add the connected_cluster resource
-        connected_cluster_resource_file_path = os.path.join(filepath_with_timestamp, consts.Connected_Cluster_Resource)
+        connected_cluster_resource_file_path = os.path.join(
+            filepath_with_timestamp, consts.Connected_Cluster_Resource
+        )
         # Formatting the last_connectivity_time and managed_identity_certificate_expiration_time into
         #  proper data-time format
         last_connectivity_time_str = str(connected_cluster.last_connectivity_time)
         connected_cluster.last_connectivity_time = last_connectivity_time_str
-        managed_identity_certificate_expiration_time_str = \
-            str(connected_cluster.managed_identity_certificate_expiration_time)
-        connected_cluster.managed_identity_certificate_expiration_time = \
+        managed_identity_certificate_expiration_time_str = str(
+            connected_cluster.managed_identity_certificate_expiration_time
+        )
+        connected_cluster.managed_identity_certificate_expiration_time = (
             managed_identity_certificate_expiration_time_str
+        )
 
         # Formatting system_data
         created_at = str(connected_cluster.system_data.created_at)
@@ -129,7 +167,7 @@ def fetch_connected_cluster_resource(filepath_with_timestamp, connected_cluster,
 
         if storage_space_available:
             # If storage space is available then only store the connected cluster resource
-            with open(connected_cluster_resource_file_path, 'w+') as cc:
+            with open(connected_cluster_resource_file_path, "w+") as cc:
                 cc.write(str(connected_cluster))
         return consts.Diagnostic_Check_Passed, storage_space_available
 
@@ -140,44 +178,67 @@ def fetch_connected_cluster_resource(filepath_with_timestamp, connected_cluster,
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while trying to store the get output of connected cluster "
-                           "resource in diagnostic logs folder. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to store the get output of connected cluster "
+                "resource in diagnostic logs folder. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Connected_Cluster_Resource_Fetch_Fault_Type,
-                summary="Error occured while fetching the Get output of connected cluster")
-            diagnoser_output.append("An exception has occured while trying to store the get output of connected "
-                                    "cluster resource in diagnostic logs folder. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured while fetching the Get output of connected cluster",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to store the get output of connected "
+                "cluster resource in diagnostic logs folder. Exception: {}".format(
+                    str(e)
+                )
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to store the get output of connected cluster resource "
-                       "in diagnostic logs folder. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to store the get output of connected cluster resource "
+            "in diagnostic logs folder. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Connected_Cluster_Resource_Fetch_Fault_Type,
-            summary="Error occured while fetching the Get output of connected cluster")
-        diagnoser_output.append("An exception has occured while trying to store the get output of connected cluster "
-                                "resource in diagnostic logs folder. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured while fetching the Get output of connected cluster",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to store the get output of connected cluster "
+            "resource in diagnostic logs folder. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Failed, storage_space_available
 
 
-def retrieve_arc_agents_logs(corev1_api_instance, filepath_with_timestamp, storage_space_available):
+def retrieve_arc_agents_logs(
+    corev1_api_instance, filepath_with_timestamp, storage_space_available
+):
     print("Step: {}: Retrieve arc agents logs".format(get_utctimestring()))
     global diagnoser_output
     try:
         if storage_space_available:
             # To retrieve all of the arc agents pods that are present in the Cluster
-            arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(namespace="azure-arc")
+            arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(
+                namespace="azure-arc"
+            )
             # Traversing through all agents
             for each_agent_pod in arc_agents_pod_list.items:
                 # Fetching the current Pod name and creating a folder with that name inside the timestamp folder
                 agent_name = each_agent_pod.metadata.name
-                arc_agent_logs_path = os.path.join(filepath_with_timestamp, consts.Arc_Agents_Logs)
+                arc_agent_logs_path = os.path.join(
+                    filepath_with_timestamp, consts.Arc_Agents_Logs
+                )
                 try:
                     os.mkdir(arc_agent_logs_path)
                 except FileExistsError:
@@ -188,7 +249,7 @@ def retrieve_arc_agents_logs(corev1_api_instance, filepath_with_timestamp, stora
                 except FileExistsError:
                     pass
                 # If the agent is not in Running state we wont be able to get logs of the containers
-                if (each_agent_pod.status.phase != "Running"):
+                if each_agent_pod.status.phase != "Running":
                     continue
                 # Traversing through all of the containers present inside each pods
                 for each_container in each_agent_pod.spec.containers:
@@ -196,12 +257,13 @@ def retrieve_arc_agents_logs(corev1_api_instance, filepath_with_timestamp, stora
                     container_name = each_container.name
                     # Creating a text file with the name of the container and adding that containers logs in it
                     container_log = corev1_api_instance.read_namespaced_pod_log(
-                        name=agent_name,
-                        container=container_name,
-                        namespace="azure-arc")
+                        name=agent_name, container=container_name, namespace="azure-arc"
+                    )
                     # Path to add the arc agents container logs.
-                    arc_agent_container_logs_path = os.path.join(agent_name_logs_path, container_name + ".txt")
-                    with open(arc_agent_container_logs_path, 'w+') as container_file:
+                    arc_agent_container_logs_path = os.path.join(
+                        agent_name_logs_path, container_name + ".txt"
+                    )
+                    with open(arc_agent_container_logs_path, "w+") as container_file:
                         container_file.write(str(container_log))
 
         return consts.Diagnostic_Check_Passed, storage_space_available
@@ -213,67 +275,104 @@ def retrieve_arc_agents_logs(corev1_api_instance, filepath_with_timestamp, stora
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while trying to fetch the azure arc agents logs from the "
-                           "cluster. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to fetch the azure arc agents logs from the "
+                "cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Arc_Agent_Logs_Failed_Fault_Type,
-                summary="Error occured in arc agents logger")
-            diagnoser_output.append("An exception has occured while trying to fetch the azure arc agents logs from "
-                                    "the cluster. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured in arc agents logger",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to fetch the azure arc agents logs from "
+                "the cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to fetch the azure arc agents logs from the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to fetch the azure arc agents logs from the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Arc_Agent_Logs_Failed_Fault_Type,
-            summary="Error occured in arc agents logger")
-        diagnoser_output.append("An exception has occured while trying to fetch the azure arc agents logs from the "
-                                "cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured in arc agents logger",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to fetch the azure arc agents logs from the "
+            "cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Failed, storage_space_available
 
 
-def retrieve_arc_agents_event_logs(filepath_with_timestamp, storage_space_available,
-                                   kubectl_client_location, kube_config, kube_context):
+def retrieve_arc_agents_event_logs(
+    filepath_with_timestamp,
+    storage_space_available,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+):
     print("Step: {}: Retrieve arc agents event logs".format(get_utctimestring()))
     global diagnoser_output
     try:
         # If storage space available then only store the azure-arc events
         if storage_space_available:
             # CMD command to get events using kubectl and converting it to json format
-            command = [kubectl_client_location, "get", "events", "-n", "azure-arc", "--output", "json"]
+            command = [
+                kubectl_client_location,
+                "get",
+                "events",
+                "-n",
+                "azure-arc",
+                "--output",
+                "json",
+            ]
             if kube_config:
                 command.extend(["--kubeconfig", kube_config])
             if kube_context:
                 command.extend(["--context", kube_context])
             # Using Popen to execute the command and fetching the output
             response_kubectl_get_events = Popen(command, stdout=PIPE, stderr=PIPE)
-            output_kubectl_get_events, error_kubectl_get_events = response_kubectl_get_events.communicate()
+            output_kubectl_get_events, error_kubectl_get_events = (
+                response_kubectl_get_events.communicate()
+            )
             if response_kubectl_get_events.returncode != 0:
                 telemetry.set_exception(
                     exception=error_kubectl_get_events.decode("ascii"),
                     fault_type=consts.Kubectl_Get_Events_Failed_Fault_Type,
-                    summary='Error while doing kubectl get events')
-                logger.warning("Error while doing kubectl get events. We were not able to capture events log in "
-                               "arc_diganostic_logs folder. Exception: ",
-                               error_kubectl_get_events.decode("ascii"))
-                diagnoser_output.append("Error while doing kubectl get events. We were not able to capture events "
-                                        "log in arc_diganostic_logs folder. Exception: ",
-                                        error_kubectl_get_events.decode("ascii"))
+                    summary="Error while doing kubectl get events",
+                )
+                logger.warning(
+                    "Error while doing kubectl get events. We were not able to capture events log in "
+                    "arc_diganostic_logs folder. Exception: ",
+                    error_kubectl_get_events.decode("ascii"),
+                )
+                diagnoser_output.append(
+                    "Error while doing kubectl get events. We were not able to capture events "
+                    "log in arc_diganostic_logs folder. Exception: ",
+                    error_kubectl_get_events.decode("ascii"),
+                )
                 return consts.Diagnostic_Check_Failed, storage_space_available
 
             # Converting output obtained in json format and fetching the azure-arc events
             events_json = json.loads(output_kubectl_get_events)
             # Path to add the azure-arc events
-            event_logs_path = os.path.join(filepath_with_timestamp, consts.Arc_Agents_Events)
+            event_logs_path = os.path.join(
+                filepath_with_timestamp, consts.Arc_Agents_Events
+            )
             if len(events_json["items"]) != 0:
-                with open(event_logs_path, 'w+') as event_log:
+                with open(event_logs_path, "w+") as event_log:
                     # Adding all the individual events
                     for events in events_json["items"]:
                         event_log.write(str(events) + "\n")
@@ -288,52 +387,75 @@ def retrieve_arc_agents_event_logs(filepath_with_timestamp, storage_space_availa
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while trying to fetch the events occured in azure-arc namespace "
-                           "from the cluster. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to fetch the events occured in azure-arc namespace "
+                "from the cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Arc_Agents_Events_Logs_Failed_Fault_Type,
-                summary="Error occured in arc agents events logger")
-            diagnoser_output.append("An exception has occured while trying to fetch the events occured in "
-                                    "azure-arc namespace from the cluster. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured in arc agents events logger",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to fetch the events occured in "
+                "azure-arc namespace from the cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to fetch the events occured in azure-arc namespace "
-                       "from the cluster. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to fetch the events occured in azure-arc namespace "
+            "from the cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Arc_Agents_Events_Logs_Failed_Fault_Type,
-            summary="Error occured in arc agents events logger")
-        diagnoser_output.append("An exception has occured while trying to fetch the events occured in "
-                                "azure-arc namespace from the cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured in arc agents events logger",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to fetch the events occured in "
+            "azure-arc namespace from the cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Failed, storage_space_available
 
 
-def retrieve_deployments_logs(appv1_api_instance, filepath_with_timestamp, storage_space_available):
+def retrieve_deployments_logs(
+    appv1_api_instance, filepath_with_timestamp, storage_space_available
+):
     print("Step: {}: Retrieve deployments logs".format(get_utctimestring()))
     global diagnoser_output
     try:
         if storage_space_available:
             # Creating new Deployment Logs folder in the given timestamp folder
-            deployments_path = os.path.join(filepath_with_timestamp, consts.Arc_Deployment_Logs)
+            deployments_path = os.path.join(
+                filepath_with_timestamp, consts.Arc_Deployment_Logs
+            )
             try:
                 os.mkdir(deployments_path)
             except FileExistsError:
                 pass
             # To retrieve all the deployment that are present in the Cluster
-            deployments_list = appv1_api_instance.list_namespaced_deployment("azure-arc")
+            deployments_list = appv1_api_instance.list_namespaced_deployment(
+                "azure-arc"
+            )
             # Traversing through all the deployments present
             for deployment in deployments_list.items:
                 # Fetching the deployment name
                 deployment_name = deployment.metadata.name
-                arc_deployment_logs_path = os.path.join(deployments_path, deployment_name + ".txt")
+                arc_deployment_logs_path = os.path.join(
+                    deployments_path, deployment_name + ".txt"
+                )
                 # Creating a text file with the name of the deployment and adding deployment status in it
-                with open(arc_deployment_logs_path, 'w+') as deployment_file:
+                with open(arc_deployment_logs_path, "w+") as deployment_file:
                     deployment_file.write(str(deployment.status))
 
         return consts.Diagnostic_Check_Passed, storage_space_available
@@ -345,54 +467,82 @@ def retrieve_deployments_logs(appv1_api_instance, filepath_with_timestamp, stora
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while trying to fetch the azure arc deployment logs from the "
-                           "cluster. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to fetch the azure arc deployment logs from the "
+                "cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Arc_Deployment_Logs_Failed_Fault_Type,
-                summary="Error occured in deployments logger")
-            diagnoser_output.append("An exception has occured while trying to fetch the azure arc deployment logs "
-                                    "from the cluster. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured in deployments logger",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to fetch the azure arc deployment logs "
+                "from the cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to fetch the azure arc deployment logs from the "
-                       "cluster. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to fetch the azure arc deployment logs from the "
+            "cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Arc_Deployment_Logs_Failed_Fault_Type,
-            summary="Error occured in deployments logger")
-        diagnoser_output.append("An exception has occured while trying to fetch the azure arc deployment logs from "
-                                "the cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured in deployments logger",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to fetch the azure arc deployment logs from "
+            "the cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Failed, storage_space_available
 
-def retrieve_arc_workload_identity_pod_logs(corev1_api_instance, filepath_with_timestamp, storage_space_available):
-    print("Step: {}: Retrieve arc-workload-identity pod logs".format(get_utctimestring()))
+
+def retrieve_arc_workload_identity_pod_logs(
+    corev1_api_instance, filepath_with_timestamp, storage_space_available
+):
+    print(
+        "Step: {}: Retrieve arc-workload-identity pod logs".format(get_utctimestring())
+    )
     global diagnoser_output
     try:
         if storage_space_available:
             # To retrieve all of the arc agents pods that are present in the Cluster
-            arc_workload_identity_pod_list = corev1_api_instance.list_namespaced_pod(namespace="arc-workload-identity")
+            arc_workload_identity_pod_list = corev1_api_instance.list_namespaced_pod(
+                namespace="arc-workload-identity"
+            )
             # Traversing through all agents
-            for each_workload_identity_agent_pod in arc_workload_identity_pod_list.items:
+            for (
+                each_workload_identity_agent_pod
+            ) in arc_workload_identity_pod_list.items:
                 # Fetching the current Pod name and creating a folder with that name inside the timestamp folder
                 agent_name = each_workload_identity_agent_pod.metadata.name
-                arc_workload_identity_logs_path = os.path.join(filepath_with_timestamp, consts.Arc_Workload_Identity_Pod_Logs)
+                arc_workload_identity_logs_path = os.path.join(
+                    filepath_with_timestamp, consts.Arc_Workload_Identity_Pod_Logs
+                )
                 try:
                     os.mkdir(arc_workload_identity_logs_path)
                 except FileExistsError:
                     pass
-                agent_name_logs_path = os.path.join(arc_workload_identity_logs_path, agent_name)
+                agent_name_logs_path = os.path.join(
+                    arc_workload_identity_logs_path, agent_name
+                )
                 try:
                     os.mkdir(agent_name_logs_path)
                 except FileExistsError:
                     pass
                 # If the agent is not in Running state we wont be able to get logs of the containers
-                if (each_workload_identity_agent_pod.status.phase != "Running"):
+                if each_workload_identity_agent_pod.status.phase != "Running":
                     continue
                 # Traversing through all of the containers present inside each pods
                 for each_container in each_workload_identity_agent_pod.spec.containers:
@@ -402,10 +552,15 @@ def retrieve_arc_workload_identity_pod_logs(corev1_api_instance, filepath_with_t
                     container_log = corev1_api_instance.read_namespaced_pod_log(
                         name=agent_name,
                         container=container_name,
-                        namespace="arc-workload-identity")
+                        namespace="arc-workload-identity",
+                    )
                     # Path to add the arc agents container logs.
-                    arc_workload_identity_container_logs_path = os.path.join(agent_name_logs_path, container_name + ".txt")
-                    with open(arc_workload_identity_container_logs_path, 'w+') as container_file:
+                    arc_workload_identity_container_logs_path = os.path.join(
+                        agent_name_logs_path, container_name + ".txt"
+                    )
+                    with open(
+                        arc_workload_identity_container_logs_path, "w+"
+                    ) as container_file:
                         container_file.write(str(container_log))
 
         return consts.Diagnostic_Check_Passed, storage_space_available
@@ -417,66 +572,104 @@ def retrieve_arc_workload_identity_pod_logs(corev1_api_instance, filepath_with_t
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while trying to fetch the azure arc agents logs from the "
-                           "cluster. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to fetch the azure arc agents logs from the "
+                "cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Arc_Workload_Identity_Pod_Logs_Failed_Fault_Type,
-                summary="Error occured in arc agents logger")
-            diagnoser_output.append("An exception has occured while trying to fetch the azure arc agents logs from "
-                                    "the cluster. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured in arc agents logger",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to fetch the azure arc agents logs from "
+                "the cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to fetch the azure arc agents logs from the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to fetch the azure arc agents logs from the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Arc_Workload_Identity_Pod_Logs_Failed_Fault_Type,
-            summary="Error occured in arc agents logger")
-        diagnoser_output.append("An exception has occured while trying to fetch the azure arc agents logs from the "
-                                "cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured in arc agents logger",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to fetch the azure arc agents logs from the "
+            "cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Failed, storage_space_available
 
-def retrieve_arc_workload_identity_event_logs(filepath_with_timestamp, storage_space_available,
-                                   kubectl_client_location, kube_config, kube_context):
+
+def retrieve_arc_workload_identity_event_logs(
+    filepath_with_timestamp,
+    storage_space_available,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+):
     print("Step: {}: Retrieve arc agents event logs".format(get_utctimestring()))
     global diagnoser_output
     try:
         # If storage space available then only store the azure-arc events
         if storage_space_available:
             # CMD command to get events using kubectl and converting it to json format
-            command = [kubectl_client_location, "get", "events", "-n", "arc-workload-identity", "--output", "json"]
+            command = [
+                kubectl_client_location,
+                "get",
+                "events",
+                "-n",
+                "arc-workload-identity",
+                "--output",
+                "json",
+            ]
             if kube_config:
                 command.extend(["--kubeconfig", kube_config])
             if kube_context:
                 command.extend(["--context", kube_context])
             # Using Popen to execute the command and fetching the output
             response_kubectl_get_events = Popen(command, stdout=PIPE, stderr=PIPE)
-            output_kubectl_get_events, error_kubectl_get_events = response_kubectl_get_events.communicate()
+            output_kubectl_get_events, error_kubectl_get_events = (
+                response_kubectl_get_events.communicate()
+            )
             if response_kubectl_get_events.returncode != 0:
                 telemetry.set_exception(
                     exception=error_kubectl_get_events.decode("ascii"),
                     fault_type=consts.Kubectl_Get_Events_Failed_Fault_Type,
-                    summary='Error while doing kubectl get events for arc-workload-identity namespace')
-                logger.warning("Error while doing kubectl get events for arc-workload-identity namespace. "
-                               "We were not able to capture events log in arc_diganostic_logs folder. Exception: ",
-                               error_kubectl_get_events.decode("ascii"))
-                diagnoser_output.append("Error while doing kubectl get events for arc-workload-identity namespace. "
-                                        "We were not able to capture events log in arc_diganostic_logs folder. Exception: ",
-                                        error_kubectl_get_events.decode("ascii"))
+                    summary="Error while doing kubectl get events for arc-workload-identity namespace",
+                )
+                logger.warning(
+                    "Error while doing kubectl get events for arc-workload-identity namespace. "
+                    "We were not able to capture events log in arc_diganostic_logs folder. Exception: ",
+                    error_kubectl_get_events.decode("ascii"),
+                )
+                diagnoser_output.append(
+                    "Error while doing kubectl get events for arc-workload-identity namespace. "
+                    "We were not able to capture events log in arc_diganostic_logs folder. Exception: ",
+                    error_kubectl_get_events.decode("ascii"),
+                )
                 return consts.Diagnostic_Check_Failed, storage_space_available
 
             # Converting output obtained in json format and fetching the arc-workload-identity events
             events_json = json.loads(output_kubectl_get_events)
             # Path to add the azure-arc events
-            event_logs_path = os.path.join(filepath_with_timestamp, consts.Arc_Workload_Identity_Events)
+            event_logs_path = os.path.join(
+                filepath_with_timestamp, consts.Arc_Workload_Identity_Events
+            )
             if len(events_json["items"]) != 0:
-                with open(event_logs_path, 'w+') as event_log:
+                with open(event_logs_path, "w+") as event_log:
                     # Adding all the individual events
                     for events in events_json["items"]:
                         event_log.write(str(events) + "\n")
@@ -491,52 +684,85 @@ def retrieve_arc_workload_identity_event_logs(filepath_with_timestamp, storage_s
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while trying to fetch the events occured in arc-workload-identity namespace "
-                           "from the cluster. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to fetch the events occured in arc-workload-identity namespace "
+                "from the cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Arc_Workload_Identity_Events_Logs_Failed_Fault_Type,
-                summary="Error occured in arc agents events logger")
-            diagnoser_output.append("An exception has occured while trying to fetch the events occured in "
-                                    "arc-workload-identity namespace from the cluster. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured in arc agents events logger",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to fetch the events occured in "
+                "arc-workload-identity namespace from the cluster. Exception: {}".format(
+                    str(e)
+                )
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to fetch the events occured in arc-workload-identity namespace "
-                       "from the cluster. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to fetch the events occured in arc-workload-identity namespace "
+            "from the cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Arc_Workload_Identity_Events_Logs_Failed_Fault_Type,
-            summary="Error occured in arc agents events logger")
-        diagnoser_output.append("An exception has occured while trying to fetch the events occured in "
-                                "arc-workload-identity namespace from the cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured in arc agents events logger",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to fetch the events occured in "
+            "arc-workload-identity namespace from the cluster. Exception: {}".format(
+                str(e)
+            )
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Failed, storage_space_available
 
 
-def retrieve_arc_workload_identity_deployments_logs(appv1_api_instance, filepath_with_timestamp, storage_space_available):
-    print("Step: {}: Retrieve arc-workload-identity deployments logs".format(get_utctimestring()))
+def retrieve_arc_workload_identity_deployments_logs(
+    appv1_api_instance, filepath_with_timestamp, storage_space_available
+):
+    print(
+        "Step: {}: Retrieve arc-workload-identity deployments logs".format(
+            get_utctimestring()
+        )
+    )
     global diagnoser_output
     try:
         if storage_space_available:
             # Creating new Deployment Logs folder in the given timestamp folder
-            deployments_path = os.path.join(filepath_with_timestamp, consts.Arc_Workload_Identity_Deployment_Logs)
+            deployments_path = os.path.join(
+                filepath_with_timestamp, consts.Arc_Workload_Identity_Deployment_Logs
+            )
             try:
                 os.mkdir(deployments_path)
             except FileExistsError:
                 pass
             # To retrieve all the deployment that are present in the Cluster
-            deployments_list = appv1_api_instance.list_namespaced_deployment("arc-workload-identity")
+            deployments_list = appv1_api_instance.list_namespaced_deployment(
+                "arc-workload-identity"
+            )
             # Traversing through all the deployments present
             for deployment in deployments_list.items:
                 # Fetching the deployment name
                 deployment_name = deployment.metadata.name
-                arc_workload_identity_deployment_logs_path = os.path.join(deployments_path, deployment_name + ".txt")
+                arc_workload_identity_deployment_logs_path = os.path.join(
+                    deployments_path, deployment_name + ".txt"
+                )
                 # Creating a text file with the name of the deployment and adding deployment status in it
-                with open(arc_workload_identity_deployment_logs_path, 'w+') as deployment_file:
+                with open(
+                    arc_workload_identity_deployment_logs_path, "w+"
+                ) as deployment_file:
                     deployment_file.write(str(deployment.status))
 
         return consts.Diagnostic_Check_Passed, storage_space_available
@@ -548,32 +774,50 @@ def retrieve_arc_workload_identity_deployments_logs(appv1_api_instance, filepath
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while trying to fetch the arc-workload-identity deployment logs from the "
-                           "cluster. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to fetch the arc-workload-identity deployment logs from the "
+                "cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Arc_Workload_Identity_Deployment_Logs_Failed_Fault_Type,
-                summary="Error occured in deployments logger")
-            diagnoser_output.append("An exception has occured while trying to fetch the arc-workload-identity deployment logs "
-                                    "from the cluster. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured in deployments logger",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to fetch the arc-workload-identity deployment logs "
+                "from the cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to fetch the arc-workload-identity deployment logs from the "
-                       "cluster. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to fetch the arc-workload-identity deployment logs from the "
+            "cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Arc_Workload_Identity_Deployment_Logs_Failed_Fault_Type,
-            summary="Error occured in deployments logger")
-        diagnoser_output.append("An exception has occured while trying to fetch the arc-workload-identity deployment logs from "
-                                "the cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured in deployments logger",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to fetch the arc-workload-identity deployment logs from "
+            "the cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Failed, storage_space_available
 
-def check_agent_state(corev1_api_instance, filepath_with_timestamp, storage_space_available):
+
+def check_agent_state(
+    corev1_api_instance, filepath_with_timestamp, storage_space_available
+):
     print("Step: {}: Check agent state".format(get_utctimestring()))
     global diagnoser_output
     # If all agents are stuck we will skip the certificates check
@@ -587,16 +831,22 @@ def check_agent_state(corev1_api_instance, filepath_with_timestamp, storage_spac
         agent_state_path = os.path.join(filepath_with_timestamp, consts.Agent_State)
         # If storage space available then only we will be writing into the file
         if storage_space_available:
-            with open(agent_state_path, 'w+') as agent_state:
+            with open(agent_state_path, "w+") as agent_state:
                 # To retrieve all of the arc agent pods that are present in the Cluster
-                arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(namespace="azure-arc")
+                arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(
+                    namespace="azure-arc"
+                )
                 # Check if any arc agent is not in Running state
                 for each_agent_pod in arc_agents_pod_list.items:
                     if storage_space_available:
                         # Storing the state of the arc agent in the user machine
-                        agent_state.write(each_agent_pod.metadata.name + " : Phase = " +
-                                          each_agent_pod.status.phase + "\n")
-                    if each_agent_pod.status.phase == 'Running':
+                        agent_state.write(
+                            each_agent_pod.metadata.name
+                            + " : Phase = "
+                            + each_agent_pod.status.phase
+                            + "\n"
+                        )
+                    if each_agent_pod.status.phase == "Running":
                         all_agents_stuck = False
                     if each_agent_pod.status.container_statuses is None:
                         probable_sufficient_resource_for_agents = False
@@ -604,46 +854,70 @@ def check_agent_state(corev1_api_instance, filepath_with_timestamp, storage_spac
                             # Adding empty line after each agents for formatting
                             agent_state.write("\n")
                         storage_space_available = describe_non_ready_agent_log(
-                            filepath_with_timestamp, corev1_api_instance, each_agent_pod.metadata.name,
-                            storage_space_available)
+                            filepath_with_timestamp,
+                            corev1_api_instance,
+                            each_agent_pod.metadata.name,
+                            storage_space_available,
+                        )
                     else:
                         all_containers_ready_for_each_agent = True
                         # If the agent is in running state we will check if all containers are running or not
-                        for each_container_status in each_agent_pod.status.container_statuses:
+                        for (
+                            each_container_status
+                        ) in each_agent_pod.status.container_statuses:
                             # Checking if all containers are running or not
                             if each_container_status.ready is False:
                                 all_containers_ready_for_each_agent = False
                                 all_agent_containers_ready = False
                                 try:
                                     # Adding the reason for container to be not in ready state
-                                    container_not_ready_reason = each_container_status.state.waiting.reason
+                                    container_not_ready_reason = (
+                                        each_container_status.state.waiting.reason
+                                    )
                                 except Exception:
                                     container_not_ready_reason = None
                                 # Adding the reason if continer is not in ready state
                                 if container_not_ready_reason is not None:
                                     if storage_space_available:
                                         agent_state.write(
-                                            "\t" + each_container_status.name + " :" " Ready = False {Reason : " +
-                                            str(container_not_ready_reason) + "} , Restart_Counts = " +
-                                            str(each_container_status.restart_count) + "\n")
+                                            "\t" + each_container_status.name + " :"
+                                            " Ready = False {Reason : "
+                                            + str(container_not_ready_reason)
+                                            + "} , Restart_Counts = "
+                                            + str(each_container_status.restart_count)
+                                            + "\n"
+                                        )
                                 else:
                                     if storage_space_available:
                                         agent_state.write(
-                                            "\t" + each_container_status.name + " :" + " Ready = " +
-                                            str(each_container_status.ready) + ", Restart_Counts = " +
-                                            str(each_container_status.restart_count) + "\n")
+                                            "\t"
+                                            + each_container_status.name
+                                            + " :"
+                                            + " Ready = "
+                                            + str(each_container_status.ready)
+                                            + ", Restart_Counts = "
+                                            + str(each_container_status.restart_count)
+                                            + "\n"
+                                        )
                             else:
                                 if storage_space_available:
                                     agent_state.write(
-                                        "\t" + each_container_status.name + " :" + " Ready = " +
-                                        str(each_container_status.ready) + ", Restart_Counts = " +
-                                        str(each_container_status.restart_count) + "\n")
+                                        "\t"
+                                        + each_container_status.name
+                                        + " :"
+                                        + " Ready = "
+                                        + str(each_container_status.ready)
+                                        + ", Restart_Counts = "
+                                        + str(each_container_status.restart_count)
+                                        + "\n"
+                                    )
                             if all_containers_ready_for_each_agent is False:
                                 storage_space_available = describe_non_ready_agent_log(
                                     filepath_with_timestamp,
                                     corev1_api_instance,
                                     each_agent_pod.metadata.name,
-                                    storage_space_available)
+                                    storage_space_available,
+                                )
 
                         if storage_space_available:
                             # Adding empty line after each agents for formatting
@@ -651,10 +925,12 @@ def check_agent_state(corev1_api_instance, filepath_with_timestamp, storage_spac
         # If storage space not available then we will be just checking if all agents are running properly or not
         else:
             # To retrieve all of the arc agent pods that are present in the Cluster
-            arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(namespace="azure-arc")
+            arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(
+                namespace="azure-arc"
+            )
             # Check if any arc agent is not in Running state
             for each_agent_pod in arc_agents_pod_list.items:
-                if each_agent_pod.status.phase == 'Running':
+                if each_agent_pod.status.phase == "Running":
                     all_agents_stuck = False
                 # If container statuses is not present then thats very high chance of less resource availability
                 if each_agent_pod.status.container_statuses is None:
@@ -663,18 +939,23 @@ def check_agent_state(corev1_api_instance, filepath_with_timestamp, storage_spac
                         filepath_with_timestamp,
                         corev1_api_instance,
                         each_agent_pod.metadata.name,
-                        storage_space_available)
+                        storage_space_available,
+                    )
                 else:
                     all_containers_ready_for_each_agent = True
                     # If the agent is in running state we will check if all containers are running or not
-                    for each_container_status in each_agent_pod.status.container_statuses:
+                    for (
+                        each_container_status
+                    ) in each_agent_pod.status.container_statuses:
                         # Checking if all containers are running or not
                         if each_container_status.ready is False:
                             all_containers_ready_for_each_agent = False
                             all_agent_containers_ready = False
                             try:
                                 # Adding the reason for container to be not in ready state
-                                container_not_ready_reason = each_container_status.state.waiting.reason
+                                container_not_ready_reason = (
+                                    each_container_status.state.waiting.reason
+                                )
                             except Exception:
                                 container_not_ready_reason = None
                             # Adding the reason if continer is not in ready state
@@ -683,25 +964,46 @@ def check_agent_state(corev1_api_instance, filepath_with_timestamp, storage_spac
                                 filepath_with_timestamp,
                                 corev1_api_instance,
                                 each_agent_pod.metadata.name,
-                                storage_space_available)
+                                storage_space_available,
+                            )
 
         # Displaying error if the arc agents are in pending state.
         if probable_sufficient_resource_for_agents is False:
-            logger.warning("Error: One or more Azure Arc agents are not in running state. It may be caused due to "
-                           "insufficient resource availability on the cluster.\n")
-            diagnoser_output.append("Error: One or more Azure Arc agents are not in running state. It may be caused "
-                                    "due to insufficient resource availability on the cluster.\n")
-            return consts.Diagnostic_Check_Failed, storage_space_available, all_agents_stuck, \
-                probable_sufficient_resource_for_agents
+            logger.warning(
+                "Error: One or more Azure Arc agents are not in running state. It may be caused due to "
+                "insufficient resource availability on the cluster.\n"
+            )
+            diagnoser_output.append(
+                "Error: One or more Azure Arc agents are not in running state. It may be caused "
+                "due to insufficient resource availability on the cluster.\n"
+            )
+            return (
+                consts.Diagnostic_Check_Failed,
+                storage_space_available,
+                all_agents_stuck,
+                probable_sufficient_resource_for_agents,
+            )
 
         elif all_agent_containers_ready is False:
-            logger.warning("Error: One or more agents in the Azure Arc are not fully running.\n")
-            diagnoser_output.append("Error: One or more agents in the Azure Arc are not fully runnning.\n")
-            return consts.Diagnostic_Check_Failed, storage_space_available, all_agents_stuck, \
-                probable_sufficient_resource_for_agents
+            logger.warning(
+                "Error: One or more agents in the Azure Arc are not fully running.\n"
+            )
+            diagnoser_output.append(
+                "Error: One or more agents in the Azure Arc are not fully runnning.\n"
+            )
+            return (
+                consts.Diagnostic_Check_Failed,
+                storage_space_available,
+                all_agents_stuck,
+                probable_sufficient_resource_for_agents,
+            )
 
-        return consts.Diagnostic_Check_Passed, storage_space_available, all_agents_stuck, \
-            probable_sufficient_resource_for_agents
+        return (
+            consts.Diagnostic_Check_Passed,
+            storage_space_available,
+            all_agents_stuck,
+            probable_sufficient_resource_for_agents,
+        )
 
     # For handling storage or OS exception that may occur during the execution
     except OSError as e:
@@ -710,86 +1012,131 @@ def check_agent_state(corev1_api_instance, filepath_with_timestamp, storage_spac
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while trying to check the azure arc agents state in the "
-                           "cluster. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to check the azure arc agents state in the "
+                "cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Agent_State_Check_Fault_Type,
-                summary="Error ocuured while performing the agent state check")
-            diagnoser_output.append("An exception has occured while trying to check the azure arc agents state in "
-                                    "the cluster. Exception: {}".format(str(e)) + "\n")
+                summary="Error ocuured while performing the agent state check",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to check the azure arc agents state in "
+                "the cluster. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to check the azure arc agents state in the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to check the azure arc agents state in the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Agent_State_Check_Fault_Type,
-            summary="Error ocuured while performing the agent state check")
-        diagnoser_output.append("An exception has occured while trying to check the azure arc agents state in the "
-                                "cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error ocuured while performing the agent state check",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to check the azure arc agents state in the "
+            "cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
 
-    return consts.Diagnostic_Check_Incomplete, storage_space_available, all_agents_stuck, \
-        probable_sufficient_resource_for_agents
+    return (
+        consts.Diagnostic_Check_Incomplete,
+        storage_space_available,
+        all_agents_stuck,
+        probable_sufficient_resource_for_agents,
+    )
 
 
 def check_agent_version(connected_cluster, azure_arc_agent_version):
     print("Step: {}: Check agent version".format(get_utctimestring()))
     global diagnoser_output
     try:
-
         # If the agent version in the connected cluster resource is none skip the check
-        if (connected_cluster.agent_version is None):
+        if connected_cluster.agent_version is None:
             return consts.Diagnostic_Check_Incomplete
 
         # To get user agent version and the latest agent version
         user_agent_version = connected_cluster.agent_version
-        current_user_version = user_agent_version.split('.')
-        latest_agent_version = azure_arc_agent_version.split('.')
+        current_user_version = user_agent_version.split(".")
+        latest_agent_version = azure_arc_agent_version.split(".")
         # Comparing if the user version is compatible or not
-        if ((int(current_user_version[0]) < int(latest_agent_version[0])) or
-                (int(latest_agent_version[1]) - int(current_user_version[1]) > 2)):
+        if (int(current_user_version[0]) < int(latest_agent_version[0])) or (
+            int(latest_agent_version[1]) - int(current_user_version[1]) > 2
+        ):
             logger.warning(
                 "We found that you are on an older agent version that is not supported.\n Please visit this link to "
-                " know the agent version support policy '" + consts.Agent_Version_Support_Policy_Link + "'.\n")
+                " know the agent version support policy '"
+                + consts.Agent_Version_Support_Policy_Link
+                + "'.\n"
+            )
             diagnoser_output.append(
                 "We found that you are on an older agent version that is not supported.\n Please visit this link to "
-                "know the agent version support policy '" + consts.Agent_Version_Support_Policy_Link + "'.\n")
+                "know the agent version support policy '"
+                + consts.Agent_Version_Support_Policy_Link
+                + "'.\n"
+            )
             return consts.Diagnostic_Check_Failed
 
         return consts.Diagnostic_Check_Passed
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to check the azure arc agents version in the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to check the azure arc agents version in the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Agent_Version_Check_Fault_Type,
-            summary="Error occured while performing the agent version check")
-        diagnoser_output.append("An exception has occured while trying to check the azure arc agents version in the "
-                                "cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured while performing the agent version check",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to check the azure arc agents version in the "
+            "cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Incomplete
 
 
-def check_diagnoser_container(corev1_api_instance, batchv1_api_instance, filepath_with_timestamp,
-                              storage_space_available, absolute_path, probable_sufficient_resource_for_agents,
-                              helm_client_location, kubectl_client_location, release_namespace,
-                              probable_pod_security_policy_presence, kube_config, kube_context):
+def check_diagnoser_container(
+    corev1_api_instance,
+    batchv1_api_instance,
+    filepath_with_timestamp,
+    storage_space_available,
+    absolute_path,
+    probable_sufficient_resource_for_agents,
+    helm_client_location,
+    kubectl_client_location,
+    release_namespace,
+    probable_pod_security_policy_presence,
+    kube_config,
+    kube_context,
+):
     print("Step: {}: Check diagnoser container".format(get_utctimestring()))
     global diagnoser_output
     try:
-
         if probable_sufficient_resource_for_agents is False:
-            logger.warning("Unable to execute the diagnoser job in the cluster. It may be caused due to insufficient "
-                           "resource availability on the cluster.\n")
-            diagnoser_output.append("Unable to execute the diagnoser job in the cluster. It may be caused due to "
-                                    "insufficient resource availability on the cluster.\n")
+            logger.warning(
+                "Unable to execute the diagnoser job in the cluster. It may be caused due to insufficient "
+                "resource availability on the cluster.\n"
+            )
+            diagnoser_output.append(
+                "Unable to execute the diagnoser job in the cluster. It may be caused due to "
+                "insufficient resource availability on the cluster.\n"
+            )
             return consts.Diagnostic_Check_Incomplete, storage_space_available
 
         # Setting DNS and Outbound Check as working
@@ -797,11 +1144,20 @@ def check_diagnoser_container(corev1_api_instance, batchv1_api_instance, filepat
         outbound_connectivity_check = "Starting"
         # Executing the Diagnoser job and fetching diagnoser logs obtained
         diagnoser_container_log = executing_diagnoser_job(
-            corev1_api_instance, batchv1_api_instance, filepath_with_timestamp, storage_space_available, absolute_path,
-            helm_client_location, kubectl_client_location, release_namespace, probable_pod_security_policy_presence,
-            kube_config, kube_context)
+            corev1_api_instance,
+            batchv1_api_instance,
+            filepath_with_timestamp,
+            storage_space_available,
+            absolute_path,
+            helm_client_location,
+            kubectl_client_location,
+            release_namespace,
+            probable_pod_security_policy_presence,
+            kube_config,
+            kube_context,
+        )
         # If diagnoser_container_log is not empty then only we will check for the results
-        if (diagnoser_container_log is not None and diagnoser_container_log != ""):
+        if diagnoser_container_log is not None and diagnoser_container_log != "":
             diagnoser_container_log_list = diagnoser_container_log.split("\n")
             diagnoser_container_log_list.pop(-1)
             dns_check_log = ""
@@ -815,121 +1171,187 @@ def check_diagnoser_container(corev1_api_instance, batchv1_api_instance, filepat
                     counter_container_logs = 0
                 elif counter_container_logs == 0:
                     dns_check_log += "  " + outputs
-            dns_check, storage_space_available = \
-                azext_utils.check_cluster_DNS(dns_check_log, filepath_with_timestamp, storage_space_available,
-                                              diagnoser_output)
-            outbound_connectivity_check, storage_space_available = \
-                azext_utils.check_cluster_outbound_connectivity(diagnoser_container_log_list[-1],
-                                                                filepath_with_timestamp,
-                                                                storage_space_available,
-                                                                diagnoser_output,
-                                                                "troubleshoot")
+            dns_check, storage_space_available = azext_utils.check_cluster_DNS(
+                dns_check_log,
+                filepath_with_timestamp,
+                storage_space_available,
+                diagnoser_output,
+            )
+            outbound_connectivity_check, storage_space_available = (
+                azext_utils.check_cluster_outbound_connectivity(
+                    diagnoser_container_log_list[-1],
+                    filepath_with_timestamp,
+                    storage_space_available,
+                    diagnoser_output,
+                    "troubleshoot",
+                )
+            )
         else:
             return consts.Diagnostic_Check_Incomplete, storage_space_available
 
         # If both the check passed then we will return Diagnoser checks Passed
-        if (dns_check == consts.Diagnostic_Check_Passed and
-                outbound_connectivity_check == consts.Diagnostic_Check_Passed):
+        if (
+            dns_check == consts.Diagnostic_Check_Passed
+            and outbound_connectivity_check == consts.Diagnostic_Check_Passed
+        ):
             return consts.Diagnostic_Check_Passed, storage_space_available
         # If any of the check remain Incomplete than we will return Incomplete
-        elif (dns_check == consts.Diagnostic_Check_Incomplete or
-              outbound_connectivity_check == consts.Diagnostic_Check_Incomplete):
+        elif (
+            dns_check == consts.Diagnostic_Check_Incomplete
+            or outbound_connectivity_check == consts.Diagnostic_Check_Incomplete
+        ):
             return consts.Diagnostic_Check_Incomplete, storage_space_available
         else:
             return consts.Diagnostic_Check_Failed, storage_space_available
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to perform diagnoser container check on the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to perform diagnoser container check on the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Diagnoser_Container_Check_Failed_Fault_Type,
-            summary="Error occured while performing the diagnoser container checks")
-        diagnoser_output.append("An exception has occured while trying to perform diagnoser container check on the "
-                                "cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured while performing the diagnoser container checks",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to perform diagnoser container check on the "
+            "cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Incomplete, storage_space_available
 
 
-def executing_diagnoser_job(corev1_api_instance, batchv1_api_instance, filepath_with_timestamp, storage_space_available,
-                            absolute_path, helm_client_location, kubectl_client_location, release_namespace,
-                            probable_pod_security_policy_presence, kube_config, kube_context):
-
+def executing_diagnoser_job(
+    corev1_api_instance,
+    batchv1_api_instance,
+    filepath_with_timestamp,
+    storage_space_available,
+    absolute_path,
+    helm_client_location,
+    kubectl_client_location,
+    release_namespace,
+    probable_pod_security_policy_presence,
+    kube_config,
+    kube_context,
+):
     global diagnoser_output
     job_name = "azure-arc-diagnoser-job"
     # CMD command to get helm values in azure arc and converting it to json format
-    command = [helm_client_location, "get", "values", "azure-arc", "--namespace", release_namespace, "-o", "json"]
+    command = [
+        helm_client_location,
+        "get",
+        "values",
+        "azure-arc",
+        "--namespace",
+        release_namespace,
+        "-o",
+        "json",
+    ]
     if kube_config:
         command.extend(["--kubeconfig", kube_config])
     if kube_context:
         command.extend(["--kube-context", kube_context])
     # Using Popen to execute the helm get values command and fetching the output
     response_helm_values_get = Popen(command, stdout=PIPE, stderr=PIPE)
-    output_helm_values_get, error_helm_get_values = response_helm_values_get.communicate()
+    output_helm_values_get, error_helm_get_values = (
+        response_helm_values_get.communicate()
+    )
     if response_helm_values_get.returncode != 0:
-        if ('forbidden' in error_helm_get_values.decode("ascii") or
-                'timed out waiting for the condition' in error_helm_get_values.decode("ascii")):
+        if "forbidden" in error_helm_get_values.decode(
+            "ascii"
+        ) or "timed out waiting for the condition" in error_helm_get_values.decode(
+            "ascii"
+        ):
             telemetry.set_exception(
                 exception=error_helm_get_values.decode("ascii"),
                 fault_type=consts.Get_Helm_Values_Failed,
-                summary='Error while doing helm get values azure-arc')
+                summary="Error while doing helm get values azure-arc",
+            )
     helm_values_json = json.loads(output_helm_values_get)
     # Retrieving the proxy values if they are present
     try:
         is_proxy_enabled = helm_values_json["global"]["isProxyEnabled"]
     except Exception as e:
         # This exception will come when isProxyEnabled parameter is not present so we are setting it as false
-        if 'isProxyEnabled' in str(e):
+        if "isProxyEnabled" in str(e):
             is_proxy_enabled = False
         else:
-            logger.warning("An exception has occured while trying to fetch Field:'isProxyEnabled' from get helm "
-                           "values. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to fetch Field:'isProxyEnabled' from get helm "
+                "values. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Helm_Values_Fetch_isProxyEnabled_Failed_Fault_Type,
-                summary="Error while parsing the 'isProxyEnabled' while using helm get values")
-            diagnoser_output.append("An exception has occured while trying to fetch Field:'isProxyEnabled' from get "
-                                    "helm values. Exception: {}".format(str(e)) + "\n")
+                summary="Error while parsing the 'isProxyEnabled' while using helm get values",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to fetch Field:'isProxyEnabled' from get "
+                "helm values. Exception: {}".format(str(e))
+                + "\n"
+            )
             return
     try:
         is_custom_cert = helm_values_json["global"]["isCustomCert"]
     except Exception as e:
         # This exception will come when isCustomCert parameter is not present so we are setting it as false
-        if 'isCustomCert' in str(e):
+        if "isCustomCert" in str(e):
             is_custom_cert = False
         else:
-            logger.warning("An exception has occured while trying to fetch Field:'isCustomCert' from get helm "
-                           "values. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to fetch Field:'isCustomCert' from get helm "
+                "values. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Helm_Values_Fetch_isCustomCert_Failed_Fault_Type,
-                summary="Error while parsing the 'isCustomCert' while using helm get values")
-            diagnoser_output.append("An exception has occured while trying to fetch Field:'isCustomCert' from get "
-                                    "helm values. Exception: {}".format(str(e)) + "\n")
+                summary="Error while parsing the 'isCustomCert' while using helm get values",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to fetch Field:'isCustomCert' from get "
+                "helm values. Exception: {}".format(str(e))
+                + "\n"
+            )
             return
     try:
         proxy_cert = helm_values_json["global"]["proxyCert"]
     except Exception as e:
         # This exception will come when proxyCert parameter is not present so we are setting it as false
-        if 'proxyCert' in str(e):
+        if "proxyCert" in str(e):
             proxy_cert = False
         else:
-            logger.warning("An exception has occured while trying to fetch Field:'proxyCert' from get helm values. "
-                           "Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while trying to fetch Field:'proxyCert' from get helm values. "
+                "Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Helm_Values_Fetch_proxyCert_Failed_Fault_Type,
-                summary="Error while parsing the 'proxyCert' while using helm get values")
-            diagnoser_output.append("An exception has occured while trying to fetch Field:'proxyCert' from get helm "
-                                    "values. Exception: {}".format(str(e)) + "\n")
+                summary="Error while parsing the 'proxyCert' while using helm get values",
+            )
+            diagnoser_output.append(
+                "An exception has occured while trying to fetch Field:'proxyCert' from get helm "
+                "values. Exception: {}".format(str(e))
+                + "\n"
+            )
             return
 
     # Depending on the presence of proxy cert using the yaml
     if proxy_cert and (is_custom_cert or is_proxy_enabled):
-        yaml_file_path = os.path.join(absolute_path, "troubleshoot_diagnoser_job_with_proxycert_mount.yaml")
+        yaml_file_path = os.path.join(
+            absolute_path, "troubleshoot_diagnoser_job_with_proxycert_mount.yaml"
+        )
     else:
-        yaml_file_path = os.path.join(absolute_path, "troubleshoot_diagnoser_job_without_proxycert.yaml")
+        yaml_file_path = os.path.join(
+            absolute_path, "troubleshoot_diagnoser_job_without_proxycert.yaml"
+        )
     # Setting the log output as Empty
     diagnoser_container_log = ""
     cmd_delete_job = [kubectl_client_location, "delete", "-f", ""]
@@ -950,14 +1372,16 @@ def executing_diagnoser_job(corev1_api_instance, batchv1_api_instance, filepath_
             # Changing the role, rolebinding and the job args namespace field to the release-namespace
             # Secret-reader role is used to fetch the secrets present in the release-namespace
             # Also we pass release-namespace in args to read secrets for helm command that we are using in the script.
-            if (troubleshoot_yaml_part == 1 or troubleshoot_yaml_part == 2):
-                each_yaml['metadata']['namespace'] = release_namespace
-            elif (troubleshoot_yaml_part == 3):
-                each_yaml['spec']['template']['spec']['containers'][0]['args'][0] = release_namespace
+            if troubleshoot_yaml_part == 1 or troubleshoot_yaml_part == 2:
+                each_yaml["metadata"]["namespace"] = release_namespace
+            elif troubleshoot_yaml_part == 3:
+                each_yaml["spec"]["template"]["spec"]["containers"][0]["args"][0] = (
+                    release_namespace
+                )
             troubleshoot_yaml_part += 1
             new_yaml.append(each_yaml)
     # Updating the yaml file
-    with open(yaml_file_path, 'w+') as f:
+    with open(yaml_file_path, "w+") as f:
         for add_updated_yaml_part in new_yaml:
             f.write("---\n")
             yaml.dump(add_updated_yaml_part, f)
@@ -969,9 +1393,11 @@ def executing_diagnoser_job(corev1_api_instance, batchv1_api_instance, filepath_
         k8s_client = client.ApiClient()
         # Attempting deletion of diagnoser resources to handle the scenario if any stale resources are present
         response_kubectl_delete_job = Popen(cmd_delete_job, stdout=PIPE, stderr=PIPE)
-        output_kubectl_delete_job, error_kubectl_delete_job = response_kubectl_delete_job.communicate()
+        output_kubectl_delete_job, error_kubectl_delete_job = (
+            response_kubectl_delete_job.communicate()
+        )
         # If any error occured while execution of delete command
-        if (response_kubectl_delete_job != 0):
+        if response_kubectl_delete_job != 0:
             # Converting the string of multiple errors to list
             error_msg_list = error_kubectl_delete_job.decode("ascii").split("\n")
             error_msg_list.pop(-1)
@@ -979,19 +1405,27 @@ def executing_diagnoser_job(corev1_api_instance, batchv1_api_instance, filepath_
             # Checking if any exception occured or not
             exception_occured_counter = 0
             for ind_errors in error_msg_list:
-                if ('Error from server (NotFound)' in ind_errors or 'deleted' in ind_errors):
+                if (
+                    "Error from server (NotFound)" in ind_errors
+                    or "deleted" in ind_errors
+                ):
                     pass
                 else:
                     valid_exception_list.append(ind_errors)
                     exception_occured_counter = 1
             # If any exception occured we will print the exception and return
             if exception_occured_counter == 1:
-                logger.warning("An error occured while deploying the diagnoser job in the cluster. Exception:")
+                logger.warning(
+                    "An error occured while deploying the diagnoser job in the cluster. Exception:"
+                )
                 telemetry.set_exception(
                     exception=error_helm_get_values.decode("ascii"),
                     fault_type=consts.Diagnoser_Job_Failed_Fault_Type,
-                    summary="Error while executing Diagnoser Job")
-                diagnoser_output.append("An error occured while deploying the diagnoser job in the cluster. Exception:")
+                    summary="Error while executing Diagnoser Job",
+                )
+                diagnoser_output.append(
+                    "An error occured while deploying the diagnoser job in the cluster. Exception:"
+                )
                 for ind_error in valid_exception_list:
                     logger.warning(ind_error)
                     diagnoser_output.append(ind_error)
@@ -1001,14 +1435,19 @@ def executing_diagnoser_job(corev1_api_instance, batchv1_api_instance, filepath_
             utils.create_from_yaml(k8s_client, yaml_file_path)
         # To handle the Exception that occured
         except Exception as e:
-            logger.warning("An error occured while deploying the diagnoser job in the cluster. Exception:")
+            logger.warning(
+                "An error occured while deploying the diagnoser job in the cluster. Exception:"
+            )
             logger.warning(str(e))
-            diagnoser_output.append("An error occured while deploying the diagnoser job in the cluster. Exception:")
+            diagnoser_output.append(
+                "An error occured while deploying the diagnoser job in the cluster. Exception:"
+            )
             diagnoser_output.append(str(e))
             telemetry.set_exception(
                 exception=error_helm_get_values.decode("ascii"),
                 fault_type=consts.Diagnoser_Job_Failed_Fault_Type,
-                summary="Error while executing Diagnoser Job")
+                summary="Error while executing Diagnoser Job",
+            )
             # Deleting all the stale resources that got created
             Popen(cmd_delete_job, stdout=PIPE, stderr=PIPE)
             return
@@ -1017,17 +1456,21 @@ def executing_diagnoser_job(corev1_api_instance, batchv1_api_instance, filepath_
         is_job_complete = False
         is_job_scheduled = False
         # To watch for changes in the pods states till it reach completed state or exit if it takes more than 60 seconds
-        for event in w.stream(batchv1_api_instance.list_namespaced_job,
-                              namespace='azure-arc',
-                              label_selector="",
-                              timeout_seconds=180):
+        for event in w.stream(
+            batchv1_api_instance.list_namespaced_job,
+            namespace="azure-arc",
+            label_selector="",
+            timeout_seconds=180,
+        ):
             try:
                 # Checking if job get scheduled or not
                 if event["object"].metadata.name == "azure-arc-diagnoser-job":
                     is_job_scheduled = True
                 # Checking if job reached completed stage or not
-                if event["object"].metadata.name == "azure-arc-diagnoser-job" and \
-                    any(condition.type == "Complete" for condition in event["object"].status.conditions):
+                if event["object"].metadata.name == "azure-arc-diagnoser-job" and any(
+                    condition.type == "Complete"
+                    for condition in event["object"].status.conditions
+                ):
                     is_job_complete = True
                     w.stop()
             except Exception:
@@ -1036,99 +1479,151 @@ def executing_diagnoser_job(corev1_api_instance, batchv1_api_instance, filepath_
                 continue
 
         # Select the error message depending on the job getting scheduled, completed & the presence of security policy
-        if (is_job_scheduled is False and probable_pod_security_policy_presence == consts.Diagnostic_Check_Failed):
-            logger.warning("Unable to schedule the diagnoser job in the kubernetes cluster. There might be a pod "
-                           "security policy or security context constraint (SCC) present which is preventing the "
-                           "deployment of azure-arc-diagnoser-job as it uses serviceaccount:azure-arc-troubleshoot-sa "
-                           "which does not have admin permissions.\nYou can whitelist it and then run the "
-                           "troubleshoot command again.\n")
+        if (
+            is_job_scheduled is False
+            and probable_pod_security_policy_presence == consts.Diagnostic_Check_Failed
+        ):
+            logger.warning(
+                "Unable to schedule the diagnoser job in the kubernetes cluster. There might be a pod "
+                "security policy or security context constraint (SCC) present which is preventing the "
+                "deployment of azure-arc-diagnoser-job as it uses serviceaccount:azure-arc-troubleshoot-sa "
+                "which does not have admin permissions.\nYou can whitelist it and then run the "
+                "troubleshoot command again.\n"
+            )
             Popen(cmd_delete_job, stdout=PIPE, stderr=PIPE)
-            diagnoser_output.append("Unable to schedule the diagnoser job in the kubernetes cluster. There might be "
-                                    "a pod security policy or security context constraint (SCC) present which is "
-                                    "preventing the deployment of azure-arc-diagnoser-job as it uses serviceaccount:"
-                                    "azure-arc-troubleshoot-sa which does not have admin permissions.\nYou can "
-                                    "whitelist it and then run the troubleshoot command again.\n")
+            diagnoser_output.append(
+                "Unable to schedule the diagnoser job in the kubernetes cluster. There might be "
+                "a pod security policy or security context constraint (SCC) present which is "
+                "preventing the deployment of azure-arc-diagnoser-job as it uses serviceaccount:"
+                "azure-arc-troubleshoot-sa which does not have admin permissions.\nYou can "
+                "whitelist it and then run the troubleshoot command again.\n"
+            )
             return
-        elif (is_job_scheduled is False):
-            logger.warning("Unable to schedule the diagnoser job in the kubernetes cluster. The possible reasons can "
-                           "be presence of a security policy or security context constraint (SCC) or it may happen "
-                           "because of lack of ResourceQuota.\n")
+        elif is_job_scheduled is False:
+            logger.warning(
+                "Unable to schedule the diagnoser job in the kubernetes cluster. The possible reasons can "
+                "be presence of a security policy or security context constraint (SCC) or it may happen "
+                "because of lack of ResourceQuota.\n"
+            )
             Popen(cmd_delete_job, stdout=PIPE, stderr=PIPE)
-            diagnoser_output.append("Unable to schedule the diagnoser job in the kubernetes cluster. The possible "
-                                    "reasons can be presence of a security policy or security context constraint "
-                                    "(SCC) or it may happen because of lack of ResourceQuota.\n")
+            diagnoser_output.append(
+                "Unable to schedule the diagnoser job in the kubernetes cluster. The possible "
+                "reasons can be presence of a security policy or security context constraint "
+                "(SCC) or it may happen because of lack of ResourceQuota.\n"
+            )
             return
-        elif (is_job_scheduled is True and is_job_complete is False):
-            logger.warning("The diagnoser job failed to reach the completed state in the kubernetes cluster.\n")
+        elif is_job_scheduled is True and is_job_complete is False:
+            logger.warning(
+                "The diagnoser job failed to reach the completed state in the kubernetes cluster.\n"
+            )
             if storage_space_available:
                 # Creating folder with name 'describe_non_ready_agent' in the given path
-                unfinished_diagnoser_job_path = os.path.join(filepath_with_timestamp,
-                                                             consts.Events_of_Incomplete_Diagnoser_Job)
-                cmd_get_diagnoser_job_events = [kubectl_client_location, "get", "events", "--field-selector", "",
-                                                "-n", "azure-arc", "--output", "json"]
+                unfinished_diagnoser_job_path = os.path.join(
+                    filepath_with_timestamp, consts.Events_of_Incomplete_Diagnoser_Job
+                )
+                cmd_get_diagnoser_job_events = [
+                    kubectl_client_location,
+                    "get",
+                    "events",
+                    "--field-selector",
+                    "",
+                    "-n",
+                    "azure-arc",
+                    "--output",
+                    "json",
+                ]
                 if kube_config:
                     cmd_get_diagnoser_job_events.extend(["--kubeconfig", kube_config])
                 if kube_context:
                     cmd_get_diagnoser_job_events.extend(["--context", kube_context])
                 # To describe the diagnoser pod which did not reach completed stage
-                arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(namespace="azure-arc")
+                arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(
+                    namespace="azure-arc"
+                )
                 for each_pod in arc_agents_pod_list.items:
                     pod_name = each_pod.metadata.name
-                    if (pod_name.startswith(job_name)):
+                    if pod_name.startswith(job_name):
                         # To retrieve the pod logs which is stuck
-                        cmd_get_diagnoser_job_events[4] = "involvedObject.name=" + pod_name
+                        cmd_get_diagnoser_job_events[4] = (
+                            "involvedObject.name=" + pod_name
+                        )
                         # Using Popen to execute the command and fetching the output
-                        response_kubectl_get_events = Popen(cmd_get_diagnoser_job_events, stdout=PIPE, stderr=PIPE)
-                        output_kubectl_get_events, error_kubectl_get_events = response_kubectl_get_events.communicate()
+                        response_kubectl_get_events = Popen(
+                            cmd_get_diagnoser_job_events, stdout=PIPE, stderr=PIPE
+                        )
+                        output_kubectl_get_events, error_kubectl_get_events = (
+                            response_kubectl_get_events.communicate()
+                        )
                         if response_kubectl_get_events.returncode != 0:
                             telemetry.set_exception(
                                 exception=error_kubectl_get_events.decode("ascii"),
                                 fault_type=consts.Kubectl_Get_Events_Failed_Fault_Type,
-                                summary='Error while doing kubectl get events')
-                            logger.warning("Error while doing kubectl get events. We were not able to capture events "
-                                           "log in arc_diganostic_logs folder. Exception: ",
-                                           error_kubectl_get_events.decode("ascii"))
-                            diagnoser_output.append("Error while doing kubectl get events. We were not able to "
-                                                    "capture events log in arc_diganostic_logs folder. Exception: ",
-                                                    error_kubectl_get_events.decode("ascii"))
-                            return consts.Diagnostic_Check_Failed, storage_space_available
+                                summary="Error while doing kubectl get events",
+                            )
+                            logger.warning(
+                                "Error while doing kubectl get events. We were not able to capture events "
+                                "log in arc_diganostic_logs folder. Exception: ",
+                                error_kubectl_get_events.decode("ascii"),
+                            )
+                            diagnoser_output.append(
+                                "Error while doing kubectl get events. We were not able to "
+                                "capture events log in arc_diganostic_logs folder. Exception: ",
+                                error_kubectl_get_events.decode("ascii"),
+                            )
+                            return (
+                                consts.Diagnostic_Check_Failed,
+                                storage_space_available,
+                            )
                         # Converting output obtained in json format and fetching the clusterconnect-agent feature
                         events_json = json.loads(output_kubectl_get_events)
                         if len(events_json["items"]) != 0:
-                            with open(unfinished_diagnoser_job_path, 'w+') as unfinished_diagnoser_job:
+                            with open(
+                                unfinished_diagnoser_job_path, "w+"
+                            ) as unfinished_diagnoser_job:
                                 # Adding all the individual events
                                 for events in events_json["items"]:
                                     unfinished_diagnoser_job.write(str(events) + "\n")
             Popen(cmd_delete_job, stdout=PIPE, stderr=PIPE)
             diagnoser_output.append(
-                "The diagnoser job failed to reach the completed state in the kubernetes cluster.\n")
+                "The diagnoser job failed to reach the completed state in the kubernetes cluster.\n"
+            )
             return
         else:
             # Fetching the Diagnoser Container logs
-            all_pods = corev1_api_instance.list_namespaced_pod('azure-arc')
+            all_pods = corev1_api_instance.list_namespaced_pod("azure-arc")
             # Traversing through all agents
             for each_pod in all_pods.items:
                 # Fetching the current Pod name and creating a folder with that name inside the timestamp folder
                 pod_name = each_pod.metadata.name
-                if (pod_name.startswith(job_name)):
+                if pod_name.startswith(job_name):
                     # Creating a text file with the name of the container and adding that containers logs in it
-                    diagnoser_container_log = corev1_api_instance.read_namespaced_pod_log(
-                        name=pod_name,
-                        container="azure-arc-diagnoser-container",
-                        namespace='azure-arc')
+                    diagnoser_container_log = (
+                        corev1_api_instance.read_namespaced_pod_log(
+                            name=pod_name,
+                            container="azure-arc-diagnoser-container",
+                            namespace="azure-arc",
+                        )
+                    )
         # Clearing all the resources after fetching the diagnoser container logs
         Popen(cmd_delete_job, stdout=PIPE, stderr=PIPE)
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to execute the diagnoser job in the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to execute the diagnoser job in the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         Popen(cmd_delete_job, stdout=PIPE, stderr=PIPE)
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Diagnoser_Job_Failed_Fault_Type,
-            summary="Error while executing Diagnoser Job")
-        diagnoser_output.append("An exception has occured while trying to execute the diagnoser job in the cluster. "
-                                "Exception: {}".format(str(e)) + "\n")
+            summary="Error while executing Diagnoser Job",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to execute the diagnoser job in the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         return
 
     return diagnoser_container_log
@@ -1141,97 +1636,148 @@ def check_msi_certificate_presence(corev1_api_instance):
         # Initializing msi certificate as not present
         msi_cert_present = False
         # Going through all the secrets in azure-arc
-        all_secrets_azurearc = corev1_api_instance.list_namespaced_secret(namespace="azure-arc")
+        all_secrets_azurearc = corev1_api_instance.list_namespaced_secret(
+            namespace="azure-arc"
+        )
         for secrets in all_secrets_azurearc.items:
             # If name of secret is azure-identity-certificate then we stop there
-            if (secrets.metadata.name == consts.MSI_Certificate_Secret_Name):
+            if secrets.metadata.name == consts.MSI_Certificate_Secret_Name:
                 msi_cert_present = True
 
         # Checking if msi cerificate is present or not
         if not msi_cert_present:
             logger.warning(
-                "Error: Unable to pull MSI certificate. Please ensure to meet the following network requirements '" +
-                consts.Doc_Quick_Start_NW_Requirements_Url + "'. \n")
+                "Error: Unable to pull MSI certificate. Please ensure to meet the following network requirements '"
+                + consts.Doc_Quick_Start_NW_Requirements_Url
+                + "'. \n"
+            )
             diagnoser_output.append(
-                "Error: Unable to pull MSI certificate. Please ensure to meet the following network requirements '" +
-                consts.Doc_Quick_Start_NW_Requirements_Url + "'. \n")
+                "Error: Unable to pull MSI certificate. Please ensure to meet the following network requirements '"
+                + consts.Doc_Quick_Start_NW_Requirements_Url
+                + "'. \n"
+            )
             return consts.Diagnostic_Check_Failed
 
         return consts.Diagnostic_Check_Passed
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while performing the msi certificate check on the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while performing the msi certificate check on the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.MSI_Cert_Check_Fault_Type,
-            summary="Error occurred while trying to perform MSI certificate presence check")
-        diagnoser_output.append("An exception has occured while performing the msi certificate check on the "
-                                "cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occurred while trying to perform MSI certificate presence check",
+        )
+        diagnoser_output.append(
+            "An exception has occured while performing the msi certificate check on the "
+            "cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Incomplete
 
 
-def check_probable_cluster_security_policy(corev1_api_instance, helm_client_location,
-                                           release_namespace, kube_config, kube_context):
-    print("Step: {}: Check probable cluster security policy".format(get_utctimestring()))
+def check_probable_cluster_security_policy(
+    corev1_api_instance,
+    helm_client_location,
+    release_namespace,
+    kube_config,
+    kube_context,
+):
+    print(
+        "Step: {}: Check probable cluster security policy".format(get_utctimestring())
+    )
     global diagnoser_output
     try:
         # Intializing the kap_pod_present and cluster_connect_feature variable as False
         kap_pod_present = False
         cluster_connect_feature = False
         # CMD command to get helm values in azure arc and converting it to json format
-        command = [helm_client_location, "get", "values", "azure-arc", "--namespace", release_namespace, "-o", "json"]
+        command = [
+            helm_client_location,
+            "get",
+            "values",
+            "azure-arc",
+            "--namespace",
+            release_namespace,
+            "-o",
+            "json",
+        ]
         if kube_config:
             command.extend(["--kubeconfig", kube_config])
         if kube_context:
             command.extend(["--kube-context", kube_context])
         # Using Popen to execute the helm get values command and fetching the output
         response_helm_values_get = Popen(command, stdout=PIPE, stderr=PIPE)
-        output_helm_values_get, error_helm_get_values = response_helm_values_get.communicate()
+        output_helm_values_get, error_helm_get_values = (
+            response_helm_values_get.communicate()
+        )
         if response_helm_values_get.returncode != 0:
-            if ('forbidden' in error_helm_get_values.decode("ascii") or
-                    'timed out waiting for the condition' in error_helm_get_values.decode("ascii")):
+            if "forbidden" in error_helm_get_values.decode(
+                "ascii"
+            ) or "timed out waiting for the condition" in error_helm_get_values.decode(
+                "ascii"
+            ):
                 telemetry.set_exception(
                     exception=error_helm_get_values.decode("ascii"),
                     fault_type=consts.Get_Helm_Values_Failed,
-                    summary='Error while doing helm get values azure-arc')
+                    summary="Error while doing helm get values azure-arc",
+                )
         # Converting output obtained in json format and fetching the clusterconnect-agent feature
         helm_values_json = json.loads(output_helm_values_get)
-        cluster_connect_feature = helm_values_json["systemDefaultValues"]["clusterconnect-agent"]["enabled"]
+        cluster_connect_feature = helm_values_json["systemDefaultValues"][
+            "clusterconnect-agent"
+        ]["enabled"]
         # To retrieve all of the arc agent pods that are present in the Cluster
-        arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(namespace="azure-arc")
+        arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(
+            namespace="azure-arc"
+        )
         # Traversing through all agents and checking if the Kube aad proxy pod is present or not
         for each_agent_pod in arc_agents_pod_list.items:
-            if (each_agent_pod.metadata.name.startswith("kube-aad-proxy")):
+            if each_agent_pod.metadata.name.startswith("kube-aad-proxy"):
                 kap_pod_present = True
                 break
         # Checking if there is any chance of pod security policy presence
-        if (cluster_connect_feature is True and kap_pod_present is False):
-            logger.warning("Error: Unable to create Kube-aad-proxy deployment. There might be a pod security policy "
-                           "or security context constraint (SCC) present which is preventing the deployment of "
-                           "kube-aad-proxy as it doesn't have admin privileges.\nKube aad proxy pod uses the "
-                           "azure-arc-kube-aad-proxy-sa service account, which doesn't have admin permissions but "
-                           "requires the permission to mount host path.\n")
+        if cluster_connect_feature is True and kap_pod_present is False:
+            logger.warning(
+                "Error: Unable to create Kube-aad-proxy deployment. There might be a pod security policy "
+                "or security context constraint (SCC) present which is preventing the deployment of "
+                "kube-aad-proxy as it doesn't have admin privileges.\nKube aad proxy pod uses the "
+                "azure-arc-kube-aad-proxy-sa service account, which doesn't have admin permissions but "
+                "requires the permission to mount host path.\n"
+            )
             diagnoser_output.append(
                 "Error: Unable to create Kube-aad-proxy deployment. There might be a pod security policy or security "
                 "context constraint (SCC) present which is preventing the deployment of kube-aad-proxy as it doesn't "
                 "have admin privileges.\nKube aad proxy pod uses the azure-arc-kube-aad-proxy-sa service account, "
-                "which doesn't have admin permissions but requires the permission to mount host path.\n")
+                "which doesn't have admin permissions but requires the permission to mount host path.\n"
+            )
             return consts.Diagnostic_Check_Failed
         return consts.Diagnostic_Check_Passed
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to performing kube aad proxy presence and pod security "
-                       "policy presence check in the cluster. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to performing kube aad proxy presence and pod security "
+            "policy presence check in the cluster. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Cluster_Security_Policy_Check_Fault_Type,
-            summary="Error occurred while trying to perform KAP certificate presence check")
-        diagnoser_output.append("An exception has occured while trying to performing kube aad proxy presence and pod "
-                                "security policy presence check in the cluster. Exception: {}".format(str(e)) + "\n")
+            summary="Error occurred while trying to perform KAP certificate presence check",
+        )
+        diagnoser_output.append(
+            "An exception has occured while trying to performing kube aad proxy presence and pod "
+            "security policy presence check in the cluster. Exception: {}".format(
+                str(e)
+            )
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Incomplete
 
@@ -1244,38 +1790,53 @@ def check_kap_cert(corev1_api_instance):
         kap_cert_present = False
         kap_pod_status = ""
         # To retrieve all of the arc agent pods that are present in the Cluster
-        arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(namespace="azure-arc")
+        arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(
+            namespace="azure-arc"
+        )
         # Traversing through all agents and checking if the Kube aad proxy pod is in containercreating state
         for each_agent_pod in arc_agents_pod_list.items:
-            if each_agent_pod.metadata.name.startswith("kube-aad-proxy") \
-                    and each_agent_pod.status.phase == "ContainerCreating":
+            if (
+                each_agent_pod.metadata.name.startswith("kube-aad-proxy")
+                and each_agent_pod.status.phase == "ContainerCreating"
+            ):
                 kap_pod_status = "ContainerCreating"
                 break
         # Going through all the secrets in azure-arc
-        all_secrets_azurearc = corev1_api_instance.list_namespaced_secret(namespace="azure-arc")
+        all_secrets_azurearc = corev1_api_instance.list_namespaced_secret(
+            namespace="azure-arc"
+        )
         for secrets in all_secrets_azurearc.items:
             # If name of secret is kube-aad-proxy-certificate then we stop there
-            if (secrets.metadata.name == consts.KAP_Certificate_Secret_Name):
+            if secrets.metadata.name == consts.KAP_Certificate_Secret_Name:
                 kap_cert_present = True
         if not kap_cert_present and kap_pod_status == "ContainerCreating":
             logger.warning(
-                "Error: Unable to pull Kube aad proxy certificate. Please attempt to onboard the cluster again.\n")
+                "Error: Unable to pull Kube aad proxy certificate. Please attempt to onboard the cluster again.\n"
+            )
             diagnoser_output.append(
-                "Error: Unable to pull Kube aad proxy certificate. Please attempt to onboard the cluster again.\n")
+                "Error: Unable to pull Kube aad proxy certificate. Please attempt to onboard the cluster again.\n"
+            )
             return consts.Diagnostic_Check_Failed
 
         return consts.Diagnostic_Check_Passed
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception occured while trying to check the presence of kube aad proxy certificater. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception occured while trying to check the presence of kube aad proxy certificater. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.KAP_Cert_Check_Fault_Type,
-            summary="Error occurred while trying to perform KAP certificate presence check")
-        diagnoser_output.append("An exception occured while trying to check the presence of kube aad proxy "
-                                "certificate. Exception: {}".format(str(e)) + "\n")
+            summary="Error occurred while trying to perform KAP certificate presence check",
+        )
+        diagnoser_output.append(
+            "An exception occured while trying to check the presence of kube aad proxy "
+            "certificate. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Incomplete
 
@@ -1285,50 +1846,77 @@ def check_msi_expiry(connected_cluster):
     global diagnoser_output
     try:
         # Fetch the expiry time of the msi certificate
-        Expiry_date = str(connected_cluster.managed_identity_certificate_expiration_time)
+        Expiry_date = str(
+            connected_cluster.managed_identity_certificate_expiration_time
+        )
         # Fetch the current time and format it same as msi certificate
-        Current_date_temp = \
-            datetime.datetime.now().utcnow().replace(microsecond=0, tzinfo=datetime.timezone.utc).isoformat()
-        Current_date = Current_date_temp.replace('T', ' ')
+        Current_date_temp = (
+            datetime.datetime.now()
+            .utcnow()
+            .replace(microsecond=0, tzinfo=datetime.timezone.utc)
+            .isoformat()
+        )
+        Current_date = Current_date_temp.replace("T", " ")
         # Check if expiry date is lesser than current time
-        if (Expiry_date < Current_date):
-            logger.warning("Error: Your MSI certificate has expired. To resolve this issue you can delete the "
-                           "connected cluster and reconnect it to azure arc.\n")
-            diagnoser_output.append("Error: Your MSI certificate has expired. To resolve this issue you can delete "
-                                    "the connected cluster and reconnect it to azure arc.\n")
+        if Expiry_date < Current_date:
+            logger.warning(
+                "Error: Your MSI certificate has expired. To resolve this issue you can delete the "
+                "connected cluster and reconnect it to azure arc.\n"
+            )
+            diagnoser_output.append(
+                "Error: Your MSI certificate has expired. To resolve this issue you can delete "
+                "the connected cluster and reconnect it to azure arc.\n"
+            )
             return consts.Diagnostic_Check_Failed
 
         return consts.Diagnostic_Check_Passed
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while performing msi expiry check on the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while performing msi expiry check on the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.MSI_Cert_Expiry_Check_Fault_Type,
-            summary="Error occured while trying to perform the MSI cert expiry check")
-        diagnoser_output.append("An exception has occured while performing msi expiry check on the cluster. "
-                                "Exception: {}".format(str(e)) + "\n")
+            summary="Error occured while trying to perform the MSI cert expiry check",
+        )
+        diagnoser_output.append(
+            "An exception has occured while performing msi expiry check on the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Incomplete
 
 
-def describe_non_ready_agent_log(filepath_with_timestamp, corev1_api_instance, agent_pod_name, storage_space_available):
-
+def describe_non_ready_agent_log(
+    filepath_with_timestamp,
+    corev1_api_instance,
+    agent_pod_name,
+    storage_space_available,
+):
     try:
         # To describe pod if its not in running state and storing it if storage is available
         if storage_space_available:
             # Creating folder with name 'describe_non_ready_agent' in the given path
-            describe_stuck_agent_path = os.path.join(filepath_with_timestamp, consts.Describe_Non_Ready_Arc_Agents)
+            describe_stuck_agent_path = os.path.join(
+                filepath_with_timestamp, consts.Describe_Non_Ready_Arc_Agents
+            )
             try:
                 os.mkdir(describe_stuck_agent_path)
             except FileExistsError:
                 pass
             # To retrieve the pod logs which is stuck
-            api_response = corev1_api_instance.read_namespaced_pod(name=agent_pod_name, namespace='azure-arc')
-            stuck_agent_pod_path = os.path.join(describe_stuck_agent_path, agent_pod_name + '.txt')
-            with open(stuck_agent_pod_path, 'w+') as stuck_agent_log:
+            api_response = corev1_api_instance.read_namespaced_pod(
+                name=agent_pod_name, namespace="azure-arc"
+            )
+            stuck_agent_pod_path = os.path.join(
+                describe_stuck_agent_path, agent_pod_name + ".txt"
+            )
+            with open(stuck_agent_pod_path, "w+") as stuck_agent_log:
                 stuck_agent_log.write(str(api_response))
 
     # For handling storage or OS exception that may occur during the execution
@@ -1338,35 +1926,58 @@ def describe_non_ready_agent_log(filepath_with_timestamp, corev1_api_instance, a
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while storing stuck agent logs in the user local machine. "
-                           "Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while storing stuck agent logs in the user local machine. "
+                "Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Describe_Stuck_Agents_Fault_Type,
-                summary="Error occured while storing the stuck agents description")
-            diagnoser_output.append("An exception has occured while storing stuck agent logs in the user local "
-                                    "machine. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured while storing the stuck agents description",
+            )
+            diagnoser_output.append(
+                "An exception has occured while storing stuck agent logs in the user local "
+                "machine. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while storing stuck agent logs in the user local machine. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while storing stuck agent logs in the user local machine. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Describe_Stuck_Agents_Fault_Type,
-            summary="Error occured while storing the stuck agents description")
-        diagnoser_output.append("An exception has occured while storing stuck agent logs in the user local machine. "
-                                "Exception: {}".format(str(e)) + "\n")
+            summary="Error occured while storing the stuck agents description",
+        )
+        diagnoser_output.append(
+            "An exception has occured while storing stuck agent logs in the user local machine. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return storage_space_available
 
 
-def get_secrets_azure_arc(corev1_api_instance, kubectl_client_location, kube_config, kube_context,
-                          filepath_with_timestamp, storage_space_available):
-    print("Step: {}: Fetching secrets in azure arc namespace".format(get_utctimestring()))
+def get_secrets_azure_arc(
+    corev1_api_instance,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+    filepath_with_timestamp,
+    storage_space_available,
+):
+    print(
+        "Step: {}: Fetching secrets in azure arc namespace".format(get_utctimestring())
+    )
     try:
         if storage_space_available:
             command = [kubectl_client_location, "get", "secrets", "-n", "azure-arc"]
@@ -1376,26 +1987,35 @@ def get_secrets_azure_arc(corev1_api_instance, kubectl_client_location, kube_con
                 command.extend(["--context", kube_context])
             # Using Popen to execute the command and fetching the output
             response_kubectl_get_secrets = Popen(command, stdout=PIPE, stderr=PIPE)
-            output_kubectl_get_secrets, error_kubectl_get_secrets = response_kubectl_get_secrets.communicate()
+            output_kubectl_get_secrets, error_kubectl_get_secrets = (
+                response_kubectl_get_secrets.communicate()
+            )
             if response_kubectl_get_secrets.returncode != 0:
                 telemetry.set_exception(
                     exception=error_kubectl_get_secrets.decode("ascii"),
                     fault_type=consts.Kubectl_Get_Secrets_Failed_Fault_Type,
-                    summary='Error while doing kubectl get secrets')
-                logger.warning("Error while doing kubectl get secrets for azure-arc namespace. We were not able to "
-                               "capture this log in arc_diganostic_logs folder. Exception: ",
-                               error_kubectl_get_secrets.decode("ascii"))
-                diagnoser_output.append("Error while doing kubectl get secrets in azure-arc namespace. We were not "
-                                        "able to capture this log in arc_diganostic_logs folder. Exception: " +
-                                        error_kubectl_get_secrets.decode("ascii"))
+                    summary="Error while doing kubectl get secrets",
+                )
+                logger.warning(
+                    "Error while doing kubectl get secrets for azure-arc namespace. We were not able to "
+                    "capture this log in arc_diganostic_logs folder. Exception: ",
+                    error_kubectl_get_secrets.decode("ascii"),
+                )
+                diagnoser_output.append(
+                    "Error while doing kubectl get secrets in azure-arc namespace. We were not "
+                    "able to capture this log in arc_diganostic_logs folder. Exception: "
+                    + error_kubectl_get_secrets.decode("ascii")
+                )
                 return storage_space_available
 
             # Converting output obtained in json format
             secrets_json = output_kubectl_get_secrets.decode()
             # Path to add the azure-arc secrets
-            secrets_logs_path = os.path.join(filepath_with_timestamp, "azure-arc-secrets.txt")
+            secrets_logs_path = os.path.join(
+                filepath_with_timestamp, "azure-arc-secrets.txt"
+            )
 
-            with open(secrets_logs_path, 'w+') as secrets_log:
+            with open(secrets_logs_path, "w+") as secrets_log:
                 secrets_log.write(secrets_json)
 
             return storage_space_available
@@ -1407,56 +2027,98 @@ def get_secrets_azure_arc(corev1_api_instance, kubectl_client_location, kube_con
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while storing list of secrets in azure arc namespace in the "
-                           "user local machine. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while storing list of secrets in azure arc namespace in the "
+                "user local machine. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Kubectl_Get_Secrets_Fault_Type,
-                summary="Exception occured while storing azure arc secrets")
-            diagnoser_output.append("An exception has occured while storing azure arc secrets in the user local "
-                                    "machine. Exception: {}".format(str(e)) + "\n")
+                summary="Exception occured while storing azure arc secrets",
+            )
+            diagnoser_output.append(
+                "An exception has occured while storing azure arc secrets in the user local "
+                "machine. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while storing list of secrets in azure arc namespace in the user "
-                       "local machine. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while storing list of secrets in azure arc namespace in the user "
+            "local machine. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Kubectl_Get_Secrets_Fault_Type,
-            summary="Exception occured while storing azure arc secrets")
-        diagnoser_output.append("An exception has occured while storing azure arc secrets in the user local machine. "
-                                "Exception: {}".format(str(e)) + "\n")
+            summary="Exception occured while storing azure arc secrets",
+        )
+        diagnoser_output.append(
+            "An exception has occured while storing azure arc secrets in the user local machine. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return storage_space_available
 
 
-def get_helm_values_azure_arc(corev1_api_instance, helm_client_location, release_namespace, kube_config, kube_context,
-                              filepath_with_timestamp, storage_space_available):
-    print("Step: {}: Fetching helm values of azure-arc release".format(get_utctimestring()))
+def get_helm_values_azure_arc(
+    corev1_api_instance,
+    helm_client_location,
+    release_namespace,
+    kube_config,
+    kube_context,
+    filepath_with_timestamp,
+    storage_space_available,
+):
+    print(
+        "Step: {}: Fetching helm values of azure-arc release".format(
+            get_utctimestring()
+        )
+    )
     try:
         if storage_space_available:
-            command = [helm_client_location, "get", "values", "azure-arc", "-n", release_namespace, "--output", "json"]
+            command = [
+                helm_client_location,
+                "get",
+                "values",
+                "azure-arc",
+                "-n",
+                release_namespace,
+                "--output",
+                "json",
+            ]
             if kube_config:
                 command.extend(["--kubeconfig", kube_config])
             if kube_context:
                 command.extend(["--kube-context", kube_context])
             # Using Popen to execute the command and fetching the output
             response_kubectl_get_helmvalues = Popen(command, stdout=PIPE, stderr=PIPE)
-            output_kubectl_get_helmvalues, error_kubectl_get_helmvalues = response_kubectl_get_helmvalues.communicate()
+            output_kubectl_get_helmvalues, error_kubectl_get_helmvalues = (
+                response_kubectl_get_helmvalues.communicate()
+            )
             if response_kubectl_get_helmvalues.returncode != 0:
                 telemetry.set_exception(
                     exception=error_kubectl_get_helmvalues.decode("ascii"),
                     fault_type=consts.Helm_Values_Save_Failed_Fault_Type,
-                    summary='Error while doing helm get values for azure-arc release')
-                logger.warning("Error while doing helm get values for azure-arc release. We were not able to capture "
-                               "this log in arc_diganostic_logs folder. Exception: ",
-                               error_kubectl_get_helmvalues.decode("ascii"))
-                diagnoser_output.append("Error while doing helm get values for azure-arc release. We were not able "
-                                        "to capture this log in arc_diganostic_logs folder. Exception: " +
-                                        error_kubectl_get_helmvalues.decode("ascii"))
+                    summary="Error while doing helm get values for azure-arc release",
+                )
+                logger.warning(
+                    "Error while doing helm get values for azure-arc release. We were not able to capture "
+                    "this log in arc_diganostic_logs folder. Exception: ",
+                    error_kubectl_get_helmvalues.decode("ascii"),
+                )
+                diagnoser_output.append(
+                    "Error while doing helm get values for azure-arc release. We were not able "
+                    "to capture this log in arc_diganostic_logs folder. Exception: "
+                    + error_kubectl_get_helmvalues.decode("ascii")
+                )
                 return storage_space_available
 
             # Converting output obtained in json format
@@ -1465,25 +2127,27 @@ def get_helm_values_azure_arc(corev1_api_instance, helm_client_location, release
 
             # removing onboarding private key
             try:
-                if (helmvalues_json['global']['onboardingPrivateKey']):
-                    del helmvalues_json['global']['onboardingPrivateKey']
+                if helmvalues_json["global"]["onboardingPrivateKey"]:
+                    del helmvalues_json["global"]["onboardingPrivateKey"]
             except Exception:
                 pass
 
             # removing azure-rbac client id and client secret, if present
             try:
-                if (helmvalues_json['systemDefaultValues']['guard']['clientId']):
-                    del helmvalues_json['systemDefaultValues']['guard']['clientId']
-                if (helmvalues_json['systemDefaultValues']['guard']['clientSecret']):
-                    del helmvalues_json['systemDefaultValues']['guard']['clientSecret']
+                if helmvalues_json["systemDefaultValues"]["guard"]["clientId"]:
+                    del helmvalues_json["systemDefaultValues"]["guard"]["clientId"]
+                if helmvalues_json["systemDefaultValues"]["guard"]["clientSecret"]:
+                    del helmvalues_json["systemDefaultValues"]["guard"]["clientSecret"]
             except Exception:
                 pass
 
             helmvalues_json = yaml.dump(helmvalues_json)
             # Path to add the helm values of azure-arc release
-            helmvalues_logs_path = os.path.join(filepath_with_timestamp, "helm_values_azure_arc.txt")
+            helmvalues_logs_path = os.path.join(
+                filepath_with_timestamp, "helm_values_azure_arc.txt"
+            )
 
-            with open(helmvalues_logs_path, 'w') as helmvalues_log:
+            with open(helmvalues_logs_path, "w") as helmvalues_log:
                 helmvalues_log.write(helmvalues_json)
 
             return storage_space_available
@@ -1495,55 +2159,98 @@ def get_helm_values_azure_arc(corev1_api_instance, helm_client_location, release
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while storing helm values of azure-arc release in the user "
-                           "local machine. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while storing helm values of azure-arc release in the user "
+                "local machine. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Helm_Values_Save_Failed_Fault_Type,
-                summary="Exception occured while storing helm values of azure-arc release")
-            diagnoser_output.append("An exception has occured while storing helm values of azure-arc release in the "
-                                    "user local machine. Exception: {}".format(str(e)) + "\n")
+                summary="Exception occured while storing helm values of azure-arc release",
+            )
+            diagnoser_output.append(
+                "An exception has occured while storing helm values of azure-arc release in the "
+                "user local machine. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while storing helm values of azure-arc release in the user local "
-                       "machine. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while storing helm values of azure-arc release in the user local "
+            "machine. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Helm_Values_Save_Failed_Fault_Type,
-            summary="Exception occured while storing helm values of azure-arc release")
-        diagnoser_output.append("An exception has occured while storing helm values of azure-arc release in the user "
-                                "local machine. Exception: {}".format(str(e)) + "\n")
+            summary="Exception occured while storing helm values of azure-arc release",
+        )
+        diagnoser_output.append(
+            "An exception has occured while storing helm values of azure-arc release in the user "
+            "local machine. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return storage_space_available
 
-def get_helm_values_arc_workload_identity(corev1_api_instance, helm_client_location, release_namespace, kube_config, kube_context,
-                              filepath_with_timestamp, storage_space_available):
-    print("Step: {}: Fetching helm values of wiextension release".format(get_utctimestring()))
+
+def get_helm_values_arc_workload_identity(
+    corev1_api_instance,
+    helm_client_location,
+    release_namespace,
+    kube_config,
+    kube_context,
+    filepath_with_timestamp,
+    storage_space_available,
+):
+    print(
+        "Step: {}: Fetching helm values of wiextension release".format(
+            get_utctimestring()
+        )
+    )
     try:
         if storage_space_available:
-            command = [helm_client_location, "get", "values", consts.Workload_Identity_Release_Name, "-n", consts.Workload_Identity_Release_Namespace, "--output", "json"]
+            command = [
+                helm_client_location,
+                "get",
+                "values",
+                consts.Workload_Identity_Release_Name,
+                "-n",
+                consts.Workload_Identity_Release_Namespace,
+                "--output",
+                "json",
+            ]
             if kube_config:
                 command.extend(["--kubeconfig", kube_config])
             if kube_context:
                 command.extend(["--kube-context", kube_context])
             # Using Popen to execute the command and fetching the output
             response_kubectl_get_helmvalues = Popen(command, stdout=PIPE, stderr=PIPE)
-            output_kubectl_get_helmvalues, error_kubectl_get_helmvalues = response_kubectl_get_helmvalues.communicate()
+            output_kubectl_get_helmvalues, error_kubectl_get_helmvalues = (
+                response_kubectl_get_helmvalues.communicate()
+            )
             if response_kubectl_get_helmvalues.returncode != 0:
                 telemetry.set_exception(
                     exception=error_kubectl_get_helmvalues.decode("ascii"),
                     fault_type=consts.Wiextension_Helm_Values_Save_Failed_Fault_Type,
-                    summary='Error while doing helm get values for wiextension release')
-                logger.warning("Error while doing helm get values for wiextension release. We were not able to capture "
-                               "this log in arc_diganostic_logs folder. Exception: ",
-                               error_kubectl_get_helmvalues.decode("ascii"))
-                diagnoser_output.append("Error while doing helm get values for wiextension release. We were not able "
-                                        "to capture this log in arc_diganostic_logs folder. Exception: " +
-                                        error_kubectl_get_helmvalues.decode("ascii"))
+                    summary="Error while doing helm get values for wiextension release",
+                )
+                logger.warning(
+                    "Error while doing helm get values for wiextension release. We were not able to capture "
+                    "this log in arc_diganostic_logs folder. Exception: ",
+                    error_kubectl_get_helmvalues.decode("ascii"),
+                )
+                diagnoser_output.append(
+                    "Error while doing helm get values for wiextension release. We were not able "
+                    "to capture this log in arc_diganostic_logs folder. Exception: "
+                    + error_kubectl_get_helmvalues.decode("ascii")
+                )
                 return storage_space_available
 
             # Converting output obtained in json format
@@ -1552,9 +2259,11 @@ def get_helm_values_arc_workload_identity(corev1_api_instance, helm_client_locat
 
             helmvalues_json = yaml.dump(helmvalues_json)
             # Path to add the helm values of wiextension release
-            helmvalues_logs_path = os.path.join(filepath_with_timestamp, consts.Wiextension_Helm_Values)
+            helmvalues_logs_path = os.path.join(
+                filepath_with_timestamp, consts.Wiextension_Helm_Values
+            )
 
-            with open(helmvalues_logs_path, 'w') as helmvalues_log:
+            with open(helmvalues_logs_path, "w") as helmvalues_log:
                 helmvalues_log.write(helmvalues_json)
 
             return storage_space_available
@@ -1566,66 +2275,100 @@ def get_helm_values_arc_workload_identity(corev1_api_instance, helm_client_locat
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while storing helm values of wiextension release in the user "
-                           "local machine. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while storing helm values of wiextension release in the user "
+                "local machine. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Wiextension_Helm_Values_Save_Failed_Fault_Type,
-                summary="Exception occured while storing helm values of wiextension release")
-            diagnoser_output.append("An exception has occured while storing helm values of wiextension release in the "
-                                    "user local machine. Exception: {}".format(str(e)) + "\n")
+                summary="Exception occured while storing helm values of wiextension release",
+            )
+            diagnoser_output.append(
+                "An exception has occured while storing helm values of wiextension release in the "
+                "user local machine. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while storing helm values of wiextension release in the user local "
-                       "machine. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while storing helm values of wiextension release in the user local "
+            "machine. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Wiextension_Helm_Values_Save_Failed_Fault_Type,
-            summary="Exception occured while storing helm values of wiextension release")
-        diagnoser_output.append("An exception has occured while storing helm values of wiextension release in the user "
-                                "local machine. Exception: {}".format(str(e)) + "\n")
+            summary="Exception occured while storing helm values of wiextension release",
+        )
+        diagnoser_output.append(
+            "An exception has occured while storing helm values of wiextension release in the user "
+            "local machine. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return storage_space_available
 
 
-def get_metadata_cr_snapshot(corev1_api_instance, kubectl_client_location, kube_config, kube_context,
-                             filepath_with_timestamp, storage_space_available):
+def get_metadata_cr_snapshot(
+    corev1_api_instance,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+    filepath_with_timestamp,
+    storage_space_available,
+):
     print("Step: {}: Fetching metadata CR details".format(get_utctimestring()))
     try:
         if storage_space_available:
-            command = [kubectl_client_location, "describe", "connectedclusters.arc.azure.com/clustermetadata", "-n",
-                       "azure-arc"]
+            command = [
+                kubectl_client_location,
+                "describe",
+                "connectedclusters.arc.azure.com/clustermetadata",
+                "-n",
+                "azure-arc",
+            ]
             if kube_config:
                 command.extend(["--kubeconfig", kube_config])
             if kube_context:
                 command.extend(["--context", kube_context])
             # Using Popen to execute the command and fetching the output
             response_kubectl_get_metadata_cr = Popen(command, stdout=PIPE, stderr=PIPE)
-            output_kubectl_get_metadata_cr, error_kubectl_get_metadata_cr = \
+            output_kubectl_get_metadata_cr, error_kubectl_get_metadata_cr = (
                 response_kubectl_get_metadata_cr.communicate()
+            )
             if response_kubectl_get_metadata_cr.returncode != 0:
                 telemetry.set_exception(
                     exception=error_kubectl_get_metadata_cr.decode("ascii"),
                     fault_type=consts.Metadata_CR_Save_Failed_Fault_Type,
-                    summary='Error occured while fetching metadata CR details')
-                logger.warning("Error while doing kubectl describe for clustermetadata CR. We were not able to "
-                               "capture this log in arc_diganostic_logs folder. Exception: ",
-                               error_kubectl_get_metadata_cr.decode("ascii"))
-                diagnoser_output.append("Error occured while fetching metadata CR details. We were not able to "
-                                        "capture this log in arc_diganostic_logs folder. Exception: " +
-                                        error_kubectl_get_metadata_cr.decode("ascii"))
+                    summary="Error occured while fetching metadata CR details",
+                )
+                logger.warning(
+                    "Error while doing kubectl describe for clustermetadata CR. We were not able to "
+                    "capture this log in arc_diganostic_logs folder. Exception: ",
+                    error_kubectl_get_metadata_cr.decode("ascii"),
+                )
+                diagnoser_output.append(
+                    "Error occured while fetching metadata CR details. We were not able to "
+                    "capture this log in arc_diganostic_logs folder. Exception: "
+                    + error_kubectl_get_metadata_cr.decode("ascii")
+                )
                 return storage_space_available
 
             # Converting output obtained in json format
             metadata_cr_json = output_kubectl_get_metadata_cr.decode()
             # Path to add the metadata CR details
-            metadata_cr_logs_path = os.path.join(filepath_with_timestamp, "metadata_cr_snapshot.txt")
+            metadata_cr_logs_path = os.path.join(
+                filepath_with_timestamp, "metadata_cr_snapshot.txt"
+            )
 
-            with open(metadata_cr_logs_path, 'w+') as metadata_cr_log:
+            with open(metadata_cr_logs_path, "w+") as metadata_cr_log:
                 metadata_cr_log.write(metadata_cr_json)
 
             return storage_space_available
@@ -1637,65 +2380,100 @@ def get_metadata_cr_snapshot(corev1_api_instance, kubectl_client_location, kube_
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while storing metadata CR details in the user local machine. "
-                           "Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while storing metadata CR details in the user local machine. "
+                "Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Metadata_CR_Save_Failed_Fault_Type,
-                summary="Error occured while storing metadata CR details")
-            diagnoser_output.append("An exception has occured while storing metadata CR details in the user local "
-                                    "machine. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured while storing metadata CR details",
+            )
+            diagnoser_output.append(
+                "An exception has occured while storing metadata CR details in the user local "
+                "machine. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while storing metadata CR details in the user local machine. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while storing metadata CR details in the user local machine. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Metadata_CR_Save_Failed_Fault_Type,
-            summary="Error occured while storing metadata CR details")
-        diagnoser_output.append("An exception has occured while storing metadata CR details in the user local "
-                                "machine. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured while storing metadata CR details",
+        )
+        diagnoser_output.append(
+            "An exception has occured while storing metadata CR details in the user local "
+            "machine. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return storage_space_available
 
 
-def get_kubeaadproxy_cr_snapshot(corev1_api_instance, kubectl_client_location, kube_config, kube_context,
-                                 filepath_with_timestamp, storage_space_available):
+def get_kubeaadproxy_cr_snapshot(
+    corev1_api_instance,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+    filepath_with_timestamp,
+    storage_space_available,
+):
     print("Step: {}: Fetching kube-aad-proxy CR details".format(get_utctimestring()))
     try:
         if storage_space_available:
-            command = [kubectl_client_location, "describe", "arccertificates.clusterconfig.azure.com/kube-aad-proxy",
-                       "-n", "azure-arc"]
+            command = [
+                kubectl_client_location,
+                "describe",
+                "arccertificates.clusterconfig.azure.com/kube-aad-proxy",
+                "-n",
+                "azure-arc",
+            ]
             if kube_config:
                 command.extend(["--kubeconfig", kube_config])
             if kube_context:
                 command.extend(["--context", kube_context])
             # Using Popen to execute the command and fetching the output
             response_kubectl_get_kap_cr = Popen(command, stdout=PIPE, stderr=PIPE)
-            output_kubectl_get_kap_cr, error_kubectl_get_kap_cr = response_kubectl_get_kap_cr.communicate()
+            output_kubectl_get_kap_cr, error_kubectl_get_kap_cr = (
+                response_kubectl_get_kap_cr.communicate()
+            )
             if response_kubectl_get_kap_cr.returncode != 0:
                 telemetry.set_exception(
                     exception=error_kubectl_get_kap_cr.decode("ascii"),
                     fault_type=consts.KAP_CR_Save_Failed_Fault_Type,
-                    summary='Error occured while fetching KAP CR details')
-                logger.warning("Error while doing kubectl describe for kube-aad-proxy CR. We were not able to "
-                               "capture this log in arc_diagnostic_logs folder. Exception: ",
-                               error_kubectl_get_kap_cr.decode("ascii"))
-                diagnoser_output.append("Error occured while fetching kube-aad-proxy CR details. We were not able to "
-                                        "capture this log in arc_diagnostic_logs folder. Exception: " +
-                                        error_kubectl_get_kap_cr.decode("ascii"))
+                    summary="Error occured while fetching KAP CR details",
+                )
+                logger.warning(
+                    "Error while doing kubectl describe for kube-aad-proxy CR. We were not able to "
+                    "capture this log in arc_diagnostic_logs folder. Exception: ",
+                    error_kubectl_get_kap_cr.decode("ascii"),
+                )
+                diagnoser_output.append(
+                    "Error occured while fetching kube-aad-proxy CR details. We were not able to "
+                    "capture this log in arc_diagnostic_logs folder. Exception: "
+                    + error_kubectl_get_kap_cr.decode("ascii")
+                )
                 return storage_space_available
 
             # Converting output obtained in json format
             kap_cr_json = output_kubectl_get_kap_cr.decode()
             # Path to add the kube-aad-proxy CR details
-            kap_cr_logs_path = os.path.join(filepath_with_timestamp, "kube_aad_proxy_cr_snapshot.txt")
+            kap_cr_logs_path = os.path.join(
+                filepath_with_timestamp, "kube_aad_proxy_cr_snapshot.txt"
+            )
 
-            with open(kap_cr_logs_path, 'w+') as kap_cr_log:
+            with open(kap_cr_logs_path, "w+") as kap_cr_log:
                 kap_cr_log.write(kap_cr_json)
 
             return storage_space_available
@@ -1707,65 +2485,102 @@ def get_kubeaadproxy_cr_snapshot(corev1_api_instance, kubectl_client_location, k
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while storing kube-aad-proxy CR details in the user local "
-                           "machine. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while storing kube-aad-proxy CR details in the user local "
+                "machine. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_KAP_CR_Save_Failed_Fault_Type,
-                summary="Exception occured while storing kube-aad-proxy CR details")
-            diagnoser_output.append("An exception has occured while storing kube-aad-proxy CR details in the user "
-                                    "local machine. Exception: {}".format(str(e)) + "\n")
+                summary="Exception occured while storing kube-aad-proxy CR details",
+            )
+            diagnoser_output.append(
+                "An exception has occured while storing kube-aad-proxy CR details in the user "
+                "local machine. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while storing kube-aad-proxy CR details in the user local machine. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while storing kube-aad-proxy CR details in the user local machine. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_KAP_CR_Save_Failed_Fault_Type,
-            summary="Exception occured while storing kube-aad-proxy CR details")
-        diagnoser_output.append("An exception has occured while storing kube-aad-proxy CR details in the user local "
-                                "machine. Exception: {}".format(str(e)) + "\n")
+            summary="Exception occured while storing kube-aad-proxy CR details",
+        )
+        diagnoser_output.append(
+            "An exception has occured while storing kube-aad-proxy CR details in the user local "
+            "machine. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return storage_space_available
 
-def get_signingkey_cr_snapshot(corev1_api_instance, kubectl_client_location, kube_config, kube_context,
-                             filepath_with_timestamp, storage_space_available):
+
+def get_signingkey_cr_snapshot(
+    corev1_api_instance,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+    filepath_with_timestamp,
+    storage_space_available,
+):
     print("Step: {}: Fetching signingkey CR details".format(get_utctimestring()))
     try:
         if storage_space_available:
-            command = [kubectl_client_location, "describe", "signingkeys.clusterconfig.azure.com/signingkey", "-n",
-                       "azure-arc"]
+            command = [
+                kubectl_client_location,
+                "describe",
+                "signingkeys.clusterconfig.azure.com/signingkey",
+                "-n",
+                "azure-arc",
+            ]
             if kube_config:
                 command.extend(["--kubeconfig", kube_config])
             if kube_context:
                 command.extend(["--context", kube_context])
             # Using Popen to execute the command and fetching the output
-            response_kubectl_get_signingkey_cr = Popen(command, stdout=PIPE, stderr=PIPE)
-            output_kubectl_get_signingkey_cr, error_kubectl_get_signingkey_cr = \
+            response_kubectl_get_signingkey_cr = Popen(
+                command, stdout=PIPE, stderr=PIPE
+            )
+            output_kubectl_get_signingkey_cr, error_kubectl_get_signingkey_cr = (
                 response_kubectl_get_signingkey_cr.communicate()
+            )
             if response_kubectl_get_signingkey_cr.returncode != 0:
                 telemetry.set_exception(
                     exception=error_kubectl_get_signingkey_cr.decode("ascii"),
                     fault_type=consts.Signingkey_CR_Save_Failed_Fault_Type,
-                    summary='Error occured while fetching signingkey CR details')
-                logger.warning("Error while doing kubectl describe for signingkey CR. We were not able to "
-                               "capture this log in arc_diganostic_logs folder. Exception: ",
-                               error_kubectl_get_signingkey_cr.decode("ascii"))
-                diagnoser_output.append("Error occured while fetching signingkey CR details. We were not able to "
-                                        "capture this log in arc_diganostic_logs folder. Exception: " +
-                                        error_kubectl_get_signingkey_cr.decode("ascii"))
+                    summary="Error occured while fetching signingkey CR details",
+                )
+                logger.warning(
+                    "Error while doing kubectl describe for signingkey CR. We were not able to "
+                    "capture this log in arc_diganostic_logs folder. Exception: ",
+                    error_kubectl_get_signingkey_cr.decode("ascii"),
+                )
+                diagnoser_output.append(
+                    "Error occured while fetching signingkey CR details. We were not able to "
+                    "capture this log in arc_diganostic_logs folder. Exception: "
+                    + error_kubectl_get_signingkey_cr.decode("ascii")
+                )
                 return storage_space_available
 
             # Converting output obtained in json format
             signingkey_cr_json = output_kubectl_get_signingkey_cr.decode()
             # Path to add the signingkey CR details
-            signingkey_cr_logs_path = os.path.join(filepath_with_timestamp, consts.SigningKey_CR_Snapshot)
+            signingkey_cr_logs_path = os.path.join(
+                filepath_with_timestamp, consts.SigningKey_CR_Snapshot
+            )
 
-            with open(signingkey_cr_logs_path, 'w+') as signingkey_cr_log:
+            with open(signingkey_cr_logs_path, "w+") as signingkey_cr_log:
                 signingkey_cr_log.write(signingkey_cr_json)
 
             return storage_space_available
@@ -1777,28 +2592,43 @@ def get_signingkey_cr_snapshot(corev1_api_instance, kubectl_client_location, kub
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while storing signingkey CR details in the user local machine. "
-                           "Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while storing signingkey CR details in the user local machine. "
+                "Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Fetch_Signingkey_CR_Save_Failed_Fault_Type,
-                summary="Error occured while storing signingkey CR details")
-            diagnoser_output.append("An exception has occured while storing signingkey CR details in the user local "
-                                    "machine. Exception: {}".format(str(e)) + "\n")
+                summary="Error occured while storing signingkey CR details",
+            )
+            diagnoser_output.append(
+                "An exception has occured while storing signingkey CR details in the user local "
+                "machine. Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while storing signingkey CR details in the user local machine. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while storing signingkey CR details in the user local machine. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Fetch_Signingkey_CR_Save_Failed_Fault_Type,
-            summary="Error occured while storing signingkey CR details")
-        diagnoser_output.append("An exception has occured while storing signingkey CR details in the user local "
-                                "machine. Exception: {}".format(str(e)) + "\n")
+            summary="Error occured while storing signingkey CR details",
+        )
+        diagnoser_output.append(
+            "An exception has occured while storing signingkey CR details in the user local "
+            "machine. Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return storage_space_available
 
@@ -1812,10 +2642,12 @@ def fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, f
         # If storage space is available then only we store the output
         if storage_space_available:
             # Path to store the diagnoser results
-            cli_output_logger_path = os.path.join(filepath_with_timestamp, consts.Diagnoser_Results)
+            cli_output_logger_path = os.path.join(
+                filepath_with_timestamp, consts.Diagnoser_Results
+            )
             # If any results are obtained during the process than we will add it to the text file.
             if len(diagnoser_output) > 0:
-                with open(cli_output_logger_path, 'w+') as cli_output_writer:
+                with open(cli_output_logger_path, "w+") as cli_output_writer:
                     for output in diagnoser_output:
                         cli_output_writer.write(output + "\n")
                     # If flag is 0 that means that process was terminated using the Keyboard Interrupt so adding that
@@ -1825,11 +2657,13 @@ def fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, f
 
             # If no issues was found during the whole troubleshoot execution
             elif flag:
-                with open(cli_output_logger_path, 'w+') as cli_output_writer:
-                    cli_output_writer.write("The diagnoser didn't find any issues on the cluster.\n")
+                with open(cli_output_logger_path, "w+") as cli_output_writer:
+                    cli_output_writer.write(
+                        "The diagnoser didn't find any issues on the cluster.\n"
+                    )
             # If process was terminated by user
             else:
-                with open(cli_output_logger_path, 'w+') as cli_output_writer:
+                with open(cli_output_logger_path, "w+") as cli_output_writer:
                     cli_output_writer.write("Process terminated externally.\n")
 
         return consts.Diagnostic_Check_Passed
@@ -1841,16 +2675,21 @@ def fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, f
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while trying to store the diagnoser results. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while trying to store the diagnoser results. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Diagnoser_Result_Fault_Type,
-            summary="Error while storing the diagnoser results")
+            summary="Error while storing the diagnoser results",
+        )
 
     return consts.Diagnostic_Check_Failed

--- a/src/connectedk8s/azext_connectedk8s/_troubleshootutils.py
+++ b/src/connectedk8s/azext_connectedk8s/_troubleshootutils.py
@@ -60,8 +60,8 @@ def fetch_kubectl_cluster_info(
                 )
                 diagnoser_output.append(
                     "Error while doing 'kubectl cluster-info'. We were not able to capture "
-                    "cluster-info logs in arc_diganostic_logs folder. Exception: ",
-                    error_cluster_info.decode("ascii"),
+                    "cluster-info logs in arc_diganostic_logs folder. Exception: "
+                    + error_cluster_info.decode("ascii"),
                 )
                 return consts.Diagnostic_Check_Failed, storage_space_available
             output_cluster_info_decoded = output_cluster_info.decode()
@@ -357,8 +357,8 @@ def retrieve_arc_agents_event_logs(
                 )
                 diagnoser_output.append(
                     "Error while doing kubectl get events. We were not able to capture events "
-                    "log in arc_diganostic_logs folder. Exception: ",
-                    error_kubectl_get_events.decode("ascii"),
+                    "log in arc_diganostic_logs folder. Exception: "
+                    + error_kubectl_get_events.decode("ascii"),
                 )
                 return consts.Diagnostic_Check_Failed, storage_space_available
 
@@ -654,8 +654,8 @@ def retrieve_arc_workload_identity_event_logs(
                 )
                 diagnoser_output.append(
                     "Error while doing kubectl get events for arc-workload-identity namespace. "
-                    "We were not able to capture events log in arc_diganostic_logs folder. Exception: ",
-                    error_kubectl_get_events.decode("ascii"),
+                    "We were not able to capture events log in arc_diganostic_logs folder. Exception: "
+                    + error_kubectl_get_events.decode("ascii"),
                 )
                 return consts.Diagnostic_Check_Failed, storage_space_available
 
@@ -1074,13 +1074,13 @@ def check_agent_version(connected_cluster, azure_arc_agent_version):
             logger.warning(
                 "We found that you are on an older agent version that is not supported.\n Please visit this link to "
                 " know the agent version support policy '"
-                + consts.Agent_Version_Support_Policy_Link
+                + consts.Doc_Agent_Version_Support_Policy_Url
                 + "'.\n"
             )
             diagnoser_output.append(
                 "We found that you are on an older agent version that is not supported.\n Please visit this link to "
                 "know the agent version support policy '"
-                + consts.Agent_Version_Support_Policy_Link
+                + consts.Doc_Agent_Version_Support_Policy_Url
                 + "'.\n"
             )
             return consts.Diagnostic_Check_Failed
@@ -1394,7 +1394,7 @@ def executing_diagnoser_job(
             response_kubectl_delete_job.communicate()
         )
         # If any error occured while execution of delete command
-        if response_kubectl_delete_job != 0:
+        if response_kubectl_delete_job.returncode != 0:
             # Converting the string of multiple errors to list
             error_msg_list = error_kubectl_delete_job.decode("ascii").split("\n")
             error_msg_list.pop(-1)
@@ -1564,13 +1564,10 @@ def executing_diagnoser_job(
                             )
                             diagnoser_output.append(
                                 "Error while doing kubectl get events. We were not able to "
-                                "capture events log in arc_diganostic_logs folder. Exception: ",
-                                error_kubectl_get_events.decode("ascii"),
+                                "capture events log in arc_diganostic_logs folder. Exception: "
+                                + error_kubectl_get_events.decode("ascii"),
                             )
-                            return (
-                                consts.Diagnostic_Check_Failed,
-                                storage_space_available,
-                            )
+                            return None
                         # Converting output obtained in json format and fetching the clusterconnect-agent feature
                         events_json = json.loads(output_kubectl_get_events)
                         if len(events_json["items"]) != 0:

--- a/src/connectedk8s/azext_connectedk8s/_troubleshootutils.py
+++ b/src/connectedk8s/azext_connectedk8s/_troubleshootutils.py
@@ -60,7 +60,7 @@ def fetch_kubectl_cluster_info(
                 )
                 diagnoser_output.append(
                     "Error while doing 'kubectl cluster-info'. We were not able to capture "
-                    "cluster-info logs in arc_diganostic_logs folder. Exception: "
+                    "cluster-info logs in arc_diagnostic_logs folder. Exception: "
                     + error_cluster_info.decode("ascii"),
                 )
                 return consts.Diagnostic_Check_Failed, storage_space_available
@@ -352,12 +352,12 @@ def retrieve_arc_agents_event_logs(
                 )
                 logger.warning(
                     "Error while doing kubectl get events. We were not able to capture events log in "
-                    "arc_diganostic_logs folder. Exception: ",
+                    "arc_diagnostic_logs folder. Exception: ",
                     error_kubectl_get_events.decode("ascii"),
                 )
                 diagnoser_output.append(
                     "Error while doing kubectl get events. We were not able to capture events "
-                    "log in arc_diganostic_logs folder. Exception: "
+                    "log in arc_diagnostic_logs folder. Exception: "
                     + error_kubectl_get_events.decode("ascii"),
                 )
                 return consts.Diagnostic_Check_Failed, storage_space_available
@@ -649,12 +649,12 @@ def retrieve_arc_workload_identity_event_logs(
                 )
                 logger.warning(
                     "Error while doing kubectl get events for arc-workload-identity namespace. "
-                    "We were not able to capture events log in arc_diganostic_logs folder. Exception: ",
+                    "We were not able to capture events log in arc_diagnostic_logs folder. Exception: ",
                     error_kubectl_get_events.decode("ascii"),
                 )
                 diagnoser_output.append(
                     "Error while doing kubectl get events for arc-workload-identity namespace. "
-                    "We were not able to capture events log in arc_diganostic_logs folder. Exception: "
+                    "We were not able to capture events log in arc_diagnostic_logs folder. Exception: "
                     + error_kubectl_get_events.decode("ascii"),
                 )
                 return consts.Diagnostic_Check_Failed, storage_space_available
@@ -1559,12 +1559,12 @@ def executing_diagnoser_job(
                             )
                             logger.warning(
                                 "Error while doing kubectl get events. We were not able to capture events "
-                                "log in arc_diganostic_logs folder. Exception: ",
+                                "log in arc_diagnostic_logs folder. Exception: ",
                                 error_kubectl_get_events.decode("ascii"),
                             )
                             diagnoser_output.append(
                                 "Error while doing kubectl get events. We were not able to "
-                                "capture events log in arc_diganostic_logs folder. Exception: "
+                                "capture events log in arc_diagnostic_logs folder. Exception: "
                                 + error_kubectl_get_events.decode("ascii"),
                             )
                             return None
@@ -1992,12 +1992,12 @@ def get_secrets_azure_arc(
                 )
                 logger.warning(
                     "Error while doing kubectl get secrets for azure-arc namespace. We were not able to "
-                    "capture this log in arc_diganostic_logs folder. Exception: ",
+                    "capture this log in arc_diagnostic_logs folder. Exception: ",
                     error_kubectl_get_secrets.decode("ascii"),
                 )
                 diagnoser_output.append(
                     "Error while doing kubectl get secrets in azure-arc namespace. We were not "
-                    "able to capture this log in arc_diganostic_logs folder. Exception: "
+                    "able to capture this log in arc_diagnostic_logs folder. Exception: "
                     + error_kubectl_get_secrets.decode("ascii")
                 )
                 return storage_space_available
@@ -2105,12 +2105,12 @@ def get_helm_values_azure_arc(
                 )
                 logger.warning(
                     "Error while doing helm get values for azure-arc release. We were not able to capture "
-                    "this log in arc_diganostic_logs folder. Exception: ",
+                    "this log in arc_diagnostic_logs folder. Exception: ",
                     error_kubectl_get_helmvalues.decode("ascii"),
                 )
                 diagnoser_output.append(
                     "Error while doing helm get values for azure-arc release. We were not able "
-                    "to capture this log in arc_diganostic_logs folder. Exception: "
+                    "to capture this log in arc_diagnostic_logs folder. Exception: "
                     + error_kubectl_get_helmvalues.decode("ascii")
                 )
                 return storage_space_available
@@ -2237,12 +2237,12 @@ def get_helm_values_arc_workload_identity(
                 )
                 logger.warning(
                     "Error while doing helm get values for wiextension release. We were not able to capture "
-                    "this log in arc_diganostic_logs folder. Exception: ",
+                    "this log in arc_diagnostic_logs folder. Exception: ",
                     error_kubectl_get_helmvalues.decode("ascii"),
                 )
                 diagnoser_output.append(
                     "Error while doing helm get values for wiextension release. We were not able "
-                    "to capture this log in arc_diganostic_logs folder. Exception: "
+                    "to capture this log in arc_diagnostic_logs folder. Exception: "
                     + error_kubectl_get_helmvalues.decode("ascii")
                 )
                 return storage_space_available
@@ -2345,12 +2345,12 @@ def get_metadata_cr_snapshot(
                 )
                 logger.warning(
                     "Error while doing kubectl describe for clustermetadata CR. We were not able to "
-                    "capture this log in arc_diganostic_logs folder. Exception: ",
+                    "capture this log in arc_diagnostic_logs folder. Exception: ",
                     error_kubectl_get_metadata_cr.decode("ascii"),
                 )
                 diagnoser_output.append(
                     "Error occured while fetching metadata CR details. We were not able to "
-                    "capture this log in arc_diganostic_logs folder. Exception: "
+                    "capture this log in arc_diagnostic_logs folder. Exception: "
                     + error_kubectl_get_metadata_cr.decode("ascii")
                 )
                 return storage_space_available
@@ -2557,12 +2557,12 @@ def get_signingkey_cr_snapshot(
                 )
                 logger.warning(
                     "Error while doing kubectl describe for signingkey CR. We were not able to "
-                    "capture this log in arc_diganostic_logs folder. Exception: ",
+                    "capture this log in arc_diagnostic_logs folder. Exception: ",
                     error_kubectl_get_signingkey_cr.decode("ascii"),
                 )
                 diagnoser_output.append(
                     "Error occured while fetching signingkey CR details. We were not able to "
-                    "capture this log in arc_diganostic_logs folder. Exception: "
+                    "capture this log in arc_diagnostic_logs folder. Exception: "
                     + error_kubectl_get_signingkey_cr.decode("ascii")
                 )
                 return storage_space_available

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -23,12 +23,22 @@ from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 from msrest.exceptions import AuthenticationError, HttpOperationError, TokenExpiredError
 from msrest.exceptions import ValidationError as MSRestValidationError
 from kubernetes.client.rest import ApiException
-from azext_connectedk8s._client_factory import resource_providers_client, cf_resource_groups
+from azext_connectedk8s._client_factory import (
+    resource_providers_client,
+    cf_resource_groups,
+)
 import azext_connectedk8s._constants as consts
 from kubernetes import client as kube_client
 from azure.cli.core import get_default_cli
-from azure.cli.core.azclierror import CLIInternalError, ClientRequestError, ArgumentUsageError, ManualInterrupt, \
-    AzureResponseError, AzureInternalError, ValidationError
+from azure.cli.core.azclierror import (
+    CLIInternalError,
+    ClientRequestError,
+    ArgumentUsageError,
+    ManualInterrupt,
+    AzureResponseError,
+    AzureInternalError,
+    ValidationError,
+)
 
 logger = get_logger(__name__)
 
@@ -52,215 +62,337 @@ class TimeoutHTTPAdapter(HTTPAdapter):
 
 
 def validate_connect_rp_location(cmd, location):
-    subscription_id = os.getenv('AZURE_SUBSCRIPTION_ID') \
-        if os.getenv('AZURE_ACCESS_TOKEN') else get_subscription_id(cmd.cli_ctx)
+    subscription_id = (
+        os.getenv("AZURE_SUBSCRIPTION_ID")
+        if os.getenv("AZURE_ACCESS_TOKEN")
+        else get_subscription_id(cmd.cli_ctx)
+    )
     rp_locations = []
-    resourceClient = resource_providers_client(cmd.cli_ctx, subscription_id=subscription_id)
+    resourceClient = resource_providers_client(
+        cmd.cli_ctx, subscription_id=subscription_id
+    )
     try:
-        providerDetails = resourceClient.get('Microsoft.Kubernetes')
+        providerDetails = resourceClient.get("Microsoft.Kubernetes")
     except Exception as e:  # pylint: disable=broad-except
-        arm_exception_handler(e, consts.Get_ResourceProvider_Fault_Type, 'Failed to fetch resource provider details')
+        arm_exception_handler(
+            e,
+            consts.Get_ResourceProvider_Fault_Type,
+            "Failed to fetch resource provider details",
+        )
 
     for resourceTypes in providerDetails.resource_types:
-        if resourceTypes.resource_type == 'connectedClusters':
-            rp_locations = [location.replace(" ", "").lower() for location in resourceTypes.locations]
+        if resourceTypes.resource_type == "connectedClusters":
+            rp_locations = [
+                location.replace(" ", "").lower()
+                for location in resourceTypes.locations
+            ]
             if location.lower() not in rp_locations:
                 telemetry.set_exception(
-                    exception='Location not supported',
+                    exception="Location not supported",
                     fault_type=consts.Invalid_Location_Fault_Type,
-                    summary='Provided location is not supported for creating connected clusters')
+                    summary="Provided location is not supported for creating connected clusters",
+                )
                 raise ArgumentUsageError(
-                    "Connected cluster resource creation is supported only in the following locations: " +
-                    ', '.join(map(str, rp_locations)),
-                    recommendation="Use the --location flag to specify one of these locations.")
+                    "Connected cluster resource creation is supported only in the following locations: "
+                    + ", ".join(map(str, rp_locations)),
+                    recommendation="Use the --location flag to specify one of these locations.",
+                )
             break
 
 
 def validate_custom_token(cmd, resource_group_name, location):
     print("Step: {}: Validating custom access token".format(get_utctimestring()))
-    if os.getenv('AZURE_ACCESS_TOKEN'):
-        if os.getenv('AZURE_SUBSCRIPTION_ID') is None:
+    if os.getenv("AZURE_ACCESS_TOKEN"):
+        if os.getenv("AZURE_SUBSCRIPTION_ID") is None:
             telemetry.set_exception(
-                exception='Required environment variable SubscriptionId not set, for custom Azure access token',
+                exception="Required environment variable SubscriptionId not set, for custom Azure access token",
                 fault_type=consts.Custom_Access_Token_Env_Var_Sub_Id_Missing_Fault_Type,
-                summary='Required environment variable SubscriptionId not set, for custom Azure access token')
+                summary="Required environment variable SubscriptionId not set, for custom Azure access token",
+            )
             raise ValidationError(
-                "Environment variable 'AZURE_SUBSCRIPTION_ID' should be set when custom access token is enabled.")
-        if os.getenv('AZURE_TENANT_ID') is None:
+                "Environment variable 'AZURE_SUBSCRIPTION_ID' should be set when custom access token is enabled."
+            )
+        if os.getenv("AZURE_TENANT_ID") is None:
             telemetry.set_exception(
-                exception='Required environment variable TenantId not set, for custom Azure access token',
+                exception="Required environment variable TenantId not set, for custom Azure access token",
                 fault_type=consts.Custom_Access_Token_Env_Var_Tenant_Id_Missing_Fault_Type,
-                summary='Required environment variable TenantId not set, for custom Azure access token')
+                summary="Required environment variable TenantId not set, for custom Azure access token",
+            )
             raise ValidationError(
-                "Environment variable 'AZURE_TENANT_ID' should be set when custom access token is enabled.")
+                "Environment variable 'AZURE_TENANT_ID' should be set when custom access token is enabled."
+            )
         if location is None:
             try:
-                resource_client = cf_resource_groups(cmd.cli_ctx, os.getenv('AZURE_SUBSCRIPTION_ID'))
+                resource_client = cf_resource_groups(
+                    cmd.cli_ctx, os.getenv("AZURE_SUBSCRIPTION_ID")
+                )
                 rg = resource_client.get(resource_group_name)
                 location = rg.location
             except Exception as ex:
-                telemetry.set_exception(exception=ex, fault_type=consts.Location_Fetch_Fault_Type,
-                                        summary='Unable to fetch location from resource group')
-                raise ValidationError("Unable to fetch location from resource group: '{}'".format(str(ex)))
+                telemetry.set_exception(
+                    exception=ex,
+                    fault_type=consts.Location_Fetch_Fault_Type,
+                    summary="Unable to fetch location from resource group",
+                )
+                raise ValidationError(
+                    "Unable to fetch location from resource group: '{}'".format(str(ex))
+                )
         return True, location
     return False, location
 
 
-def get_chart_path(registry_path, kube_config, kube_context, helm_client_location, chart_folder_name='AzureArcCharts',
-                   chart_name='azure-arc-k8sagents', new_path=True):
+def get_chart_path(
+    registry_path,
+    kube_config,
+    kube_context,
+    helm_client_location,
+    chart_folder_name="AzureArcCharts",
+    chart_name="azure-arc-k8sagents",
+    new_path=True,
+):
     print("Step: {}: Determine Helmchart Export Path".format(get_utctimestring()))
     # Exporting Helm chart
-    chart_export_path = os.path.join(os.path.expanduser('~'), '.azure', chart_folder_name)
+    chart_export_path = os.path.join(
+        os.path.expanduser("~"), ".azure", chart_folder_name
+    )
     try:
         if os.path.isdir(chart_export_path):
             shutil.rmtree(chart_export_path)
     except:
-        logger.warning("Unable to cleanup the {} already present on the machine. In case of failure, please cleanup "
-                       "the directory '{}' and try again.".format(chart_folder_name, chart_export_path))
+        logger.warning(
+            "Unable to cleanup the {} already present on the machine. In case of failure, please cleanup "
+            "the directory '{}' and try again.".format(
+                chart_folder_name, chart_export_path
+            )
+        )
 
-    pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context,
-                    helm_client_location, new_path, chart_name)
+    pull_helm_chart(
+        registry_path,
+        chart_export_path,
+        kube_config,
+        kube_context,
+        helm_client_location,
+        new_path,
+        chart_name,
+    )
 
     # Returning helm chart path
     helm_chart_path = os.path.join(chart_export_path, chart_name)
     if chart_folder_name == consts.Pre_Onboarding_Helm_Charts_Folder_Name:
         chart_path = helm_chart_path
     else:
-        chart_path = os.getenv('HELMCHART') if os.getenv('HELMCHART') else helm_chart_path
+        chart_path = (
+            os.getenv("HELMCHART") if os.getenv("HELMCHART") else helm_chart_path
+        )
 
     return chart_path
 
 
-def pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context, helm_client_location, new_path,
-                    chart_name='azure-arc-k8sagents', retry_count=5, retry_delay=3):
-    chart_url = registry_path.split(':')[0]
-    chart_version = registry_path.split(':')[1]
-    print("Step: {}: Pulling HelmChart: {}, Version: {}".format(get_utctimestring(), chart_url, chart_version))
+def pull_helm_chart(
+    registry_path,
+    chart_export_path,
+    kube_config,
+    kube_context,
+    helm_client_location,
+    new_path,
+    chart_name="azure-arc-k8sagents",
+    retry_count=5,
+    retry_delay=3,
+):
+    chart_url = registry_path.split(":")[0]
+    chart_version = registry_path.split(":")[1]
+    print(
+        "Step: {}: Pulling HelmChart: {}, Version: {}".format(
+            get_utctimestring(), chart_url, chart_version
+        )
+    )
 
     if new_path:
         # Version check for stable release train (chart_version will be in X.Y.Z format as opposed to X.Y.Z-NONSTABLE)
-        if '-' not in chart_version and (version.parse(chart_version) < version.parse("1.14.0")):
+        if "-" not in chart_version and (
+            version.parse(chart_version) < version.parse("1.14.0")
+        ):
             error_summary = "This CLI version does not support upgrading to Agents versions older than v1.14"
             telemetry.set_exception(
-                exception='Operation not supported on older Agents',
+                exception="Operation not supported on older Agents",
                 fault_type=consts.Operation_Not_Supported_Fault_Type,
-                summary=error_summary)
+                summary=error_summary,
+            )
             raise ClientRequestError(
                 error_summary,
                 recommendation="Please select an agent-version >= v1.14 to upgrade to using 'az connectedk8s upgrade "
-                               "-g <rg_name> -n <cluster_name> --agent-version <at-least-1.14>'.")
+                "-g <rg_name> -n <cluster_name> --agent-version <at-least-1.14>'.",
+            )
 
         base_path = os.path.dirname(chart_url)
         image_name = os.path.basename(chart_url)
-        chart_url = base_path + '/v2/' + image_name
+        chart_url = base_path + "/v2/" + image_name
 
-    cmd_helm_chart_pull = [helm_client_location, "pull", "oci://" + chart_url, "--untar", "--untardir",
-                           chart_export_path, "--version", chart_version]
+    cmd_helm_chart_pull = [
+        helm_client_location,
+        "pull",
+        "oci://" + chart_url,
+        "--untar",
+        "--untardir",
+        chart_export_path,
+        "--version",
+        chart_version,
+    ]
     if kube_config:
         cmd_helm_chart_pull.extend(["--kubeconfig", kube_config])
     if kube_context:
         cmd_helm_chart_pull.extend(["--kube-context", kube_context])
     for i in range(retry_count):
-        response_helm_chart_pull = subprocess.Popen(cmd_helm_chart_pull, stdout=PIPE, stderr=PIPE)
+        response_helm_chart_pull = subprocess.Popen(
+            cmd_helm_chart_pull, stdout=PIPE, stderr=PIPE
+        )
         _, error_helm_chart_pull = response_helm_chart_pull.communicate()
         if response_helm_chart_pull.returncode != 0:
             if i == retry_count - 1:
                 telemetry.set_exception(
                     exception=error_helm_chart_pull.decode("ascii"),
                     fault_type=consts.Pull_HelmChart_Fault_Type,
-                    summary="Unable to pull {} helm charts from the registry".format(chart_name))
+                    summary="Unable to pull {} helm charts from the registry".format(
+                        chart_name
+                    ),
+                )
                 raise CLIInternalError(
-                    "Unable to pull {} helm chart from the registry '{}': ".format(chart_name, registry_path) +
-                    error_helm_chart_pull.decode("ascii"))
+                    "Unable to pull {} helm chart from the registry '{}': ".format(
+                        chart_name, registry_path
+                    )
+                    + error_helm_chart_pull.decode("ascii")
+                )
             time.sleep(retry_delay)
         else:
             break
 
 
-def save_cluster_diagnostic_checks_pod_description(corev1_api_instance, batchv1_api_instance, helm_client_location,
-                                                   kubectl_client_location, kube_config, kube_context,
-                                                   filepath_with_timestamp, storage_space_available):
+def save_cluster_diagnostic_checks_pod_description(
+    corev1_api_instance,
+    batchv1_api_instance,
+    helm_client_location,
+    kubectl_client_location,
+    kube_config,
+    kube_context,
+    filepath_with_timestamp,
+    storage_space_available,
+):
     try:
         job_name = "cluster-diagnostic-checks-job"
-        all_pods = corev1_api_instance.list_namespaced_pod('azure-arc-release')
+        all_pods = corev1_api_instance.list_namespaced_pod("azure-arc-release")
         # Traversing through all agents
         for each_pod in all_pods.items:
             # Fetching the current Pod name and creating a folder with that name inside the timestamp folder
             pod_name = each_pod.metadata.name
-            if (pod_name.startswith(job_name)):
-                describe_job_pod = [kubectl_client_location, "describe", "pod", pod_name, "-n", "azure-arc-release"]
+            if pod_name.startswith(job_name):
+                describe_job_pod = [
+                    kubectl_client_location,
+                    "describe",
+                    "pod",
+                    pod_name,
+                    "-n",
+                    "azure-arc-release",
+                ]
                 if kube_config:
                     describe_job_pod.extend(["--kubeconfig", kube_config])
                 if kube_context:
                     describe_job_pod.extend(["--context", kube_context])
-                response_describe_job_pod = Popen(describe_job_pod, stdout=PIPE, stderr=PIPE)
-                output_describe_job_pod, error_describe_job_pod = response_describe_job_pod.communicate()
-                if (response_describe_job_pod.returncode == 0):
+                response_describe_job_pod = Popen(
+                    describe_job_pod, stdout=PIPE, stderr=PIPE
+                )
+                output_describe_job_pod, error_describe_job_pod = (
+                    response_describe_job_pod.communicate()
+                )
+                if response_describe_job_pod.returncode == 0:
                     pod_description = output_describe_job_pod.decode()
                     if storage_space_available:
-                        dns_check_path = os.path.join(filepath_with_timestamp,
-                                                      "cluster_diagnostic_checks_pod_description.txt")
-                        with open(dns_check_path, 'w+') as f:
+                        dns_check_path = os.path.join(
+                            filepath_with_timestamp,
+                            "cluster_diagnostic_checks_pod_description.txt",
+                        )
+                        with open(dns_check_path, "w+") as f:
                             f.write(pod_description)
                 else:
                     telemetry.set_exception(
                         exception=error_describe_job_pod.decode("ascii"),
                         fault_type=consts.Cluster_Diagnostic_Checks_Pod_Description_Save_Failed,
-                        summary="Failed to save cluster diagnostic checks pod description in the local machine")
+                        summary="Failed to save cluster diagnostic checks pod description in the local machine",
+                    )
     except OSError as e:
         if "[Errno 28]" in str(e):
             storage_space_available = False
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while saving the cluster diagnostic checks pod description in "
-                           "the local machine. Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while saving the cluster diagnostic checks pod description in "
+                "the local machine. Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Cluster_Diagnostic_Checks_Pod_Description_Save_Failed,
-                summary="Error occured while saving the cluster diagnostic checks pod description in the local machine")
+                summary="Error occured while saving the cluster diagnostic checks pod description in the local machine",
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while saving the cluster diagnostic checks pod description in the "
-                       "local machine. Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while saving the cluster diagnostic checks pod description in the "
+            "local machine. Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Cluster_Diagnostic_Checks_Pod_Description_Save_Failed,
-            summary="Error occured while saving the cluster diagnostic checks pod description in the local machine")
+            summary="Error occured while saving the cluster diagnostic checks pod description in the local machine",
+        )
 
 
-def check_cluster_DNS(dns_check_log, filepath_with_timestamp, storage_space_available, diagnoser_output):
-
+def check_cluster_DNS(
+    dns_check_log, filepath_with_timestamp, storage_space_available, diagnoser_output
+):
     try:
         if consts.DNS_Check_Result_String not in dns_check_log:
             return consts.Diagnostic_Check_Incomplete, storage_space_available
-        formatted_dns_log = dns_check_log.replace('\t', '')
+        formatted_dns_log = dns_check_log.replace("\t", "")
         # Validating if DNS is working or not and displaying proper result
-        if ("NXDOMAIN" in formatted_dns_log or "connection timed out" in formatted_dns_log):
+        if (
+            "NXDOMAIN" in formatted_dns_log
+            or "connection timed out" in formatted_dns_log
+        ):
             logger.warning(
                 "Error: We found an issue with the DNS resolution on your cluster. For details about debugging DNS "
-                "issues visit 'https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/'.\n")
+                "issues visit 'https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/'.\n"
+            )
             diagnoser_output.append(
                 "Error: We found an issue with the DNS resolution on your cluster. For details about debugging DNS "
-                "issues visit 'https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/'.\n")
+                "issues visit 'https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/'.\n"
+            )
             if storage_space_available:
                 dns_check_path = os.path.join(filepath_with_timestamp, consts.DNS_Check)
-                with open(dns_check_path, 'w+') as dns:
-                    dns.write(formatted_dns_log + "\nWe found an issue with the DNS resolution on your cluster.")
+                with open(dns_check_path, "w+") as dns:
+                    dns.write(
+                        formatted_dns_log
+                        + "\nWe found an issue with the DNS resolution on your cluster."
+                    )
             telemetry.set_exception(
-                exception='DNS resolution check failed in the cluster',
+                exception="DNS resolution check failed in the cluster",
                 fault_type=consts.DNS_Check_Failed,
-                summary="DNS check failed in the cluster")
+                summary="DNS check failed in the cluster",
+            )
             return consts.Diagnostic_Check_Failed, storage_space_available
         else:
             if storage_space_available:
                 dns_check_path = os.path.join(filepath_with_timestamp, consts.DNS_Check)
-                with open(dns_check_path, 'w+') as dns:
-                    dns.write(formatted_dns_log + "\nCluster DNS check passed successfully.")
+                with open(dns_check_path, "w+") as dns:
+                    dns.write(
+                        formatted_dns_log + "\nCluster DNS check passed successfully."
+                    )
             return consts.Diagnostic_Check_Passed, storage_space_available
 
     # For handling storage or OS exception that may occur during the execution
@@ -270,150 +402,223 @@ def check_cluster_DNS(dns_check_log, filepath_with_timestamp, storage_space_avai
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
-            logger.warning("An exception has occured while performing the DNS check on the cluster. "
-                           "Exception: {}".format(str(e)) + "\n")
+            logger.warning(
+                "An exception has occured while performing the DNS check on the cluster. "
+                "Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Cluster_DNS_Check_Fault_Type,
-                summary="Error occured while performing cluster DNS check")
-            diagnoser_output.append("An exception has occured while performing the DNS check on the cluster. "
-                                    "Exception: {}".format(str(e)) + "\n")
+                summary="Error occured while performing cluster DNS check",
+            )
+            diagnoser_output.append(
+                "An exception has occured while performing the DNS check on the cluster. "
+                "Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while performing the DNS check on the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while performing the DNS check on the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Cluster_DNS_Check_Fault_Type,
-            summary="Error occured while performing cluster DNS check")
-        diagnoser_output.append("An exception has occured while performing the DNS check on the cluster. "
-                                "Exception: {}".format(str(e)) + "\n")
+            summary="Error occured while performing cluster DNS check",
+        )
+        diagnoser_output.append(
+            "An exception has occured while performing the DNS check on the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Incomplete, storage_space_available
 
 
-def check_cluster_outbound_connectivity(outbound_connectivity_check_log, filepath_with_timestamp,
-                                        storage_space_available, diagnoser_output,
-                                        outbound_connectivity_check_for='pre-onboarding-inspector'):
-
+def check_cluster_outbound_connectivity(
+    outbound_connectivity_check_log,
+    filepath_with_timestamp,
+    storage_space_available,
+    diagnoser_output,
+    outbound_connectivity_check_for="pre-onboarding-inspector",
+):
     try:
-        if outbound_connectivity_check_for == 'pre-onboarding-inspector':
-            if consts.Outbound_Connectivity_Check_Result_String not in outbound_connectivity_check_log:
+        if outbound_connectivity_check_for == "pre-onboarding-inspector":
+            if (
+                consts.Outbound_Connectivity_Check_Result_String
+                not in outbound_connectivity_check_log
+            ):
                 return consts.Diagnostic_Check_Incomplete, storage_space_available
 
-            Outbound_Connectivity_Log_For_Cluster_Connect = outbound_connectivity_check_log.split('  ')[0]
+            Outbound_Connectivity_Log_For_Cluster_Connect = (
+                outbound_connectivity_check_log.split("  ")[0]
+            )
             # extracting the endpoints for cluster connect feature
-            Cluster_Connect_Precheck_Endpoint_Url = Outbound_Connectivity_Log_For_Cluster_Connect.split(" : ")[1]
+            Cluster_Connect_Precheck_Endpoint_Url = (
+                Outbound_Connectivity_Log_For_Cluster_Connect.split(" : ")[1]
+            )
             # extracting the obo endpoint response code from outbound connectivity check
-            Cluster_Connect_Precheck_Endpoint_response_code = \
+            Cluster_Connect_Precheck_Endpoint_response_code = (
                 Outbound_Connectivity_Log_For_Cluster_Connect.split(" : ")[2]
+            )
 
-            if (Cluster_Connect_Precheck_Endpoint_response_code != "000"):
+            if Cluster_Connect_Precheck_Endpoint_response_code != "000":
                 if storage_space_available:
-                    cluster_connect_outbound_connectivity_check_path = \
-                        os.path.join(filepath_with_timestamp,
-                                     consts.Outbound_Network_Connectivity_Check_for_cluster_connect)
-                    with open(cluster_connect_outbound_connectivity_check_path, 'w+') as outbound:
-                        outbound.write("Response code " + Cluster_Connect_Precheck_Endpoint_response_code +
-                                       "\nOutbound network connectivity check to cluster connect precheck endpoints "
-                                       "passed successfully.")
+                    cluster_connect_outbound_connectivity_check_path = os.path.join(
+                        filepath_with_timestamp,
+                        consts.Outbound_Network_Connectivity_Check_for_cluster_connect,
+                    )
+                    with open(
+                        cluster_connect_outbound_connectivity_check_path, "w+"
+                    ) as outbound:
+                        outbound.write(
+                            "Response code "
+                            + Cluster_Connect_Precheck_Endpoint_response_code
+                            + "\nOutbound network connectivity check to cluster connect precheck endpoints "
+                            "passed successfully."
+                        )
             else:
-                logger.warning("The outbound network connectivity check has failed for the endpoint - " +
-                               Cluster_Connect_Precheck_Endpoint_Url +
-                               "\nThis will affect the \"cluster-connect\" feature. If you are planning to use "
-                               "\"cluster-connect\" functionality , please ensure outbound connectivity to the "
-                               "above endpoint.\n")
+                logger.warning(
+                    "The outbound network connectivity check has failed for the endpoint - "
+                    + Cluster_Connect_Precheck_Endpoint_Url
+                    + '\nThis will affect the "cluster-connect" feature. If you are planning to use '
+                    '"cluster-connect" functionality , please ensure outbound connectivity to the '
+                    "above endpoint.\n"
+                )
                 telemetry.set_user_fault()
                 telemetry.set_exception(
-                    exception='Outbound network connectivity check failed for the Cluster Connect endpoint',
+                    exception="Outbound network connectivity check failed for the Cluster Connect endpoint",
                     fault_type=consts.Outbound_Connectivity_Check_Failed_For_Cluster_Connect,
-                    summary="Outbound network connectivity check failed for the Cluster Connect precheck endpoint")
+                    summary="Outbound network connectivity check failed for the Cluster Connect precheck endpoint",
+                )
                 if storage_space_available:
-                    cluster_connect_outbound_connectivity_check_path = \
-                        os.path.join(filepath_with_timestamp,
-                                     consts.Outbound_Network_Connectivity_Check_for_cluster_connect)
-                    with open(cluster_connect_outbound_connectivity_check_path, 'w+') as outbound:
-                        outbound.write("Response code " + Cluster_Connect_Precheck_Endpoint_response_code +
-                                       "\nOutbound connectivity failed for the endpoint:" +
-                                       Cluster_Connect_Precheck_Endpoint_Url +
-                                       " ,this is an optional endpoint needed for cluster-connect feature.")
+                    cluster_connect_outbound_connectivity_check_path = os.path.join(
+                        filepath_with_timestamp,
+                        consts.Outbound_Network_Connectivity_Check_for_cluster_connect,
+                    )
+                    with open(
+                        cluster_connect_outbound_connectivity_check_path, "w+"
+                    ) as outbound:
+                        outbound.write(
+                            "Response code "
+                            + Cluster_Connect_Precheck_Endpoint_response_code
+                            + "\nOutbound connectivity failed for the endpoint:"
+                            + Cluster_Connect_Precheck_Endpoint_Url
+                            + " ,this is an optional endpoint needed for cluster-connect feature."
+                        )
 
-            Onboarding_Precheck_Endpoint_outbound_connectivity_response = outbound_connectivity_check_log[-1:-4:-1]
-            Onboarding_Precheck_Endpoint_outbound_connectivity_response = \
+            Onboarding_Precheck_Endpoint_outbound_connectivity_response = (
+                outbound_connectivity_check_log[-1:-4:-1]
+            )
+            Onboarding_Precheck_Endpoint_outbound_connectivity_response = (
                 Onboarding_Precheck_Endpoint_outbound_connectivity_response[::-1]
+            )
 
             # Validating if outbound connectiivty is working or not and displaying proper result
-            if (Onboarding_Precheck_Endpoint_outbound_connectivity_response != "000"):
+            if Onboarding_Precheck_Endpoint_outbound_connectivity_response != "000":
                 if storage_space_available:
-                    outbound_connectivity_check_path = \
-                        os.path.join(filepath_with_timestamp, consts.Outbound_Network_Connectivity_Check_for_onboarding)
-                    with open(outbound_connectivity_check_path, 'w+') as outbound:
-                        outbound.write("Response code " + Onboarding_Precheck_Endpoint_outbound_connectivity_response +
-                                       "\nOutbound network connectivity check to the onboarding precheck endpoint "
-                                       "passed successfully.")
+                    outbound_connectivity_check_path = os.path.join(
+                        filepath_with_timestamp,
+                        consts.Outbound_Network_Connectivity_Check_for_onboarding,
+                    )
+                    with open(outbound_connectivity_check_path, "w+") as outbound:
+                        outbound.write(
+                            "Response code "
+                            + Onboarding_Precheck_Endpoint_outbound_connectivity_response
+                            + "\nOutbound network connectivity check to the onboarding precheck endpoint "
+                            "passed successfully."
+                        )
                 return consts.Diagnostic_Check_Passed, storage_space_available
             else:
-                outbound_connectivity_failed_warning_message = \
-                    "Error: We found an issue with outbound network connectivity from the cluster to the endpoints " \
-                    "required for onboarding.\nPlease ensure to meet the following network requirements " \
-                    + consts.Doc_Network_Requirements_Url + "\nIf your cluster is behind an outbound proxy server, " \
-                    " please ensure that you have passed proxy parameters during the onboarding of your cluster.\n" \
-                    "For more details visit " + consts.Quick_Start_Outbound_Proxy_Url + " \n"
+                outbound_connectivity_failed_warning_message = (
+                    "Error: We found an issue with outbound network connectivity from the cluster to the endpoints "
+                    "required for onboarding.\nPlease ensure to meet the following network requirements "
+                    + consts.Doc_Network_Requirements_Url
+                    + "\nIf your cluster is behind an outbound proxy server, "
+                    " please ensure that you have passed proxy parameters during the onboarding of your cluster.\n"
+                    "For more details visit "
+                    + consts.Quick_Start_Outbound_Proxy_Url
+                    + " \n"
+                )
                 logger.warning(outbound_connectivity_failed_warning_message)
                 telemetry.set_user_fault()
                 diagnoser_output.append(outbound_connectivity_failed_warning_message)
                 if storage_space_available:
-                    outbound_connectivity_check_path = \
-                        os.path.join(filepath_with_timestamp,
-                                     consts.Outbound_Network_Connectivity_Check_for_onboarding)
-                    with open(outbound_connectivity_check_path, 'w+') as outbound:
-                        outbound.write("Response code " + Onboarding_Precheck_Endpoint_outbound_connectivity_response +
-                                       "\nWe found an issue with Outbound network connectivity from the cluster "
-                                       "required for onboarding.")
+                    outbound_connectivity_check_path = os.path.join(
+                        filepath_with_timestamp,
+                        consts.Outbound_Network_Connectivity_Check_for_onboarding,
+                    )
+                    with open(outbound_connectivity_check_path, "w+") as outbound:
+                        outbound.write(
+                            "Response code "
+                            + Onboarding_Precheck_Endpoint_outbound_connectivity_response
+                            + "\nWe found an issue with Outbound network connectivity from the cluster "
+                            "required for onboarding."
+                        )
                 telemetry.set_exception(
-                    exception='Outbound network connectivity check failed for onboarding',
+                    exception="Outbound network connectivity check failed for onboarding",
                     fault_type=consts.Outbound_Connectivity_Check_Failed_For_Onboarding,
-                    summary="Outbound network connectivity check for onboarding failed in the cluster")
+                    summary="Outbound network connectivity check for onboarding failed in the cluster",
+                )
                 return consts.Diagnostic_Check_Failed, storage_space_available
 
-        elif outbound_connectivity_check_for == 'troubleshoot':
+        elif outbound_connectivity_check_for == "troubleshoot":
             outbound_connectivity_response = outbound_connectivity_check_log[-1:-4:-1]
             outbound_connectivity_response = outbound_connectivity_response[::-1]
-            if consts.Outbound_Connectivity_Check_Result_String not in outbound_connectivity_check_log:
+            if (
+                consts.Outbound_Connectivity_Check_Result_String
+                not in outbound_connectivity_check_log
+            ):
                 return consts.Diagnostic_Check_Incomplete, storage_space_available
 
-            if (outbound_connectivity_response != "000"):
+            if outbound_connectivity_response != "000":
                 if storage_space_available:
-                    outbound_connectivity_check_path = \
-                        os.path.join(filepath_with_timestamp, consts.Outbound_Network_Connectivity_Check)
-                    with open(outbound_connectivity_check_path, 'w+') as outbound:
-                        outbound.write("Response code " + outbound_connectivity_response +
-                                       "\nOutbound network connectivity check passed successfully.")
+                    outbound_connectivity_check_path = os.path.join(
+                        filepath_with_timestamp,
+                        consts.Outbound_Network_Connectivity_Check,
+                    )
+                    with open(outbound_connectivity_check_path, "w+") as outbound:
+                        outbound.write(
+                            "Response code "
+                            + outbound_connectivity_response
+                            + "\nOutbound network connectivity check passed successfully."
+                        )
                 return consts.Diagnostic_Check_Passed, storage_space_available
 
-            outbound_connectivity_failed_warning_message = \
-                "Error: We found an issue with outbound network connectivity from the cluster.\nPlease ensure to " \
-                "meet the following network requirements '" + consts.Doc_Network_Requirements_Url + \
-                " \nIf your cluster is behind an outbound proxy server, please ensure that you have passed proxy " \
-                "parameters during the onboarding of your cluster.\nFor more details visit " + \
-                consts.Doc_Quick_Start_Outbound_Proxy_Url + " \n"
+            outbound_connectivity_failed_warning_message = (
+                "Error: We found an issue with outbound network connectivity from the cluster.\nPlease ensure to "
+                "meet the following network requirements '"
+                + consts.Doc_Network_Requirements_Url
+                + " \nIf your cluster is behind an outbound proxy server, please ensure that you have passed proxy "
+                "parameters during the onboarding of your cluster.\nFor more details visit "
+                + consts.Doc_Quick_Start_Outbound_Proxy_Url
+                + " \n"
+            )
             logger.warning(outbound_connectivity_failed_warning_message)
             diagnoser_output.append(outbound_connectivity_failed_warning_message)
             if storage_space_available:
-                outbound_connectivity_check_path = \
-                    os.path.join(filepath_with_timestamp, consts.Outbound_Network_Connectivity_Check)
-                with open(outbound_connectivity_check_path, 'w+') as outbound:
+                outbound_connectivity_check_path = os.path.join(
+                    filepath_with_timestamp, consts.Outbound_Network_Connectivity_Check
+                )
+                with open(outbound_connectivity_check_path, "w+") as outbound:
                     outbound.write(
-                        "Response code " + outbound_connectivity_response +
-                        "\nWe found an issue with Outbound network connectivity from the cluster.")
+                        "Response code "
+                        + outbound_connectivity_response
+                        + "\nWe found an issue with Outbound network connectivity from the cluster."
+                    )
             telemetry.set_exception(
-                exception='Outbound network connectivity check failed',
+                exception="Outbound network connectivity check failed",
                 fault_type=consts.Outbound_Connectivity_Check_Failed,
-                summary="Outbound network connectivity check failed in the cluster")
+                summary="Outbound network connectivity check failed in the cluster",
+            )
             return consts.Diagnostic_Check_Failed, storage_space_available
 
     # For handling storage or OS exception that may occur during the execution
@@ -423,42 +628,57 @@ def check_cluster_outbound_connectivity(outbound_connectivity_check_log, filepat
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             shutil.rmtree(filepath_with_timestamp, ignore_errors=False, onerror=None)
         else:
             logger.warning(
                 "An exception has occured while performing the outbound connectivity check on the cluster. "
-                "Exception: {}".format(str(e)) + "\n")
+                "Exception: {}".format(str(e))
+                + "\n"
+            )
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Outbound_Connectivity_Check_Fault_Type,
-                summary="Error occured while performing outbound connectivity check in the cluster")
+                summary="Error occured while performing outbound connectivity check in the cluster",
+            )
             diagnoser_output.append(
                 "An exception has occured while performing the outbound connectivity check on the cluster. "
-                "Exception: {}".format(str(e)) + "\n")
+                "Exception: {}".format(str(e))
+                + "\n"
+            )
 
     # To handle any exception that may occur during the execution
     except Exception as e:
-        logger.warning("An exception has occured while performing the outbound connectivity check on the cluster. "
-                       "Exception: {}".format(str(e)) + "\n")
+        logger.warning(
+            "An exception has occured while performing the outbound connectivity check on the cluster. "
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Outbound_Connectivity_Check_Fault_Type,
-            summary="Error occured while performing outbound connectivity check in the cluster")
+            summary="Error occured while performing outbound connectivity check in the cluster",
+        )
         diagnoser_output.append(
             "An exception has occured while performing the outbound connectivity check on the cluster. "
-            "Exception: {}".format(str(e)) + "\n")
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
 
     return consts.Diagnostic_Check_Incomplete, storage_space_available
 
 
 def create_folder_diagnosticlogs(time_stamp, folder_name):
-
-    print("Step: {}: Creating folder for Cluster Diagnostic Checks Logs".format(get_utctimestring()))
+    print(
+        "Step: {}: Creating folder for Cluster Diagnostic Checks Logs".format(
+            get_utctimestring()
+        )
+    )
     try:
         # Fetching path to user directory to create the arc diagnostic folder
-        home_dir = os.path.expanduser('~')
-        filepath = os.path.join(home_dir, '.azure', folder_name)
+        home_dir = os.path.expanduser("~")
+        filepath = os.path.join(home_dir, ".azure", folder_name)
         # Creating Diagnostic folder and its subfolder with the given timestamp and cluster name to store all the logs
         try:
             os.mkdir(filepath)
@@ -483,33 +703,40 @@ def create_folder_diagnosticlogs(time_stamp, folder_name):
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.No_Storage_Space_Available_Fault_Type,
-                summary="No space left on device")
+                summary="No space left on device",
+            )
             return "", False
         logger.warning(
             "An exception has occured while creating the diagnostic logs folder in your local machine. "
-            "Exception: {}".format(str(e)) + "\n")
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Diagnostics_Folder_Creation_Failed_Fault_Type,
-            summary="Error while trying to create diagnostic logs folder")
+            summary="Error while trying to create diagnostic logs folder",
+        )
         return "", False
 
     # To handle any exception that may occur during the execution
     except Exception as e:
         logger.warning(
             "An exception has occured while creating the diagnostic logs folder in your local machine. "
-            "Exception: {}".format(str(e)) + "\n")
+            "Exception: {}".format(str(e))
+            + "\n"
+        )
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Diagnostics_Folder_Creation_Failed_Fault_Type,
-            summary="Error while trying to create diagnostic logs folder")
+            summary="Error while trying to create diagnostic logs folder",
+        )
         return "", False
 
 
 def add_helm_repo(kube_config, kube_context, helm_client_location):
     print("Step: {}: Adding Helm Repo".format(get_utctimestring()))
-    repo_name = os.getenv('HELMREPONAME')
-    repo_url = os.getenv('HELMREPOURL')
+    repo_name = os.getenv("HELMREPONAME")
+    repo_url = os.getenv("HELMREPOURL")
     cmd_helm_repo = [helm_client_location, "repo", "add", repo_name, repo_url]
     if kube_config:
         cmd_helm_repo.extend(["--kubeconfig", kube_config])
@@ -518,55 +745,81 @@ def add_helm_repo(kube_config, kube_context, helm_client_location):
     response_helm_repo = Popen(cmd_helm_repo, stdout=PIPE, stderr=PIPE)
     _, error_helm_repo = response_helm_repo.communicate()
     if response_helm_repo.returncode != 0:
-        telemetry.set_exception(exception=error_helm_repo.decode("ascii"), fault_type=consts.Add_HelmRepo_Fault_Type,
-                                summary='Failed to add helm repository')
+        telemetry.set_exception(
+            exception=error_helm_repo.decode("ascii"),
+            fault_type=consts.Add_HelmRepo_Fault_Type,
+            summary="Failed to add helm repository",
+        )
         raise CLIInternalError(
-            "Unable to add repository {} to helm: ".format(repo_url) + error_helm_repo.decode("ascii"))
+            "Unable to add repository {} to helm: ".format(repo_url)
+            + error_helm_repo.decode("ascii")
+        )
 
 
 def get_helm_registry(cmd, config_dp_endpoint, release_train_custom=None):
-    print("Step: {}: Getting HelmPackagePath from Arc DataPlane".format(get_utctimestring()))
+    print(
+        "Step: {}: Getting HelmPackagePath from Arc DataPlane".format(
+            get_utctimestring()
+        )
+    )
     # Setting uri
     api_version = "2019-11-01-preview"
-    chart_location_url_segment = "azure-arc-k8sagents/GetLatestHelmPackagePath?api-version={}".format(api_version)
-    release_train = os.getenv('RELEASETRAIN') if os.getenv('RELEASETRAIN') else 'stable'
+    chart_location_url_segment = (
+        "azure-arc-k8sagents/GetLatestHelmPackagePath?api-version={}".format(
+            api_version
+        )
+    )
+    release_train = os.getenv("RELEASETRAIN") if os.getenv("RELEASETRAIN") else "stable"
     chart_location_url = "{}/{}".format(config_dp_endpoint, chart_location_url_segment)
     if release_train_custom:
         release_train = release_train_custom
     uri_parameters = ["releaseTrain={}".format(release_train)]
     resource = cmd.cli_ctx.cloud.endpoints.active_directory_resource_id
     headers = None
-    if os.getenv('AZURE_ACCESS_TOKEN'):
-        headers = ["Authorization=Bearer {}".format(os.getenv('AZURE_ACCESS_TOKEN'))]
+    if os.getenv("AZURE_ACCESS_TOKEN"):
+        headers = ["Authorization=Bearer {}".format(os.getenv("AZURE_ACCESS_TOKEN"))]
     # Sending request with retries
-    r = send_request_with_retries(cmd.cli_ctx,
-                                  'post',
-                                  chart_location_url,
-                                  headers=headers,
-                                  fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
-                                  summary='Error while fetching helm chart registry path',
-                                  uri_parameters=uri_parameters,
-                                  resource=resource)
+    r = send_request_with_retries(
+        cmd.cli_ctx,
+        "post",
+        chart_location_url,
+        headers=headers,
+        fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
+        summary="Error while fetching helm chart registry path",
+        uri_parameters=uri_parameters,
+        resource=resource,
+    )
     if r.content:
         try:
-            return r.json().get('repositoryPath')
+            return r.json().get("repositoryPath")
         except Exception as e:
-            telemetry.set_exception(exception=e,
-                                    fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
-                                    summary='Error while fetching helm chart registry path')
-            raise CLIInternalError("Error while fetching helm chart registry path from JSON response: " + str(e))
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
+                summary="Error while fetching helm chart registry path",
+            )
+            raise CLIInternalError(
+                "Error while fetching helm chart registry path from JSON response: "
+                + str(e)
+            )
     else:
-        telemetry.set_exception(exception='No content in response',
-                                fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
-                                summary='No content in acr path response')
+        telemetry.set_exception(
+            exception="No content in response",
+            fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
+            summary="No content in acr path response",
+        )
         raise CLIInternalError("No content was found in helm registry path response.")
 
 
-def get_helm_values(cmd, config_dp_endpoint, release_train_custom=None, request_body=None):
+def get_helm_values(
+    cmd, config_dp_endpoint, release_train_custom=None, request_body=None
+):
     # Setting uri
     api_version = "2024-07-01-preview"
-    chart_location_url_segment = "azure-arc-k8sagents/GetHelmSettings?api-version={}".format(api_version)
-    release_train = os.getenv('RELEASETRAIN') if os.getenv('RELEASETRAIN') else 'stable'
+    chart_location_url_segment = (
+        "azure-arc-k8sagents/GetHelmSettings?api-version={}".format(api_version)
+    )
+    release_train = os.getenv("RELEASETRAIN") if os.getenv("RELEASETRAIN") else "stable"
     chart_location_url = "{}/{}".format(config_dp_endpoint, chart_location_url_segment)
     dp_request_identity = request_body.identity
     id = request_body.id
@@ -580,52 +833,108 @@ def get_helm_values(cmd, config_dp_endpoint, release_train_custom=None, request_
     uri_parameters = ["releaseTrain={}".format(release_train)]
     resource = cmd.cli_ctx.cloud.endpoints.active_directory_resource_id
     headers = None
-    if os.getenv('AZURE_ACCESS_TOKEN'):
-        headers = ["Authorization=Bearer {}".format(os.getenv('AZURE_ACCESS_TOKEN'))]
+    if os.getenv("AZURE_ACCESS_TOKEN"):
+        headers = ["Authorization=Bearer {}".format(os.getenv("AZURE_ACCESS_TOKEN"))]
     # Sending request with retries
-    r = send_request_with_retries(cmd.cli_ctx, 'post', chart_location_url, headers=headers, fault_type=consts.Get_HelmRegistery_Path_Fault_Type, summary='Error while fetching helm chart registry path', uri_parameters=uri_parameters, resource=resource, request_body=request_body)
+    r = send_request_with_retries(
+        cmd.cli_ctx,
+        "post",
+        chart_location_url,
+        headers=headers,
+        fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
+        summary="Error while fetching helm chart registry path",
+        uri_parameters=uri_parameters,
+        resource=resource,
+        request_body=request_body,
+    )
     if r.content:
         try:
             return r.json()
         except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
-                                    summary='Error while fetching helm values from DP')
-            raise CLIInternalError("Error while fetching helm values from DP from JSON response: " + str(e))
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
+                summary="Error while fetching helm values from DP",
+            )
+            raise CLIInternalError(
+                "Error while fetching helm values from DP from JSON response: " + str(e)
+            )
     else:
-        telemetry.set_exception(exception='No content in response', fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
-                                summary='No content in acr path response')
+        telemetry.set_exception(
+            exception="No content in response",
+            fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
+            summary="No content in acr path response",
+        )
         raise CLIInternalError("No content was found in helm registry path response.")
 
 
 def health_check_dp(cmd, config_dp_endpoint):
     # Setting uri
     api_version = "2024-07-01-preview"
-    chart_location_url_segment = "azure-arc-k8sagents/healthCheck?api-version={}".format(api_version)
+    chart_location_url_segment = (
+        "azure-arc-k8sagents/healthCheck?api-version={}".format(api_version)
+    )
     chart_location_url = "{}/{}".format(config_dp_endpoint, chart_location_url_segment)
     uri_parameters = []
     resource = cmd.cli_ctx.cloud.endpoints.active_directory_resource_id
     headers = None
-    if os.getenv('AZURE_ACCESS_TOKEN'):
-        headers = ["Authorization=Bearer {}".format(os.getenv('AZURE_ACCESS_TOKEN'))]
+    if os.getenv("AZURE_ACCESS_TOKEN"):
+        headers = ["Authorization=Bearer {}".format(os.getenv("AZURE_ACCESS_TOKEN"))]
     # Sending request with retries
-    r = send_request_with_retries(cmd.cli_ctx, 'post', chart_location_url, headers=headers, fault_type=consts.Get_HelmRegistery_Path_Fault_Type, summary='Error while performing DP health check', uri_parameters=uri_parameters, resource=resource)
+    r = send_request_with_retries(
+        cmd.cli_ctx,
+        "post",
+        chart_location_url,
+        headers=headers,
+        fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
+        summary="Error while performing DP health check",
+        uri_parameters=uri_parameters,
+        resource=resource,
+    )
     if r.status_code == 200:
         return True
     else:
-        telemetry.set_exception(exception="Error while performing DP health check", fault_type=consts.DP_Health_Check,
-                                summary='Error while performing DP health check')
+        telemetry.set_exception(
+            exception="Error while performing DP health check",
+            fault_type=consts.DP_Health_Check,
+            summary="Error while performing DP health check",
+        )
         raise CLIInternalError("Error while performing DP health check")
 
 
-def send_request_with_retries(cli_ctx, method, url, headers, fault_type, summary, uri_parameters=None, resource=None, retry_count=5, retry_delay=3, request_body=None):
+def send_request_with_retries(
+    cli_ctx,
+    method,
+    url,
+    headers,
+    fault_type,
+    summary,
+    uri_parameters=None,
+    resource=None,
+    retry_count=5,
+    retry_delay=3,
+    request_body=None,
+):
     for i in range(retry_count):
         try:
-            response = send_raw_request(cli_ctx, method, url, headers=headers, uri_parameters=uri_parameters, resource=resource, body=request_body)
+            response = send_raw_request(
+                cli_ctx,
+                method,
+                url,
+                headers=headers,
+                uri_parameters=uri_parameters,
+                resource=resource,
+                body=request_body,
+            )
             return response
         except Exception as e:
             if i == retry_count - 1:
-                telemetry.set_exception(exception=e, fault_type=fault_type, summary=summary)
-                raise CLIInternalError("Error while fetching helm chart registry path: " + str(e))
+                telemetry.set_exception(
+                    exception=e, fault_type=fault_type, summary=summary
+                )
+                raise CLIInternalError(
+                    "Error while fetching helm chart registry path: " + str(e)
+                )
             time.sleep(retry_delay)
 
 
@@ -633,12 +942,18 @@ def arm_exception_handler(ex, fault_type, summary, return_if_not_found=False):
     if isinstance(ex, AuthenticationError):
         telemetry.set_exception(exception=ex, fault_type=fault_type, summary=summary)
         raise AzureResponseError(
-            "Authentication error occured while making ARM request: " + str(ex) + "\nSummary: {}".format(summary))
+            "Authentication error occured while making ARM request: "
+            + str(ex)
+            + "\nSummary: {}".format(summary)
+        )
 
     if isinstance(ex, TokenExpiredError):
         telemetry.set_exception(exception=ex, fault_type=fault_type, summary=summary)
         raise AzureResponseError(
-            "Token expiration error occured while making ARM request: " + str(ex) + "\nSummary: {}".format(summary))
+            "Token expiration error occured while making ARM request: "
+            + str(ex)
+            + "\nSummary: {}".format(summary)
+        )
 
     if isinstance(ex, HttpOperationError):
         status_code = ex.response.status_code
@@ -649,14 +964,23 @@ def arm_exception_handler(ex, fault_type, summary, return_if_not_found=False):
         telemetry.set_exception(exception=ex, fault_type=fault_type, summary=summary)
         if status_code // 100 == 5:
             raise AzureInternalError(
-                "Http operation error occured while making ARM request: " + str(ex) + "\nSummary: {}".format(summary))
+                "Http operation error occured while making ARM request: "
+                + str(ex)
+                + "\nSummary: {}".format(summary)
+            )
         raise AzureResponseError(
-            "Http operation error occured while making ARM request: " + str(ex) + "\nSummary: {}".format(summary))
+            "Http operation error occured while making ARM request: "
+            + str(ex)
+            + "\nSummary: {}".format(summary)
+        )
 
     if isinstance(ex, MSRestValidationError):
         telemetry.set_exception(exception=ex, fault_type=fault_type, summary=summary)
         raise AzureResponseError(
-            "Validation error occured while making ARM request: " + str(ex) + "\nSummary: {}".format(summary))
+            "Validation error occured while making ARM request: "
+            + str(ex)
+            + "\nSummary: {}".format(summary)
+        )
 
     if isinstance(ex, HttpResponseError):
         status_code = ex.status_code
@@ -667,26 +991,38 @@ def arm_exception_handler(ex, fault_type, summary, return_if_not_found=False):
         telemetry.set_exception(exception=ex, fault_type=fault_type, summary=summary)
         if status_code // 100 == 5:
             raise AzureInternalError(
-                "Http response error occured while making ARM request: " + str(ex) + "\nSummary: {}".format(summary))
+                "Http response error occured while making ARM request: "
+                + str(ex)
+                + "\nSummary: {}".format(summary)
+            )
         raise AzureResponseError(
-            "Http response error occured while making ARM request: " + str(ex) + "\nSummary: {}".format(summary))
+            "Http response error occured while making ARM request: "
+            + str(ex)
+            + "\nSummary: {}".format(summary)
+        )
 
     if isinstance(ex, ResourceNotFoundError) and return_if_not_found:
         return
 
     telemetry.set_exception(exception=ex, fault_type=fault_type, summary=summary)
-    raise ClientRequestError("Error occured while making ARM request: " + str(ex) + "\nSummary: {}".format(summary))
+    raise ClientRequestError(
+        "Error occured while making ARM request: "
+        + str(ex)
+        + "\nSummary: {}".format(summary)
+    )
 
 
-def kubernetes_exception_handler(ex,
-                                 fault_type,
-                                 summary,
-                                 error_message='Error occured while connecting to the kubernetes cluster: ',
-                                 message_for_unauthorized_request='The user does not have required privileges on the '
-                                 'kubernetes cluster to deploy Azure Arc enabled Kubernetes agents. Please '
-                                 'ensure you have cluster admin privileges on the cluster to onboard.',
-                                 message_for_not_found='The requested kubernetes resource was not found.',
-                                 raise_error=True):
+def kubernetes_exception_handler(
+    ex,
+    fault_type,
+    summary,
+    error_message="Error occured while connecting to the kubernetes cluster: ",
+    message_for_unauthorized_request="The user does not have required privileges on the "
+    "kubernetes cluster to deploy Azure Arc enabled Kubernetes agents. Please "
+    "ensure you have cluster admin privileges on the cluster to onboard.",
+    message_for_not_found="The requested kubernetes resource was not found.",
+    raise_error=True,
+):
     telemetry.set_user_fault()
     if isinstance(ex, ApiException):
         status_code = ex.status
@@ -697,11 +1033,15 @@ def kubernetes_exception_handler(ex,
         else:
             logger.debug("Kubernetes Exception: " + str(ex))
         if raise_error:
-            telemetry.set_exception(exception=ex, fault_type=fault_type, summary=summary)
+            telemetry.set_exception(
+                exception=ex, fault_type=fault_type, summary=summary
+            )
             raise ValidationError(error_message + "\nError Response: " + str(ex.body))
     else:
         if raise_error:
-            telemetry.set_exception(exception=ex, fault_type=fault_type, summary=summary)
+            telemetry.set_exception(
+                exception=ex, fault_type=fault_type, summary=summary
+            )
             raise ValidationError(error_message + "\nError: " + str(ex))
 
         logger.debug("Kubernetes Exception: " + str(ex))
@@ -715,48 +1055,79 @@ def validate_infrastructure_type(infra):
 
 
 def get_values_file():
-    values_file = os.getenv('HELMVALUESPATH')
+    values_file = os.getenv("HELMVALUESPATH")
     if (values_file is not None) and (os.path.isfile(values_file)):
-        logger.warning("Values files detected. Reading additional helm parameters from same.")
+        logger.warning(
+            "Values files detected. Reading additional helm parameters from same."
+        )
         # trimming required for windows os
-        if (values_file.startswith("'") or values_file.startswith('"')):
+        if values_file.startswith("'") or values_file.startswith('"'):
             values_file = values_file[1:]
-        if (values_file.endswith("'") or values_file.endswith('"')):
+        if values_file.endswith("'") or values_file.endswith('"'):
             values_file = values_file[:-1]
         return values_file
     return None
 
 
 def ensure_namespace_cleanup():
-    print("Step: {}: Confirming '{}' namespace got deleted.".format(get_utctimestring(), consts.Arc_Namespace))
+    print(
+        "Step: {}: Confirming '{}' namespace got deleted.".format(
+            get_utctimestring(), consts.Arc_Namespace
+        )
+    )
     api_instance = kube_client.CoreV1Api()
     timeout = time.time() + 180
     while True:
         if time.time() > timeout:
             telemetry.set_user_fault()
-            logger.warning("Namespace 'azure-arc' still in terminating state. Please ensure that you delete the "
-                           "'azure-arc' namespace before onboarding the cluster again.")
+            logger.warning(
+                "Namespace 'azure-arc' still in terminating state. Please ensure that you delete the "
+                "'azure-arc' namespace before onboarding the cluster again."
+            )
             return
         try:
-            api_response = api_instance.list_namespace(field_selector='metadata.name=azure-arc')
+            api_response = api_instance.list_namespace(
+                field_selector="metadata.name=azure-arc"
+            )
             if not api_response.items:
                 return
             time.sleep(5)
         except Exception as e:  # pylint: disable=broad-except
             logger.warning("Error while retrieving namespace information: " + str(e))
-            kubernetes_exception_handler(e,
-                                         consts.Get_Kubernetes_Namespace_Fault_Type,
-                                         'Unable to fetch kubernetes namespace',
-                                         raise_error=False)
+            kubernetes_exception_handler(
+                e,
+                consts.Get_Kubernetes_Namespace_Fault_Type,
+                "Unable to fetch kubernetes namespace",
+                raise_error=False,
+            )
 
 
-def delete_arc_agents(release_namespace, kube_config, kube_context, helm_client_location,
-                      is_arm64_cluster=False, no_hooks=False):
+def delete_arc_agents(
+    release_namespace,
+    kube_config,
+    kube_context,
+    helm_client_location,
+    is_arm64_cluster=False,
+    no_hooks=False,
+):
     print("Step: {}: Uninstalling Arc Agents' Helm release".format(get_utctimestring()))
-    if (no_hooks):
-        cmd_helm_delete = [helm_client_location, "delete", "azure-arc", "--namespace", release_namespace, "--no-hooks"]
+    if no_hooks:
+        cmd_helm_delete = [
+            helm_client_location,
+            "delete",
+            "azure-arc",
+            "--namespace",
+            release_namespace,
+            "--no-hooks",
+        ]
     else:
-        cmd_helm_delete = [helm_client_location, "delete", "azure-arc", "--namespace", release_namespace]
+        cmd_helm_delete = [
+            helm_client_location,
+            "delete",
+            "azure-arc",
+            "--namespace",
+            release_namespace,
+        ]
     if is_arm64_cluster:
         cmd_helm_delete.extend(["--timeout", "15m"])
     if kube_config:
@@ -766,16 +1137,24 @@ def delete_arc_agents(release_namespace, kube_config, kube_context, helm_client_
     response_helm_delete = Popen(cmd_helm_delete, stdout=PIPE, stderr=PIPE)
     _, error_helm_delete = response_helm_delete.communicate()
     if response_helm_delete.returncode != 0:
-        if 'forbidden' in error_helm_delete.decode("ascii") or \
-                'Error: warning: Hook pre-delete' in error_helm_delete.decode("ascii") or \
-                'Error: timed out waiting for the condition' in error_helm_delete.decode("ascii"):
+        if (
+            "forbidden" in error_helm_delete.decode("ascii")
+            or "Error: warning: Hook pre-delete" in error_helm_delete.decode("ascii")
+            or "Error: timed out waiting for the condition"
+            in error_helm_delete.decode("ascii")
+        ):
             telemetry.set_user_fault()
-        telemetry.set_exception(exception=error_helm_delete.decode("ascii"),
-                                fault_type=consts.Delete_HelmRelease_Fault_Type,
-                                summary='Unable to delete helm release')
-        err_msg = "Error occured while cleaning up arc agents. Helm release deletion failed: " + \
-            error_helm_delete.decode("ascii") + " Please run 'helm delete azure-arc --namespace {}' to ensure that " \
+        telemetry.set_exception(
+            exception=error_helm_delete.decode("ascii"),
+            fault_type=consts.Delete_HelmRelease_Fault_Type,
+            summary="Unable to delete helm release",
+        )
+        err_msg = (
+            "Error occured while cleaning up arc agents. Helm release deletion failed: "
+            + error_helm_delete.decode("ascii")
+            + " Please run 'helm delete azure-arc --namespace {}' to ensure that "
             "the release is deleted.".format(release_namespace)
+        )
         raise CLIInternalError(err_msg)
     ensure_namespace_cleanup()
     # Cleanup azure-arc-release NS if present (created during helm installation)
@@ -783,8 +1162,11 @@ def delete_arc_agents(release_namespace, kube_config, kube_context, helm_client_
 
 
 def cleanup_release_install_namespace_if_exists():
-    print("Step: {}: Clean up release namespace '{}'.".format(
-        get_utctimestring(), consts.Release_Install_Namespace))
+    print(
+        "Step: {}: Clean up release namespace '{}'.".format(
+            get_utctimestring(), consts.Release_Install_Namespace
+        )
+    )
     api_instance = kube_client.CoreV1Api()
     try:
         api_instance.read_namespace(consts.Release_Install_Namespace)
@@ -796,10 +1178,12 @@ def cleanup_release_install_namespace_if_exists():
         kubernetes_exception_handler(
             ex,
             consts.Get_Kubernetes_Helm_Release_Namespace_Fault_Type,
-            error_message='Unable to fetch details about existense of kubernetes '
-            'namespace: {}'.format(consts.Release_Install_Namespace),
-            summary='Unable to fetch kubernetes '
-            'namespace: {}'.format(consts.Release_Install_Namespace))
+            error_message="Unable to fetch details about existense of kubernetes "
+            "namespace: {}".format(consts.Release_Install_Namespace),
+            summary="Unable to fetch kubernetes " "namespace: {}".format(
+                consts.Release_Install_Namespace
+            ),
+        )
 
     # If namespace exists, delete it
     try:
@@ -808,69 +1192,132 @@ def cleanup_release_install_namespace_if_exists():
         kubernetes_exception_handler(
             ex,
             consts.Delete_Kubernetes_Helm_Release_Namespace_Fault_Type,
-            error_message='Unable to clean-up kubernetes '
-            'namespace: {}'.format(consts.Release_Install_Namespace),
-            summary='Unable to delete kubernetes '
-            'namespace: {}'.format(consts.Release_Install_Namespace))
+            error_message="Unable to clean-up kubernetes " "namespace: {}".format(
+                consts.Release_Install_Namespace
+            ),
+            summary="Unable to delete kubernetes " "namespace: {}".format(
+                consts.Release_Install_Namespace
+            ),
+        )
 
 
 # DO NOT use this method for re-put scenarios. This method involves new NS creation for helm release. For re-put scenarios, brownfield scenario needs to be handled where helm release still stays in default NS
-def helm_install_release(resource_manager, chart_path, kubernetes_distro, kubernetes_infra, location, private_key_pem,
-                         kube_config, kube_context, no_wait, values_file, cloud_name, enable_custom_locations, custom_locations_oid,
-                         helm_client_location, enable_private_link, arm_metadata, onboarding_timeout=consts.DEFAULT_MAX_ONBOARDING_TIMEOUT_HELMVALUE_SECONDS,
-                         helm_content_values=None):
-
-    cmd_helm_install = [helm_client_location, "upgrade", "--install", "azure-arc", chart_path,
-                        "--set", "global.kubernetesDistro={}".format(kubernetes_distro),
-                        "--set", "global.kubernetesInfra={}".format(kubernetes_infra),
-                        "--set", "global.onboardingPrivateKey={}".format(private_key_pem),
-                        "--set", "systemDefaultValues.spnOnboarding=false",
-                        "--set", "global.azureEnvironment={}".format(cloud_name),
-                        "--set", "systemDefaultValues.clusterconnect-agent.enabled=true",
-                        "--namespace", "{}".format(consts.Release_Install_Namespace),
-                        "--create-namespace",
-                        "--output", "json"]
+def helm_install_release(
+    resource_manager,
+    chart_path,
+    kubernetes_distro,
+    kubernetes_infra,
+    location,
+    private_key_pem,
+    kube_config,
+    kube_context,
+    no_wait,
+    values_file,
+    cloud_name,
+    enable_custom_locations,
+    custom_locations_oid,
+    helm_client_location,
+    enable_private_link,
+    arm_metadata,
+    onboarding_timeout=consts.DEFAULT_MAX_ONBOARDING_TIMEOUT_HELMVALUE_SECONDS,
+    helm_content_values=None,
+):
+    cmd_helm_install = [
+        helm_client_location,
+        "upgrade",
+        "--install",
+        "azure-arc",
+        chart_path,
+        "--set",
+        "global.kubernetesDistro={}".format(kubernetes_distro),
+        "--set",
+        "global.kubernetesInfra={}".format(kubernetes_infra),
+        "--set",
+        "global.onboardingPrivateKey={}".format(private_key_pem),
+        "--set",
+        "systemDefaultValues.spnOnboarding=false",
+        "--set",
+        "global.azureEnvironment={}".format(cloud_name),
+        "--set",
+        "systemDefaultValues.clusterconnect-agent.enabled=true",
+        "--namespace",
+        "{}".format(consts.Release_Install_Namespace),
+        "--create-namespace",
+        "--output",
+        "json",
+    ]
 
     # Special configurations from 2022-09-01 ARM metadata.
     if "dataplaneEndpoints" in arm_metadata:
         if "arcConfigEndpoint" in arm_metadata["dataplaneEndpoints"]:
-            notification_endpoint = arm_metadata["dataplaneEndpoints"]["arcGlobalNotificationServiceEndpoint"]
+            notification_endpoint = arm_metadata["dataplaneEndpoints"][
+                "arcGlobalNotificationServiceEndpoint"
+            ]
             config_endpoint = arm_metadata["dataplaneEndpoints"]["arcConfigEndpoint"]
-            his_endpoint = arm_metadata["dataplaneEndpoints"]["arcHybridIdentityServiceEndpoint"]
+            his_endpoint = arm_metadata["dataplaneEndpoints"][
+                "arcHybridIdentityServiceEndpoint"
+            ]
             if his_endpoint[-1] != "/":
                 his_endpoint = his_endpoint + "/"
-            his_endpoint = his_endpoint + f"discovery?location={location}&api-version=1.0-preview"
+            his_endpoint = (
+                his_endpoint + f"discovery?location={location}&api-version=1.0-preview"
+            )
             relay_endpoint = arm_metadata["suffixes"]["relayEndpointSuffix"]
             active_directory = arm_metadata["authentication"]["loginEndpoint"]
             cmd_helm_install.extend(
                 [
-                    "--set", "systemDefaultValues.azureResourceManagerEndpoint={}".
-                    format(resource_manager),
-                    "--set", "systemDefaultValues.azureArcAgents.config_dp_endpoint_override={}".
-                    format(config_endpoint),
-                    "--set", "systemDefaultValues.clusterconnect-agent.notification_dp_endpoint_override={}".
-                    format(notification_endpoint),
-                    "--set", "systemDefaultValues.clusterconnect-agent.relay_endpoint_suffix_override={}".
-                    format(relay_endpoint),
-                    "--set", "systemDefaultValues.clusteridentityoperator.his_endpoint_override={}".
-                    format(his_endpoint),
-                    "--set", "systemDefaultValues.activeDirectoryEndpoint={}".
-                    format(active_directory)
+                    "--set",
+                    "systemDefaultValues.azureResourceManagerEndpoint={}".format(
+                        resource_manager
+                    ),
+                    "--set",
+                    "systemDefaultValues.azureArcAgents.config_dp_endpoint_override={}".format(
+                        config_endpoint
+                    ),
+                    "--set",
+                    "systemDefaultValues.clusterconnect-agent.notification_dp_endpoint_override={}".format(
+                        notification_endpoint
+                    ),
+                    "--set",
+                    "systemDefaultValues.clusterconnect-agent.relay_endpoint_suffix_override={}".format(
+                        relay_endpoint
+                    ),
+                    "--set",
+                    "systemDefaultValues.clusteridentityoperator.his_endpoint_override={}".format(
+                        his_endpoint
+                    ),
+                    "--set",
+                    "systemDefaultValues.activeDirectoryEndpoint={}".format(
+                        active_directory
+                    ),
                 ]
             )
         else:
-            logger.debug("'arcConfigEndpoint' doesn't exist under 'dataplaneEndpoints' in the ARM metadata.")
+            logger.debug(
+                "'arcConfigEndpoint' doesn't exist under 'dataplaneEndpoints' in the ARM metadata."
+            )
 
     # Add helmValues content response from DP
     cmd_helm_install = parse_helm_values(helm_content_values, cmd_helm=cmd_helm_install)
 
     # Add custom-locations related params
     if enable_custom_locations and not enable_private_link:
-        cmd_helm_install.extend(["--set", "systemDefaultValues.customLocations.enabled=true"])
-        cmd_helm_install.extend(["--set", "systemDefaultValues.customLocations.oid={}".format(custom_locations_oid)])
+        cmd_helm_install.extend(
+            ["--set", "systemDefaultValues.customLocations.enabled=true"]
+        )
+        cmd_helm_install.extend(
+            [
+                "--set",
+                "systemDefaultValues.customLocations.oid={}".format(
+                    custom_locations_oid
+                ),
+            ]
+        )
     # Disable cluster connect if private link is enabled
     if enable_private_link is True:
-        cmd_helm_install.extend(["--set", "systemDefaultValues.clusterconnect-agent.enabled=false"])
+        cmd_helm_install.extend(
+            ["--set", "systemDefaultValues.clusterconnect-agent.enabled=false"]
+        )
     # To set some other helm parameters through file
     if values_file:
         cmd_helm_install.extend(["-f", values_file])
@@ -881,25 +1328,50 @@ def helm_install_release(resource_manager, chart_path, kubernetes_distro, kubern
     if not no_wait:
         # Change --timeout format for helm client to understand
         onboarding_timeout = onboarding_timeout + "s"
-        cmd_helm_install.extend(["--wait", "--timeout", "{}".format(onboarding_timeout)])
+        cmd_helm_install.extend(
+            ["--wait", "--timeout", "{}".format(onboarding_timeout)]
+        )
     response_helm_install = Popen(cmd_helm_install, stdout=PIPE, stderr=PIPE)
     _, error_helm_install = response_helm_install.communicate()
     if response_helm_install.returncode != 0:
         helm_install_error_message = error_helm_install.decode("ascii")
-        if any(message in helm_install_error_message for message in consts.Helm_Install_Release_Userfault_Messages):
+        if any(
+            message in helm_install_error_message
+            for message in consts.Helm_Install_Release_Userfault_Messages
+        ):
             telemetry.set_user_fault()
-        telemetry.set_exception(exception=helm_install_error_message, fault_type=consts.Install_HelmRelease_Fault_Type,
-                                summary='Unable to install helm release')
-        warn_msg = "Please check if the azure-arc namespace was deployed and run 'kubectl get pods -n azure-arc' " \
-            "to check if all the pods are in running state. A possible cause for pods stuck in pending " \
+        telemetry.set_exception(
+            exception=helm_install_error_message,
+            fault_type=consts.Install_HelmRelease_Fault_Type,
+            summary="Unable to install helm release",
+        )
+        warn_msg = (
+            "Please check if the azure-arc namespace was deployed and run 'kubectl get pods -n azure-arc' "
+            "to check if all the pods are in running state. A possible cause for pods stuck in pending "
             "state could be insufficient resources on the kubernetes cluster to onboard to arc."
+        )
         logger.warning(warn_msg)
-        raise CLIInternalError("Unable to install helm release: " + error_helm_install.decode("ascii"))
+        raise CLIInternalError(
+            "Unable to install helm release: " + error_helm_install.decode("ascii")
+        )
 
 
-def get_release_namespace(kube_config, kube_context, helm_client_location, release_name='azure-arc'):
-    print("Step: {}: Get namespace of release: {}".format(get_utctimestring(), release_name))
-    cmd_helm_release = [helm_client_location, "list", "-a", "--all-namespaces", "--output", "json"]
+def get_release_namespace(
+    kube_config, kube_context, helm_client_location, release_name="azure-arc"
+):
+    print(
+        "Step: {}: Get namespace of release: {}".format(
+            get_utctimestring(), release_name
+        )
+    )
+    cmd_helm_release = [
+        helm_client_location,
+        "list",
+        "-a",
+        "--all-namespaces",
+        "--output",
+        "json",
+    ]
     if kube_config:
         cmd_helm_release.extend(["--kubeconfig", kube_config])
     if kube_context:
@@ -907,38 +1379,48 @@ def get_release_namespace(kube_config, kube_context, helm_client_location, relea
     response_helm_release = Popen(cmd_helm_release, stdout=PIPE, stderr=PIPE)
     output_helm_release, error_helm_release = response_helm_release.communicate()
     if response_helm_release.returncode != 0:
-        if 'forbidden' in error_helm_release.decode("ascii") or \
-                "Kubernetes cluster unreachable" in error_helm_release.decode("ascii"):
+        if "forbidden" in error_helm_release.decode(
+            "ascii"
+        ) or "Kubernetes cluster unreachable" in error_helm_release.decode("ascii"):
             telemetry.set_user_fault()
         telemetry.set_exception(
             exception=error_helm_release.decode("ascii"),
             fault_type=consts.List_HelmRelease_Fault_Type,
-            summary='Unable to list helm release')
-        raise CLIInternalError("Helm list release failed: " + error_helm_release.decode("ascii"))
+            summary="Unable to list helm release",
+        )
+        raise CLIInternalError(
+            "Helm list release failed: " + error_helm_release.decode("ascii")
+        )
     output_helm_release = output_helm_release.decode("ascii")
     try:
         output_helm_release = json.loads(output_helm_release)
     except json.decoder.JSONDecodeError:
         return None
     for release in output_helm_release:
-        if release['name'] == release_name:
-            return release['namespace']
+        if release["name"] == release_name:
+            return release["namespace"]
     return None
 
 
-def flatten(dd, separator='.', prefix=''):
+def flatten(dd, separator=".", prefix=""):
     try:
         if isinstance(dd, dict):
-            return {prefix + separator + k if prefix else
-                    k: v for kk, vv in dd.items() for k, v in flatten(vv, separator, kk).items()}
+            return {
+                prefix + separator + k if prefix else k: v
+                for kk, vv in dd.items()
+                for k, v in flatten(vv, separator, kk).items()
+            }
         else:
             return {prefix: dd}
     except Exception as e:
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Error_Flattening_User_Supplied_Value_Dict,
-            summary='Error while flattening the user supplied helm values dict')
-        raise CLIInternalError("Error while flattening the user supplied helm values dict")
+            summary="Error while flattening the user supplied helm values dict",
+        )
+        raise CLIInternalError(
+            "Error while flattening the user supplied helm values dict"
+        )
 
 
 def check_features_to_update(features_to_update):
@@ -958,13 +1440,16 @@ def user_confirmation(message, yes=False):
         return
     try:
         if not prompt_y_n(message):
-            raise ManualInterrupt('Operation cancelled.')
+            raise ManualInterrupt("Operation cancelled.")
     except NoTTYException:
-        raise CLIInternalError('Unable to prompt for confirmation as no tty available. Use --yes.')
+        raise CLIInternalError(
+            "Unable to prompt for confirmation as no tty available. Use --yes."
+        )
 
 
 def is_guid(guid):
     import uuid
+
     try:
         uuid.UUID(guid)
         return True
@@ -981,66 +1466,117 @@ def try_list_node_fix():
 
         V1ContainerImage.names = V1ContainerImage.names.setter(names)
     except Exception as ex:
-        logger.debug("Error while trying to monkey patch the fix for list_node(): {}".format(str(ex)))
+        logger.debug(
+            "Error while trying to monkey patch the fix for list_node(): {}".format(
+                str(ex)
+            )
+        )
 
 
-def check_provider_registrations(cli_ctx, subscription_id, is_gateway_enabled, is_workload_identity_enabled):
+def check_provider_registrations(
+    cli_ctx, subscription_id, is_gateway_enabled, is_workload_identity_enabled
+):
     print("Step: {}: Checking Provider Registrations".format(get_utctimestring()))
     try:
         rp_client = resource_providers_client(cli_ctx, subscription_id)
-        cc_registration_state = rp_client.get(consts.Connected_Cluster_Provider_Namespace).registration_state
+        cc_registration_state = rp_client.get(
+            consts.Connected_Cluster_Provider_Namespace
+        ).registration_state
         if cc_registration_state != "Registered":
             telemetry.set_exception(
-                exception="{} provider is not registered".format(consts.Connected_Cluster_Provider_Namespace),
+                exception="{} provider is not registered".format(
+                    consts.Connected_Cluster_Provider_Namespace
+                ),
                 fault_type=consts.CC_Provider_Namespace_Not_Registered_Fault_Type,
-                summary="{} provider is not registered".format(consts.Connected_Cluster_Provider_Namespace))
-            err_msg = "{} provider is not registered. Please register it using 'az provider register -n 'Microsoft." \
-                "Kubernetes' before running the connect command.".format(consts.Connected_Cluster_Provider_Namespace)
+                summary="{} provider is not registered".format(
+                    consts.Connected_Cluster_Provider_Namespace
+                ),
+            )
+            err_msg = (
+                "{} provider is not registered. Please register it using 'az provider register -n 'Microsoft."
+                "Kubernetes' before running the connect command.".format(
+                    consts.Connected_Cluster_Provider_Namespace
+                )
+            )
             raise ValidationError(err_msg)
-        kc_registration_state = rp_client.get(consts.Kubernetes_Configuration_Provider_Namespace).registration_state
+        kc_registration_state = rp_client.get(
+            consts.Kubernetes_Configuration_Provider_Namespace
+        ).registration_state
         if kc_registration_state != "Registered":
             if is_workload_identity_enabled:
                 telemetry.set_exception(
-                    exception="{} provider is not registered".format(consts.Kubernetes_Configuration_Provider_Namespace),
+                    exception="{} provider is not registered".format(
+                        consts.Kubernetes_Configuration_Provider_Namespace
+                    ),
                     fault_type=consts.Kubernetes_Configuration_Provider_Namespace_Not_Registered_Fault_Type,
-                    summary="{} provider is not registered".format(consts.Kubernetes_Configuration_Provider_Namespace))
-                err_msg = "{} provider is not registered. Please register it using 'az provider register -n 'Microsoft." \
-                    "KubernetesConfiguration' before running the connect command.".format(consts.Kubernetes_Configuration_Provider_Namespace)
+                    summary="{} provider is not registered".format(
+                        consts.Kubernetes_Configuration_Provider_Namespace
+                    ),
+                )
+                err_msg = (
+                    "{} provider is not registered. Please register it using 'az provider register -n 'Microsoft."
+                    "KubernetesConfiguration' before running the connect command.".format(
+                        consts.Kubernetes_Configuration_Provider_Namespace
+                    )
+                )
                 raise ValidationError(err_msg)
-            
+
             telemetry.set_user_fault()
-            logger.warning("{} provider is not registered".format(consts.Kubernetes_Configuration_Provider_Namespace))
+            logger.warning(
+                "{} provider is not registered".format(
+                    consts.Kubernetes_Configuration_Provider_Namespace
+                )
+            )
         if is_gateway_enabled:
-            hc_registration_state = rp_client.get(consts.Hybrid_Compute_Provider_Namespace).registration_state
+            hc_registration_state = rp_client.get(
+                consts.Hybrid_Compute_Provider_Namespace
+            ).registration_state
             if hc_registration_state != "Registered":
                 telemetry.set_exception(
-                    exception="{} provider is not registered".format(consts.Hybrid_Compute_Provider_Namespace),
+                    exception="{} provider is not registered".format(
+                        consts.Hybrid_Compute_Provider_Namespace
+                    ),
                     fault_type=consts.HC_Provider_Namespace_Not_Registered_Fault_Type,
-                    summary="{} provider is not registered".format(consts.Hybrid_Compute_Provider_Namespace))
-                err_msg = "{} provider is not registered. Please register it using 'az provider register -n 'Microsoft." \
-                    "HybridCompute' before running the connect command.".format(consts.Hybrid_Compute_Provider_Namespace)
+                    summary="{} provider is not registered".format(
+                        consts.Hybrid_Compute_Provider_Namespace
+                    ),
+                )
+                err_msg = (
+                    "{} provider is not registered. Please register it using 'az provider register -n 'Microsoft."
+                    "HybridCompute' before running the connect command.".format(
+                        consts.Hybrid_Compute_Provider_Namespace
+                    )
+                )
                 raise ValidationError(err_msg)
     except ValidationError as e:
         raise e
     except Exception as ex:
-        logger.warning("Couldn't check the required provider's registration status. Error: {}".format(str(ex)))
+        logger.warning(
+            "Couldn't check the required provider's registration status. Error: {}".format(
+                str(ex)
+            )
+        )
 
 
 def can_create_clusterrolebindings():
     try:
         api_instance = kube_client.AuthorizationV1Api()
-        access_review = kube_client.V1SelfSubjectAccessReview(spec={
-            "resourceAttributes": {
-                "verb": "create",
-                "resource": "clusterrolebindings",
-                "group": "rbac.authorization.k8s.io"
+        access_review = kube_client.V1SelfSubjectAccessReview(
+            spec={
+                "resourceAttributes": {
+                    "verb": "create",
+                    "resource": "clusterrolebindings",
+                    "group": "rbac.authorization.k8s.io",
+                }
             }
-        })
+        )
         response = api_instance.create_self_subject_access_review(access_review)
         return response.status.allowed
     except Exception as ex:
-        warn_msg = "Couldn't check for the permission to create clusterrolebindings on this k8s cluster. " \
+        warn_msg = (
+            "Couldn't check for the permission to create clusterrolebindings on this k8s cluster. "
             "Error: {}".format(str(ex))
+        )
         logger.warning(warn_msg)
         return "Unknown"
 
@@ -1051,7 +1587,11 @@ def validate_node_api_response(api_instance, node_api_response):
             node_api_response = api_instance.list_node()
             return node_api_response
         except Exception as ex:
-            logger.debug("Error occcured while listing nodes on this kubernetes cluster: {}".format(str(ex)))
+            logger.debug(
+                "Error occcured while listing nodes on this kubernetes cluster: {}".format(
+                    str(ex)
+                )
+            )
             return None
     else:
         return node_api_response
@@ -1060,7 +1600,7 @@ def validate_node_api_response(api_instance, node_api_response):
 def az_cli(args_str):
     args = args_str.split()
     cli = get_default_cli()
-    cli.invoke(args, out_file=open(os.devnull, 'w'))
+    cli.invoke(args, out_file=open(os.devnull, "w"))
     if cli.result.result:
         return cli.result.result
     if cli.result.error:
@@ -1079,12 +1619,15 @@ def az_cli(args_str):
 #     else:
 #         return False
 
+
 def is_cli_using_msal_auth():
     response_cli_version = az_cli("version --output json")
     try:
-        cli_version = response_cli_version['azure-cli']
+        cli_version = response_cli_version["azure-cli"]
     except Exception as ex:
-        raise CLIInternalError("Unable to decode the az cli version installed: {}".format(str(ex)))
+        raise CLIInternalError(
+            "Unable to decode the az cli version installed: {}".format(str(ex))
+        )
     v1 = cli_version
     v2 = consts.AZ_CLI_ADAL_TO_MSAL_MIGRATE_VERSION
     for i, j in zip(map(int, v1.split(".")), map(int, v2.split("."))):
@@ -1099,6 +1642,7 @@ def get_metadata(arm_endpoint, api_version="2022-09-01"):
     metadata_endpoint = None
     try:
         import requests
+
         session = requests.Session()
         metadata_endpoint = arm_endpoint + metadata_url_suffix
         response = session.get(metadata_endpoint)
@@ -1110,7 +1654,10 @@ def get_metadata(arm_endpoint, api_version="2022-09-01"):
     except Exception as err:
         msg = f"Failed to request ARM metadata {metadata_endpoint}."
         print(msg, file=sys.stderr)
-        print(f"Please ensure you have network connection. Error: {str(err)}", file=sys.stderr)
+        print(
+            f"Please ensure you have network connection. Error: {str(err)}",
+            file=sys.stderr,
+        )
         arm_exception_handler(err, msg)
 
 
@@ -1128,30 +1675,68 @@ def get_utctimestring():
     return time.strftime("%Y-%m-%dT%H-%M-%SZ", time.gmtime())
 
 
-def helm_update_agent(helm_client_location, kube_config, kube_context, helm_content_values, values_file, 
-                      cluster_name, release_namespace, chart_path):
-    cmd_helm_values = [helm_client_location, "get", "values", "azure-arc", "--namespace", release_namespace]
+def helm_update_agent(
+    helm_client_location,
+    kube_config,
+    kube_context,
+    helm_content_values,
+    values_file,
+    cluster_name,
+    release_namespace,
+    chart_path,
+):
+    cmd_helm_values = [
+        helm_client_location,
+        "get",
+        "values",
+        "azure-arc",
+        "--namespace",
+        release_namespace,
+    ]
     if kube_config:
         cmd_helm_values.extend(["--kubeconfig", kube_config])
     if kube_context:
         cmd_helm_values.extend(["--kube-context", kube_context])
 
-    user_values_location = os.path.join(os.path.expanduser('~'), '.azure', 'userValues.txt')
-    existing_user_values = open(user_values_location, 'w+')
-    response_helm_values_get = Popen(cmd_helm_values, stdout=existing_user_values, stderr=PIPE)
+    user_values_location = os.path.join(
+        os.path.expanduser("~"), ".azure", "userValues.txt"
+    )
+    existing_user_values = open(user_values_location, "w+")
+    response_helm_values_get = Popen(
+        cmd_helm_values, stdout=existing_user_values, stderr=PIPE
+    )
     _, error_helm_get_values = response_helm_values_get.communicate()
     if response_helm_values_get.returncode != 0:
-        if ('forbidden' in error_helm_get_values.decode("ascii") or
-                'timed out waiting for the condition' in error_helm_get_values.decode("ascii")):
+        if "forbidden" in error_helm_get_values.decode(
+            "ascii"
+        ) or "timed out waiting for the condition" in error_helm_get_values.decode(
+            "ascii"
+        ):
             telemetry.set_user_fault()
             telemetry.set_exception(
                 exception=error_helm_get_values.decode("ascii"),
                 fault_type=consts.Get_Helm_Values_Failed,
-                summary='Error while doing helm get values azure-arc')
-            raise CLIInternalError(str.format(consts.Update_Agent_Failure, error_helm_get_values.decode("ascii")))
-    
-    cmd_helm_upgrade = [helm_client_location, "upgrade", "azure-arc", chart_path, "--namespace", release_namespace,
-                        "-f", user_values_location, "--wait", "--output", "json"]
+                summary="Error while doing helm get values azure-arc",
+            )
+            raise CLIInternalError(
+                str.format(
+                    consts.Update_Agent_Failure, error_helm_get_values.decode("ascii")
+                )
+            )
+
+    cmd_helm_upgrade = [
+        helm_client_location,
+        "upgrade",
+        "azure-arc",
+        chart_path,
+        "--namespace",
+        release_namespace,
+        "-f",
+        user_values_location,
+        "--wait",
+        "--output",
+        "json",
+    ]
     # Add helmValues content response from DP
     cmd_helm_upgrade = parse_helm_values(helm_content_values, cmd_helm=cmd_helm_upgrade)
     if values_file:
@@ -1164,17 +1749,23 @@ def helm_update_agent(helm_client_location, kube_config, kube_context, helm_cont
     _, error_helm_upgrade = response_helm_upgrade.communicate()
     if response_helm_upgrade.returncode != 0:
         helm_upgrade_error_message = error_helm_upgrade.decode("ascii")
-        if any(message in helm_upgrade_error_message for message in consts.Helm_Install_Release_Userfault_Messages):
+        if any(
+            message in helm_upgrade_error_message
+            for message in consts.Helm_Install_Release_Userfault_Messages
+        ):
             telemetry.set_user_fault()
         telemetry.set_exception(
             exception=error_helm_upgrade.decode("ascii"),
             fault_type=consts.Install_HelmRelease_Fault_Type,
-            summary='Unable to install helm release')
+            summary="Unable to install helm release",
+        )
         try:
             os.remove(user_values_location)
         except OSError:
             pass
-        raise CLIInternalError(str.format(consts.Update_Agent_Failure, error_helm_upgrade.decode("ascii")))
+        raise CLIInternalError(
+            str.format(consts.Update_Agent_Failure, error_helm_upgrade.decode("ascii"))
+        )
 
     logger.info(str.format(consts.Update_Agent_Success, cluster_name))
     try:

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -11,9 +11,7 @@ import subprocess
 from subprocess import Popen, PIPE
 import time
 from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 import json
-from knack.util import CLIError
 from knack.log import get_logger
 from knack.prompting import NoTTYException, prompt_y_n
 from azure.cli.core.commands.client_factory import get_subscription_id

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -156,7 +156,7 @@ def get_chart_path(
     try:
         if os.path.isdir(chart_export_path):
             shutil.rmtree(chart_export_path)
-    except:
+    except OSError:
         logger.warning(
             "Unable to cleanup the {} already present on the machine. In case of failure, please cleanup "
             "the directory '{}' and try again.".format(

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -543,7 +543,7 @@ def check_cluster_outbound_connectivity(
                     + "\nIf your cluster is behind an outbound proxy server, "
                     " please ensure that you have passed proxy parameters during the onboarding of your cluster.\n"
                     "For more details visit "
-                    + consts.Quick_Start_Outbound_Proxy_Url
+                    + consts.Doc_Quick_Start_Outbound_Proxy_Url
                     + " \n"
                 )
                 logger.warning(outbound_connectivity_failed_warning_message)
@@ -884,20 +884,20 @@ def health_check_dp(cmd, config_dp_endpoint):
         "post",
         chart_location_url,
         headers=headers,
-        fault_type=consts.Get_HelmRegistery_Path_Fault_Type,
+        fault_type=consts.DP_Health_Check_Fault_Type,
         summary="Error while performing DP health check",
         uri_parameters=uri_parameters,
         resource=resource,
     )
     if r.status_code == 200:
         return True
-    else:
-        telemetry.set_exception(
-            exception="Error while performing DP health check",
-            fault_type=consts.DP_Health_Check,
-            summary="Error while performing DP health check",
-        )
-        raise CLIInternalError("Error while performing DP health check")
+
+    telemetry.set_exception(
+        exception="Error while performing DP health check",
+        fault_type=consts.DP_Health_Check_Fault_Type,
+        summary="Error while performing DP health check",
+    )
+    raise CLIInternalError("Error while performing DP health check")
 
 
 def send_request_with_retries(
@@ -1168,7 +1168,7 @@ def cleanup_release_install_namespace_if_exists():
     api_instance = kube_client.CoreV1Api()
     try:
         api_instance.read_namespace(consts.Release_Install_Namespace)
-    except Exception as ex:
+    except ApiException as ex:
         if ex.status == 404:
             # Nothing to delete, exiting here
             return
@@ -1656,7 +1656,7 @@ def get_metadata(arm_endpoint, api_version="2022-09-01"):
             f"Please ensure you have network connection. Error: {str(err)}",
             file=sys.stderr,
         )
-        arm_exception_handler(err, msg)
+        arm_exception_handler(err, msg, "Failed to get ARM metadata")
 
 
 def parse_helm_values(helm_content_values, cmd_helm):

--- a/src/connectedk8s/azext_connectedk8s/_validators.py
+++ b/src/connectedk8s/azext_connectedk8s/_validators.py
@@ -5,10 +5,7 @@
 import azext_connectedk8s._constants as consts
 
 
-from os import name
 from azure.cli.core.azclierror import ArgumentUsageError
-from azure.cli.core.azclierror import InvalidArgumentValueError, ArgumentUsageError
-import re
 
 
 def example_name_or_id_validator(cmd, namespace):

--- a/src/connectedk8s/azext_connectedk8s/_validators.py
+++ b/src/connectedk8s/azext_connectedk8s/_validators.py
@@ -7,10 +7,7 @@ import azext_connectedk8s._constants as consts
 
 from os import name
 from azure.cli.core.azclierror import ArgumentUsageError
-from azure.cli.core.azclierror import (
-    InvalidArgumentValueError,
-    ArgumentUsageError
-)
+from azure.cli.core.azclierror import InvalidArgumentValueError, ArgumentUsageError
 import re
 
 
@@ -18,34 +15,49 @@ def example_name_or_id_validator(cmd, namespace):
     # Example of a storage account name or ID validator.
     from azure.cli.core.commands.client_factory import get_subscription_id
     from azure.mgmt.core.tools import is_valid_resource_id, resource_id
+
     if namespace.storage_account:
         if not is_valid_resource_id(namespace.RESOURCE):
             namespace.storage_account = resource_id(
                 subscription=get_subscription_id(cmd.cli_ctx),
                 resource_group=namespace.resource_group_name,
-                namespace='Microsoft.Storage',
-                type='storageAccounts',
-                name=namespace.storage_account
+                namespace="Microsoft.Storage",
+                type="storageAccounts",
+                name=namespace.storage_account,
             )
 
 
 def validate_private_link_properties(namespace):
     if not namespace.enable_private_link and namespace.private_link_scope_resource_id:
-        err_msg = "Conflicting private link parameters received. The parameter '--private-link-scope-resource-id' " \
+        err_msg = (
+            "Conflicting private link parameters received. The parameter '--private-link-scope-resource-id' "
             "should not be set if '--enable-private-link' is passed as null or False."
+        )
         raise ArgumentUsageError(err_msg)
-    if namespace.enable_private_link is True and not namespace.private_link_scope_resource_id:
-        err_msg = "The parameter '--private-link-scope-resource-id' was not provided. It is mandatory to pass this " \
+    if (
+        namespace.enable_private_link is True
+        and not namespace.private_link_scope_resource_id
+    ):
+        err_msg = (
+            "The parameter '--private-link-scope-resource-id' was not provided. It is mandatory to pass this "
             "parameter for enabling private link on the connected cluster resource."
+        )
         raise ArgumentUsageError(err_msg)
 
 
 def override_client_request_id_header(cmd, namespace):
     if namespace.correlation_id is not None:
-        cmd.cli_ctx.data['headers'][consts.Client_Request_Id_Header] = namespace.correlation_id
+        cmd.cli_ctx.data["headers"][consts.Client_Request_Id_Header] = (
+            namespace.correlation_id
+        )
     else:
-        cmd.cli_ctx.data['headers'][consts.Client_Request_Id_Header] = consts.Default_Onboarding_Source_Tracking_Guid
+        cmd.cli_ctx.data["headers"][consts.Client_Request_Id_Header] = (
+            consts.Default_Onboarding_Source_Tracking_Guid
+        )
+
 
 def validate_gateway_updates(namespace):
     if namespace.gateway_resource_id != "" and namespace.disable_gateway:
-        raise ArgumentUsageError("Cannot specify both --gateway-resource-id and --disable-gateway simultaneously.")
+        raise ArgumentUsageError(
+            "Cannot specify both --gateway-resource-id and --disable-gateway simultaneously."
+        )

--- a/src/connectedk8s/azext_connectedk8s/action.py
+++ b/src/connectedk8s/azext_connectedk8s/action.py
@@ -15,7 +15,7 @@ class AddConfigurationSettings(argparse._AppendAction):
             config_settings = {}
         for item in values:
             try:
-                key, value = item.split('=', 1)
+                key, value = item.split("=", 1)
                 feature, setting = key.split(".")
                 # Check if the feature is already in the dictionary
                 if feature not in config_settings:
@@ -24,8 +24,11 @@ class AddConfigurationSettings(argparse._AppendAction):
                 # Update the setting in the feature's dictionary
                 config_settings[feature][setting] = value
             except ValueError as ex:
-                raise ArgumentUsageError('Usage error: {} configuration_setting_key=configuration_setting_value'.
-                                         format(option_string)) from ex
+                raise ArgumentUsageError(
+                    "Usage error: {} configuration_setting_key=configuration_setting_value".format(
+                        option_string
+                    )
+                ) from ex
         setattr(namespace, self.dest, config_settings)
 
 
@@ -37,7 +40,7 @@ class AddConfigurationProtectedSettings(argparse._AppendAction):
             prot_settings = {}
         for item in values:
             try:
-                key, value = item.split('=', 1)
+                key, value = item.split("=", 1)
                 feature, setting = key.split(".")
                 # Check if the feature is already in the dictionary
                 if feature not in prot_settings:
@@ -46,6 +49,8 @@ class AddConfigurationProtectedSettings(argparse._AppendAction):
                 # Add the setting to the feature's dictionary
                 prot_settings[feature][setting] = value
             except ValueError as ex:
-                raise ArgumentUsageError('Usage error: {} configuration_protected_setting_key='
-                                         'configuration_protected_setting_value'.format(option_string)) from ex
+                raise ArgumentUsageError(
+                    "Usage error: {} configuration_protected_setting_key="
+                    "configuration_protected_setting_value".format(option_string)
+                ) from ex
         setattr(namespace, self.dest, prot_settings)

--- a/src/connectedk8s/azext_connectedk8s/commands.py
+++ b/src/connectedk8s/azext_connectedk8s/commands.py
@@ -5,33 +5,49 @@
 
 # pylint: disable=line-too-long
 from azure.cli.core.commands import CliCommandType
-from azext_connectedk8s._client_factory import (cf_connectedk8s, cf_connected_cluster, cf_connectedk8s_prev_2022_10_01, cf_connected_cluster_prev_2022_10_01)
+from azext_connectedk8s._client_factory import (
+    cf_connectedk8s,
+    cf_connected_cluster,
+    cf_connectedk8s_prev_2022_10_01,
+    cf_connected_cluster_prev_2022_10_01,
+)
 from ._format import connectedk8s_show_table_format
 from ._format import connectedk8s_list_table_format
 
 
 def load_command_table(self, _):
-
     connectedk8s_sdk = CliCommandType(
-        operations_tmpl='azext_connectedk8s.vendored_sdks.operations#ConnectedClusterOperations.{}',
-        client_factory=cf_connectedk8s
+        operations_tmpl="azext_connectedk8s.vendored_sdks.operations#ConnectedClusterOperations.{}",
+        client_factory=cf_connectedk8s,
     )
     connectedk8s_sdk_prev = CliCommandType(
-        operations_tmpl='azext_connectedk8s.vendored_sdks.preview_2022_10_01.operations#ConnectedClusterOperations.{}',
-        client_factory=cf_connectedk8s_prev_2022_10_01
+        operations_tmpl="azext_connectedk8s.vendored_sdks.preview_2022_10_01.operations#ConnectedClusterOperations.{}",
+        client_factory=cf_connectedk8s_prev_2022_10_01,
     )
-    with self.command_group('connectedk8s', connectedk8s_sdk, client_factory=cf_connected_cluster) as g:
-        g.custom_command('connect', 'create_connectedk8s', supports_no_wait=True)
-        g.custom_command('update', 'update_connected_cluster')
-        g.custom_command('upgrade', 'upgrade_agents')
-        g.custom_command('delete', 'delete_connectedk8s', supports_no_wait=True)
-        g.custom_command('enable-features', 'enable_features', is_preview=True)
-        g.custom_command('disable-features', 'disable_features', is_preview=True)
-        g.custom_command('list', 'list_connectedk8s', table_transformer=connectedk8s_list_table_format)
-        g.custom_show_command('show', 'get_connectedk8s', table_transformer=connectedk8s_show_table_format)
-        g.custom_command('proxy', 'client_side_proxy_wrapper')
-        g.custom_command('troubleshoot', 'troubleshoot', is_preview=True)
+    with self.command_group(
+        "connectedk8s", connectedk8s_sdk, client_factory=cf_connected_cluster
+    ) as g:
+        g.custom_command("connect", "create_connectedk8s", supports_no_wait=True)
+        g.custom_command("update", "update_connected_cluster")
+        g.custom_command("upgrade", "upgrade_agents")
+        g.custom_command("delete", "delete_connectedk8s", supports_no_wait=True)
+        g.custom_command("enable-features", "enable_features", is_preview=True)
+        g.custom_command("disable-features", "disable_features", is_preview=True)
+        g.custom_command(
+            "list",
+            "list_connectedk8s",
+            table_transformer=connectedk8s_list_table_format,
+        )
+        g.custom_show_command(
+            "show", "get_connectedk8s", table_transformer=connectedk8s_show_table_format
+        )
+        g.custom_command("proxy", "client_side_proxy_wrapper")
+        g.custom_command("troubleshoot", "troubleshoot", is_preview=True)
 
-    with self.command_group('connectedk8s', connectedk8s_sdk_prev, client_factory=cf_connected_cluster_prev_2022_10_01) as g:
+    with self.command_group(
+        "connectedk8s",
+        connectedk8s_sdk_prev,
+        client_factory=cf_connected_cluster_prev_2022_10_01,
+    ) as g:
         pass
         # use this block for using preview sdk client for a command

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -162,11 +162,6 @@ def create_connectedk8s(
         if custom_token_passed is True
         else get_subscription_id(cmd.cli_ctx)
     )
-    if custom_token_passed is True:
-        onboarding_tenant_id = os.getenv("AZURE_TENANT_ID")
-    else:
-        account = Profile().get_subscription(subscription_id)
-        onboarding_tenant_id = account["homeTenantId"]
 
     resource_id = f"/subscriptions/{subscription_id}/resourcegroups/{resource_group_name}/providers/Microsoft.\
         Kubernetes/connectedClusters/{cluster_name}/location/{location}"
@@ -1309,11 +1304,7 @@ def install_helm_client():
 
 def resource_group_exists(ctx, resource_group_name, subscription_id=None):
     groups = cf_resource_groups(ctx, subscription_id=subscription_id)
-    try:
-        groups.get(resource_group_name)
-        return True
-    except:  # pylint: disable=bare-except
-        return False
+    return groups.check_existence(resource_group_name)
 
 
 def connected_cluster_exists(client, resource_group_name, cluster_name):
@@ -1529,9 +1520,7 @@ def generate_arc_agent_configuration(
     if redacted_protected_settings is None:
         redacted_protected_settings = {}
 
-    for feature in set(
-        list(configuration_settings.keys()) + list(redacted_protected_settings.keys())
-    ):
+    for feature in configuration_settings.keys() | redacted_protected_settings.keys():
         settings = configuration_settings.get(feature)
         protected_settings = redacted_protected_settings.get(feature)
         configuration = ArcAgentryConfigurations(
@@ -3679,7 +3668,7 @@ def client_side_proxy_wrapper(
             for f in older_version_files:
                 try:
                     os.remove(f)
-                except:
+                except OSError:
                     logger.warning("failed to delete older version files")
 
         try:

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -47,7 +47,6 @@ from Crypto.Util import asn1
 from azext_connectedk8s._client_factory import cf_resource_groups
 from azext_connectedk8s._client_factory import resource_providers_client
 from azext_connectedk8s._client_factory import (
-    cf_connected_cluster_prev_2022_10_01,
     cf_connected_cluster_prev_2023_11_01,
     cf_connected_cluster_prev_2024_07_01,
 )
@@ -62,9 +61,6 @@ from .vendored_sdks.models import (
     ConnectedCluster,
     ConnectedClusterIdentity,
     ListClusterUserCredentialProperties,
-)
-from .vendored_sdks.preview_2022_10_01.models import (
-    ConnectedCluster as ConnectedClusterPreview,
 )
 from .vendored_sdks.preview_2022_10_01.models import (
     ConnectedClusterPatch as ConnectedClusterPatchPreview,

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -4513,7 +4513,7 @@ def troubleshoot(
             )
 
         connected_cluster = get_connectedk8s_2024_07_01(
-            cmd, client, resource_group_name, cluster_name
+            cmd, resource_group_name, cluster_name
         )
         # saving signing key CR snapshot only if oidc issuer prfile is enabled
         if connected_cluster.oidc_issuer_profile.enabled:

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -28,9 +28,16 @@ from azure.cli.core._profile import Profile
 from azure.cli.core.util import sdk_no_wait
 from azure.cli.core import telemetry
 from azure.cli.core.azclierror import (
-    ManualInterrupt, InvalidArgumentValueError, UnclassifiedUserFault,
-    CLIInternalError, FileOperationError, ClientRequestError, ValidationError,
-    ArgumentUsageError, MutuallyExclusiveArgumentError, RequiredArgumentMissingError
+    ManualInterrupt,
+    InvalidArgumentValueError,
+    UnclassifiedUserFault,
+    CLIInternalError,
+    FileOperationError,
+    ClientRequestError,
+    ValidationError,
+    ArgumentUsageError,
+    MutuallyExclusiveArgumentError,
+    RequiredArgumentMissingError,
 )
 from azure.core.exceptions import HttpResponseError
 from kubernetes import client as kube_client, config
@@ -39,8 +46,11 @@ from Crypto.PublicKey import RSA
 from Crypto.Util import asn1
 from azext_connectedk8s._client_factory import cf_resource_groups
 from azext_connectedk8s._client_factory import resource_providers_client
-from azext_connectedk8s._client_factory import \
-    cf_connected_cluster_prev_2022_10_01, cf_connected_cluster_prev_2023_11_01, cf_connected_cluster_prev_2024_07_01
+from azext_connectedk8s._client_factory import (
+    cf_connected_cluster_prev_2022_10_01,
+    cf_connected_cluster_prev_2023_11_01,
+    cf_connected_cluster_prev_2024_07_01,
+)
 from azext_connectedk8s._client_factory import cf_connectedmachine
 import azext_connectedk8s._constants as consts
 import azext_connectedk8s._utils as utils
@@ -48,17 +58,30 @@ import azext_connectedk8s._clientproxyutils as clientproxyutils
 import azext_connectedk8s._troubleshootutils as troubleshootutils
 import azext_connectedk8s._precheckutils as precheckutils
 from glob import glob
-from .vendored_sdks.models import ConnectedCluster, ConnectedClusterIdentity, ListClusterUserCredentialProperties
-from .vendored_sdks.preview_2022_10_01.models import ConnectedCluster as ConnectedClusterPreview
-from .vendored_sdks.preview_2022_10_01.models import ConnectedClusterPatch as ConnectedClusterPatchPreview
+from .vendored_sdks.models import (
+    ConnectedCluster,
+    ConnectedClusterIdentity,
+    ListClusterUserCredentialProperties,
+)
+from .vendored_sdks.preview_2022_10_01.models import (
+    ConnectedCluster as ConnectedClusterPreview,
+)
+from .vendored_sdks.preview_2022_10_01.models import (
+    ConnectedClusterPatch as ConnectedClusterPatchPreview,
+)
 from .vendored_sdks.preview_2024_07_01.models import (
-    ConnectedCluster as ConnectedCluster2024_07_01_Preview, OidcIssuerProfile,
-    SecurityProfile, SecurityProfileWorkloadIdentity, ArcAgentryConfigurations,
-    Gateway, ArcAgentProfile
+    ConnectedCluster as ConnectedCluster2024_07_01_Preview,
+    OidcIssuerProfile,
+    SecurityProfile,
+    SecurityProfileWorkloadIdentity,
+    ArcAgentryConfigurations,
+    Gateway,
+    ArcAgentProfile,
 )
 import sys
 import hashlib
 import re
+
 logger = get_logger(__name__)
 # pylint:disable=unused-argument
 # pylint: disable=too-many-locals
@@ -67,62 +90,113 @@ logger = get_logger(__name__)
 # pylint: disable=line-too-long
 
 
-def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlation_id=None, https_proxy="", http_proxy="", no_proxy="", proxy_cert="", location=None,
-                        kube_config=None, kube_context=None, no_wait=False, tags=None, distribution='generic', infrastructure='generic',
-                        disable_auto_upgrade=False, cl_oid=None, onboarding_timeout=consts.DEFAULT_MAX_ONBOARDING_TIMEOUT_HELMVALUE_SECONDS, enable_private_link=None,
-                        private_link_scope_resource_id=None, distribution_version=None, azure_hybrid_benefit=None, skip_ssl_verification=False, yes=False, container_log_path=None,
-                        enable_oidc_issuer=False, enable_workload_identity=False, self_hosted_issuer="", gateway_resource_id="", configuration_settings=None,
-                        configuration_protected_settings=None):
+def create_connectedk8s(
+    cmd,
+    client,
+    resource_group_name,
+    cluster_name,
+    correlation_id=None,
+    https_proxy="",
+    http_proxy="",
+    no_proxy="",
+    proxy_cert="",
+    location=None,
+    kube_config=None,
+    kube_context=None,
+    no_wait=False,
+    tags=None,
+    distribution="generic",
+    infrastructure="generic",
+    disable_auto_upgrade=False,
+    cl_oid=None,
+    onboarding_timeout=consts.DEFAULT_MAX_ONBOARDING_TIMEOUT_HELMVALUE_SECONDS,
+    enable_private_link=None,
+    private_link_scope_resource_id=None,
+    distribution_version=None,
+    azure_hybrid_benefit=None,
+    skip_ssl_verification=False,
+    yes=False,
+    container_log_path=None,
+    enable_oidc_issuer=False,
+    enable_workload_identity=False,
+    self_hosted_issuer="",
+    gateway_resource_id="",
+    configuration_settings=None,
+    configuration_protected_settings=None,
+):
     logger.warning("This operation might take a while...\n")
     # changing cli config to push telemetry in 1 hr interval
     try:
-        if cmd.cli_ctx and hasattr(cmd.cli_ctx, 'config'):
-            cmd.cli_ctx.config.set_value('telemetry', 'push_interval_in_hours', '1')
+        if cmd.cli_ctx and hasattr(cmd.cli_ctx, "config"):
+            cmd.cli_ctx.config.set_value("telemetry", "push_interval_in_hours", "1")
     except Exception as e:
-        telemetry.set_exception(exception=e,
-                                fault_type=consts.Failed_To_Change_Telemetry_Push_Interval,
-                                summary="Failed to change the telemetry push interval to 1 hr")
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Failed_To_Change_Telemetry_Push_Interval,
+            summary="Failed to change the telemetry push interval to 1 hr",
+        )
 
     # Validate custom token operation
-    custom_token_passed, location = utils.validate_custom_token(cmd, resource_group_name, location)
+    custom_token_passed, location = utils.validate_custom_token(
+        cmd, resource_group_name, location
+    )
 
     # Prompt for confirmation for few parameters
     if enable_private_link is True:
-        confirmation_message = "The Cluster Connect and Custom Location features are not supported by Private Link at "\
+        confirmation_message = (
+            "The Cluster Connect and Custom Location features are not supported by Private Link at "
             "this time. Enabling Private Link will disable these features. Are you sure you want to continue?"
+        )
         utils.user_confirmation(confirmation_message, yes)
         if cl_oid:
-            logger.warning("Private Link is being enabled, and Custom Location is not supported by Private Link at "
-                           "this time, so the '--custom-locations-oid' parameter will be ignored.")
+            logger.warning(
+                "Private Link is being enabled, and Custom Location is not supported by Private Link at "
+                "this time, so the '--custom-locations-oid' parameter will be ignored."
+            )
     if azure_hybrid_benefit == "True":
-        confirmation_message = "I confirm I have an eligible Windows Server license with Azure Hybrid Benefit to " \
+        confirmation_message = (
+            "I confirm I have an eligible Windows Server license with Azure Hybrid Benefit to "
             "apply this benefit to AKS on HCI or Windows Server. Visit https://aka.ms/ahb-aks for details"
+        )
         utils.user_confirmation(confirmation_message, yes)
 
     # Setting subscription id and tenant Id
-    subscription_id = os.getenv('AZURE_SUBSCRIPTION_ID') if custom_token_passed is True \
+    subscription_id = (
+        os.getenv("AZURE_SUBSCRIPTION_ID")
+        if custom_token_passed is True
         else get_subscription_id(cmd.cli_ctx)
+    )
     if custom_token_passed is True:
-        onboarding_tenant_id = os.getenv('AZURE_TENANT_ID')
+        onboarding_tenant_id = os.getenv("AZURE_TENANT_ID")
     else:
         account = Profile().get_subscription(subscription_id)
-        onboarding_tenant_id = account['homeTenantId']
+        onboarding_tenant_id = account["homeTenantId"]
 
-    resource_id = f'/subscriptions/{subscription_id}/resourcegroups/{resource_group_name}/providers/Microsoft.\
-        Kubernetes/connectedClusters/{cluster_name}/location/{location}'
-    telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.resourceid': resource_id})
+    resource_id = f"/subscriptions/{subscription_id}/resourcegroups/{resource_group_name}/providers/Microsoft.\
+        Kubernetes/connectedClusters/{cluster_name}/location/{location}"
+    telemetry.add_extension_event(
+        "connectedk8s", {"Context.Default.AzureCLI.resourceid": resource_id}
+    )
 
     # Send cloud information to telemetry
     azure_cloud = send_cloud_telemetry(cmd)
 
     # Checking provider registration status
-    utils.check_provider_registrations(cmd.cli_ctx, subscription_id, is_gateway_enabled=bool(gateway_resource_id), 
-                                        is_workload_identity_enabled=(enable_workload_identity or enable_oidc_issuer))
+    utils.check_provider_registrations(
+        cmd.cli_ctx,
+        subscription_id,
+        is_gateway_enabled=bool(gateway_resource_id),
+        is_workload_identity_enabled=(enable_workload_identity or enable_oidc_issuer),
+    )
 
     # Setting kubeconfig
     kube_config = set_kube_config(kube_config)
 
-    print("Step: {}: Escape Proxy Settings, if passed in".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Escape Proxy Settings, if passed in".format(
+            utils.get_utctimestring()
+        )
+    )
 
     # Escaping comma, forward slash present in https proxy urls, needed for helm params.
     https_proxy = escape_proxy_settings(https_proxy)
@@ -135,30 +209,54 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
 
     # check whether proxy cert path exists
     if proxy_cert != "" and (not os.path.exists(proxy_cert)):
-        telemetry.set_exception(exception='Proxy cert path does not exist',
-                                fault_type=consts.Proxy_Cert_Path_Does_Not_Exist_Fault_Type,
-                                summary='Proxy cert path does not exist')
-        raise InvalidArgumentValueError(str.format(consts.Proxy_Cert_Path_Does_Not_Exist_Error, proxy_cert))
+        telemetry.set_exception(
+            exception="Proxy cert path does not exist",
+            fault_type=consts.Proxy_Cert_Path_Does_Not_Exist_Fault_Type,
+            summary="Proxy cert path does not exist",
+        )
+        raise InvalidArgumentValueError(
+            str.format(consts.Proxy_Cert_Path_Does_Not_Exist_Error, proxy_cert)
+        )
 
-    proxy_cert = proxy_cert.replace('\\', r'\\\\')
+    proxy_cert = proxy_cert.replace("\\", r"\\\\")
 
-    configuration_settings, configuration_protected_settings, redacted_protected_values = add_config_protected_settings(http_proxy, https_proxy, no_proxy, proxy_cert, container_log_path, configuration_settings, configuration_protected_settings)
+    (
+        configuration_settings,
+        configuration_protected_settings,
+        redacted_protected_values,
+    ) = add_config_protected_settings(
+        http_proxy,
+        https_proxy,
+        no_proxy,
+        proxy_cert,
+        container_log_path,
+        configuration_settings,
+        configuration_protected_settings,
+    )
     arc_agentry_configurations = None
-    if configuration_protected_settings is not None or configuration_settings is not None:
-        arc_agentry_configurations = generate_arc_agent_configuration(configuration_settings, configuration_protected_settings)
+    if (
+        configuration_protected_settings is not None
+        or configuration_settings is not None
+    ):
+        arc_agentry_configurations = generate_arc_agent_configuration(
+            configuration_settings, configuration_protected_settings
+        )
         client = cf_connected_cluster_prev_2024_07_01(cmd.cli_ctx, None)
 
     # Set preview client if latest preview properties are provided.
-    if enable_private_link is not None or distribution_version is not None or azure_hybrid_benefit is not None \
-        or enable_workload_identity or enable_oidc_issuer or gateway_resource_id != "":
+    if (
+        enable_private_link is not None
+        or distribution_version is not None
+        or azure_hybrid_benefit is not None
+        or enable_workload_identity
+        or enable_oidc_issuer
+        or gateway_resource_id != ""
+    ):
         client = cf_connected_cluster_prev_2024_07_01(cmd.cli_ctx, None)
 
     gateway = None
     if gateway_resource_id != "":
-        gateway = Gateway(
-            enabled=True,
-            resource_id=gateway_resource_id
-        )
+        gateway = Gateway(enabled=True, resource_id=gateway_resource_id)
 
     arc_agent_profile = None
     if disable_auto_upgrade:
@@ -170,7 +268,9 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
         azure_cloud = consts.Azure_DogfoodCloudName
 
     arm_metadata = utils.get_metadata(cmd.cli_ctx.cloud.endpoints.resource_manager)
-    config_dp_endpoint, release_train = get_config_dp_endpoint(cmd, location, values_file, arm_metadata)
+    config_dp_endpoint, release_train = get_config_dp_endpoint(
+        cmd, location, values_file, arm_metadata
+    )
 
     # Loading the kubeconfig file in kubernetes client configuration
     load_kube_config(kube_config, kube_context, skip_ssl_verification)
@@ -190,9 +290,16 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
 
     # check if this is aks_hci low bandwith scenario
     lowbandwidth = False
-    lowbandwith_distros = ["aks_workload", "aks_management", "aks_edge_k3s", "aks_edge_k8s"]
+    lowbandwith_distros = [
+        "aks_workload",
+        "aks_management",
+        "aks_edge_k3s",
+        "aks_edge_k8s",
+    ]
 
-    if (infrastructure.lower() == 'azure_stack_hci') and (distribution.lower() in lowbandwith_distros):
+    if (infrastructure.lower() == "azure_stack_hci") and (
+        distribution.lower() in lowbandwith_distros
+    ):
         lowbandwidth = True
 
     # Install kubectl and helm
@@ -200,168 +307,257 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
         kubectl_client_location = install_kubectl_client()
         helm_client_location = install_helm_client()
     except Exception as e:
-        raise CLIInternalError("An exception has occured while trying to perform kubectl or helm install : {}"
-                               .format(str(e)))
+        raise CLIInternalError(
+            "An exception has occured while trying to perform kubectl or helm install : {}".format(
+                str(e)
+            )
+        )
     # Handling the user manual interrupt
     except KeyboardInterrupt:
-        raise ManualInterrupt('Process terminated externally.')
+        raise ManualInterrupt("Process terminated externally.")
 
     # Pre onboarding checks
     diagnostic_checks = "Failed"
     try:
         # if aks_hci lowbandwidth scenario skip, otherwise continue to perform pre-onboarding check
         if not lowbandwidth:
-            print("Step: {}: Starting Pre-onboarding-check".format(utils.get_utctimestring()))
+            print(
+                "Step: {}: Starting Pre-onboarding-check".format(
+                    utils.get_utctimestring()
+                )
+            )
             batchv1_api_instance = kube_client.BatchV1Api()
             storage_space_available = True
 
             current_time = time.ctime(time.time())
             time_stamp = ""
             for elements in current_time:
-                if (elements == ' '):
-                    time_stamp += '-'
+                if elements == " ":
+                    time_stamp += "-"
                     continue
-                if (elements == ':'):
-                    time_stamp += '.'
+                if elements == ":":
+                    time_stamp += "."
                     continue
                 time_stamp += elements
-            time_stamp = cluster_name + '-' + time_stamp
+            time_stamp = cluster_name + "-" + time_stamp
 
             # Generate the diagnostic folder in a given location
-            filepath_with_timestamp, diagnostic_folder_status = \
-                utils.create_folder_diagnosticlogs(time_stamp, consts.Pre_Onboarding_Check_Logs)
+            filepath_with_timestamp, diagnostic_folder_status = (
+                utils.create_folder_diagnosticlogs(
+                    time_stamp, consts.Pre_Onboarding_Check_Logs
+                )
+            )
 
             if diagnostic_folder_status is not True:
                 storage_space_available = False
 
             # Performing cluster-diagnostic-checks
-            diagnostic_checks, storage_space_available = \
-                precheckutils.fetch_diagnostic_checks_results(api_instance, batchv1_api_instance, helm_client_location,
-                                                              kubectl_client_location, kube_config, kube_context,
-                                                              location, http_proxy, https_proxy, no_proxy, proxy_cert,
-                                                              azure_cloud, filepath_with_timestamp,
-                                                              storage_space_available)
-            precheckutils.fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, 1)
+            diagnostic_checks, storage_space_available = (
+                precheckutils.fetch_diagnostic_checks_results(
+                    api_instance,
+                    batchv1_api_instance,
+                    helm_client_location,
+                    kubectl_client_location,
+                    kube_config,
+                    kube_context,
+                    location,
+                    http_proxy,
+                    https_proxy,
+                    no_proxy,
+                    proxy_cert,
+                    azure_cloud,
+                    filepath_with_timestamp,
+                    storage_space_available,
+                )
+            )
+            precheckutils.fetching_cli_output_logs(
+                filepath_with_timestamp, storage_space_available, 1
+            )
 
             if storage_space_available is False:
-                logger.warning("There is no storage space available on your device and hence not saving cluster "
-                               "diagnostic check logs on your device")
+                logger.warning(
+                    "There is no storage space available on your device and hence not saving cluster "
+                    "diagnostic check logs on your device"
+                )
 
     except Exception as e:
-        ex_msg = "An exception occured while trying to execute pre-onboarding diagnostic checks : {}".format(str(e))
-        summ_msg = "An exception occured while trying to execute pre-onboarding diagnostic checks : {}".format(str(e))
-        telemetry.set_exception(exception=ex_msg,
-                                fault_type=consts.Pre_Onboarding_Diagnostic_Checks_Execution_Failed,
-                                summary=summ_msg)
-        err_msg = "An exception has occured while trying to execute pre-onboarding diagnostic checks : "\
+        ex_msg = "An exception occured while trying to execute pre-onboarding diagnostic checks : {}".format(
+            str(e)
+        )
+        summ_msg = "An exception occured while trying to execute pre-onboarding diagnostic checks : {}".format(
+            str(e)
+        )
+        telemetry.set_exception(
+            exception=ex_msg,
+            fault_type=consts.Pre_Onboarding_Diagnostic_Checks_Execution_Failed,
+            summary=summ_msg,
+        )
+        err_msg = (
+            "An exception has occured while trying to execute pre-onboarding diagnostic checks : "
             "{}".format(str(e))
+        )
         raise CLIInternalError(err_msg)
 
     # Handling the user manual interrupt
     except KeyboardInterrupt:
         try:
-            troubleshootutils.fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, 0)
+            troubleshootutils.fetching_cli_output_logs(
+                filepath_with_timestamp, storage_space_available, 0
+            )
         except Exception:
             pass
-        raise ManualInterrupt('Process terminated externally.')
+        raise ManualInterrupt("Process terminated externally.")
 
     # If the checks didnt pass then stop the onboarding
     if diagnostic_checks != consts.Diagnostic_Check_Passed and lowbandwidth is False:
         if storage_space_available:
-            logger.warning("The pre-check result logs logs have been saved at this path: "
-                           "%s.\nThese logs can be attached while filing a support ticket for further assistance.\n",
-                           filepath_with_timestamp)
-        if (diagnostic_checks == consts.Diagnostic_Check_Incomplete):
-            telemetry.set_exception(exception='Cluster Diagnostic Prechecks Incomplete',
-                                    fault_type=consts.Cluster_Diagnostic_Prechecks_Incomplete,
-                                    summary="Cluster Diagnostic Prechecks didnt complete in the cluster")
-            err_msg = "Execution of pre-onboarding checks failed. So not proceeding with cluster onboarding. Please "\
-                "meet the prerequisites - " + consts.Doc_Onboarding_PreRequisites_Url + " and try onboarding again."
+            logger.warning(
+                "The pre-check result logs logs have been saved at this path: "
+                "%s.\nThese logs can be attached while filing a support ticket for further assistance.\n",
+                filepath_with_timestamp,
+            )
+        if diagnostic_checks == consts.Diagnostic_Check_Incomplete:
+            telemetry.set_exception(
+                exception="Cluster Diagnostic Prechecks Incomplete",
+                fault_type=consts.Cluster_Diagnostic_Prechecks_Incomplete,
+                summary="Cluster Diagnostic Prechecks didnt complete in the cluster",
+            )
+            err_msg = (
+                "Execution of pre-onboarding checks failed. So not proceeding with cluster onboarding. Please "
+                "meet the prerequisites - "
+                + consts.Doc_Onboarding_PreRequisites_Url
+                + " and try onboarding again."
+            )
             raise ValidationError(err_msg)
 
         # if diagnostic_checks != consts.Diagnostic_Check_Incomplete
-        telemetry.set_exception(exception='Cluster Diagnostic Prechecks Failed',
-                                fault_type=consts.Cluster_Diagnostic_Prechecks_Failed,
-                                summary="Cluster Diagnostic Prechecks Failed in the cluster")
-        err_msg = "One or more pre-onboarding diagnostic checks failed and hence not proceeding with "\
+        telemetry.set_exception(
+            exception="Cluster Diagnostic Prechecks Failed",
+            fault_type=consts.Cluster_Diagnostic_Prechecks_Failed,
+            summary="Cluster Diagnostic Prechecks Failed in the cluster",
+        )
+        err_msg = (
+            "One or more pre-onboarding diagnostic checks failed and hence not proceeding with "
             "cluster onboarding. Please resolve them and try onboarding again."
+        )
         raise ValidationError(err_msg)
 
     if lowbandwidth is False:
-        print("Step: {}: The required pre-checks for onboarding have succeeded.".format(utils.get_utctimestring()))
+        print(
+            "Step: {}: The required pre-checks for onboarding have succeeded.".format(
+                utils.get_utctimestring()
+            )
+        )
     else:
-        print("Step: {}: Skipped onboarding pre-checks for AKS-HCI low bandwidth scenario. "
-              "Continuing...".format(utils.get_utctimestring()))
+        print(
+            "Step: {}: Skipped onboarding pre-checks for AKS-HCI low bandwidth scenario. "
+            "Continuing...".format(utils.get_utctimestring())
+        )
 
     if not required_node_exists:
         telemetry.set_user_fault()
-        telemetry.set_exception(exception="Couldn't find any node on the kubernetes cluster with the OS 'linux'",
-                                fault_type=consts.Linux_Node_Not_Exists,
-                                summary="Couldn't find any node on the kubernetes cluster with the OS 'linux'")
-        logger.warning("Please ensure that this Kubernetes cluster has any nodes with OS 'linux', for scheduling the "
-                       "Arc-Agents onto and connecting to Azure. Learn more at %s",
-                       "https://aka.ms/ArcK8sSupportedOSArchitecture")
+        telemetry.set_exception(
+            exception="Couldn't find any node on the kubernetes cluster with the OS 'linux'",
+            fault_type=consts.Linux_Node_Not_Exists,
+            summary="Couldn't find any node on the kubernetes cluster with the OS 'linux'",
+        )
+        logger.warning(
+            "Please ensure that this Kubernetes cluster has any nodes with OS 'linux', for scheduling the "
+            "Arc-Agents onto and connecting to Azure. Learn more at %s",
+            "https://aka.ms/ArcK8sSupportedOSArchitecture",
+        )
 
-    print("Step: {}: Checking if user can create ClusterRoleBindings".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Checking if user can create ClusterRoleBindings".format(
+            utils.get_utctimestring()
+        )
+    )
     crb_permission = utils.can_create_clusterrolebindings()
-    if not crb_permission or crb_permission == 'Unknown':
+    if not crb_permission or crb_permission == "Unknown":
         ex_msg = "Your credentials doesn't have permission to create clusterrolebindings on this kubernetes cluster."
         summ_msg = "Your credentials doesn't have permission to create clusterrolebindings on this kubernetes cluster."
-        telemetry.set_exception(exception=ex_msg,
-                                fault_type=consts.Cannot_Create_ClusterRoleBindings_Fault_Type,
-                                summary=summ_msg)
-        err_msg = "Your credentials doesn't have permission to create clusterrolebindings on this "\
+        telemetry.set_exception(
+            exception=ex_msg,
+            fault_type=consts.Cannot_Create_ClusterRoleBindings_Fault_Type,
+            summary=summ_msg,
+        )
+        err_msg = (
+            "Your credentials doesn't have permission to create clusterrolebindings on this "
             "kubernetes cluster. Please check your permissions."
+        )
         raise ValidationError(err_msg)
 
-    print("Step: {}: Determining Cluster Distribution and Infrastructure".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Determining Cluster Distribution and Infrastructure".format(
+            utils.get_utctimestring()
+        )
+    )
     # Get kubernetes cluster info
-    if distribution == 'generic':
-        kubernetes_distro = get_kubernetes_distro(node_api_response)  # (cluster heuristics)
+    if distribution == "generic":
+        kubernetes_distro = get_kubernetes_distro(
+            node_api_response
+        )  # (cluster heuristics)
     else:
         kubernetes_distro = distribution
 
-    if infrastructure == 'generic':
-        kubernetes_infra = get_kubernetes_infra(node_api_response)  # (cluster heuristics)
+    if infrastructure == "generic":
+        kubernetes_infra = get_kubernetes_infra(
+            node_api_response
+        )  # (cluster heuristics)
     else:
         kubernetes_infra = infrastructure
 
     kubernetes_properties = {
-        'Context.Default.AzureCLI.KubernetesVersion': kubernetes_version,
-        'Context.Default.AzureCLI.KubernetesDistro': kubernetes_distro,
-        'Context.Default.AzureCLI.KubernetesInfra': kubernetes_infra
+        "Context.Default.AzureCLI.KubernetesVersion": kubernetes_version,
+        "Context.Default.AzureCLI.KubernetesDistro": kubernetes_distro,
+        "Context.Default.AzureCLI.KubernetesInfra": kubernetes_infra,
     }
-    telemetry.add_extension_event('connectedk8s', kubernetes_properties)
+    telemetry.add_extension_event("connectedk8s", kubernetes_properties)
 
     # Checking if it is an AKS cluster
     is_aks_cluster = check_aks_cluster(kube_config, kube_context)
     if is_aks_cluster:
-        logger.warning("Connecting an Azure Kubernetes Service (AKS) cluster to Azure Arc is only required for "
-                       "running Arc enabled services like App Services and Data Services on the cluster. Other "
-                       "features like Azure Monitor and Azure Defender are natively available on AKS. "
-                       "Learn more at %s.", "https://go.microsoft.com/fwlink/?linkid=2144200")
+        logger.warning(
+            "Connecting an Azure Kubernetes Service (AKS) cluster to Azure Arc is only required for "
+            "running Arc enabled services like App Services and Data Services on the cluster. Other "
+            "features like Azure Monitor and Azure Defender are natively available on AKS. "
+            "Learn more at %s.",
+            "https://go.microsoft.com/fwlink/?linkid=2144200",
+        )
 
     # Validate location
-    print("Step: {}: Checking Connect RP is available in the Location passed in.".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Checking Connect RP is available in the Location passed in.".format(
+            utils.get_utctimestring()
+        )
+    )
     utils.validate_connect_rp_location(cmd, location)
     resourceClient = cf_resource_groups(cmd.cli_ctx, subscription_id=subscription_id)
 
     # Validate location of private link scope resource. Throws error only if there is a location mismatch
     if enable_private_link is True:
-        print("Step: {}: Validate location of PrviateLinkScope passed in.".format(utils.get_utctimestring()))
+        print(
+            "Step: {}: Validate location of PrviateLinkScope passed in.".format(
+                utils.get_utctimestring()
+            )
+        )
         try:
-            pls_arm_id_arr = private_link_scope_resource_id.split('/')
+            pls_arm_id_arr = private_link_scope_resource_id.split("/")
             hc_client = cf_connectedmachine(cmd.cli_ctx, pls_arm_id_arr[2])
             pls_get_result = hc_client.get(pls_arm_id_arr[4], pls_arm_id_arr[8])
             pls_location = pls_get_result.location.lower()
             if pls_location != location.lower():
                 ex_msg = "Connected cluster resource and Private link scope resource are present in different locations"
-                telemetry.set_exception(exception=ex_msg,
-                                        fault_type=consts.Pls_Location_Mismatch_Fault_Type,
-                                        summary='Pls resource location mismatch')
-                err_msg = "The location of the private link scope resource does not match the location "\
-                    "of connected cluster resource. Please ensure that both the resources are in the same azure "\
+                telemetry.set_exception(
+                    exception=ex_msg,
+                    fault_type=consts.Pls_Location_Mismatch_Fault_Type,
+                    summary="Pls resource location mismatch",
+                )
+                err_msg = (
+                    "The location of the private link scope resource does not match the location "
+                    "of connected cluster resource. Please ensure that both the resources are in the same azure "
                     "location."
+                )
                 raise ArgumentUsageError(err_msg)
         except ArgumentUsageError as argex:
             raise (argex)
@@ -369,34 +565,58 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
             if isinstance(ex, HttpResponseError):
                 status_code = ex.response.status_code
                 if status_code == 404:
-                    telemetry.set_exception(exception='Private link scope resource does not exist',
-                                            fault_type=consts.Pls_Resource_Not_Found,
-                                            summary='Pls resource does not exist')
-                    err_msg = "The private link scope resource '{}' does not exist. Please ensure that "\
-                        "you pass a valid ARM Resource Id.".format(private_link_scope_resource_id)
+                    telemetry.set_exception(
+                        exception="Private link scope resource does not exist",
+                        fault_type=consts.Pls_Resource_Not_Found,
+                        summary="Pls resource does not exist",
+                    )
+                    err_msg = (
+                        "The private link scope resource '{}' does not exist. Please ensure that "
+                        "you pass a valid ARM Resource Id.".format(
+                            private_link_scope_resource_id
+                        )
+                    )
                     raise ArgumentUsageError(err_msg)
-            logger.warning("Error occured while checking the private link scope resource location: %s\n", ex)
+            logger.warning(
+                "Error occured while checking the private link scope resource location: %s\n",
+                ex,
+            )
 
     # Check Previous Azure-Arc release's Existance
-    print("Step: {}: Check if an earlier azure-arc release exists".format(utils.get_utctimestring()))
-    release_namespace = utils.get_release_namespace(kube_config, kube_context, helm_client_location)
+    print(
+        "Step: {}: Check if an earlier azure-arc release exists".format(
+            utils.get_utctimestring()
+        )
+    )
+    release_namespace = utils.get_release_namespace(
+        kube_config, kube_context, helm_client_location
+    )
 
     if release_namespace:
-        print("Step: {}: Found an earlier instance of azure-arc release".format(utils.get_utctimestring()))
+        print(
+            "Step: {}: Found an earlier instance of azure-arc release".format(
+                utils.get_utctimestring()
+            )
+        )
         # Loading config map
         api_instance = kube_client.CoreV1Api()
         try:
-            configmap = api_instance.read_namespaced_config_map('azure-clusterconfig', 'azure-arc')
+            configmap = api_instance.read_namespaced_config_map(
+                "azure-clusterconfig", "azure-arc"
+            )
         except Exception as e:  # pylint: disable=broad-except
-            not_found_msg = "The helm release 'azure-arc' is present but azure-arc namespace/configmap is missing " \
-                "is missing. Please run 'helm delete azure-arc --namespace {} --no-hooks' to cleanup the release " \
+            not_found_msg = (
+                "The helm release 'azure-arc' is present but azure-arc namespace/configmap is missing "
+                "is missing. Please run 'helm delete azure-arc --namespace {} --no-hooks' to cleanup the release "
                 "before onboarding the cluster again.".format(release_namespace)
+            )
             utils.kubernetes_exception_handler(
                 e,
                 consts.Read_ConfigMap_Fault_Type,
-                'Unable to read ConfigMap',
+                "Unable to read ConfigMap",
                 error_message="Unable to read ConfigMap 'azure-clusterconfig' in 'azure-arc' namespace: ",
-                message_for_not_found=not_found_msg)
+                message_for_not_found=not_found_msg,
+            )
         configmap_rg_name = configmap.data["AZURE_RESOURCE_GROUP"]
         configmap_cluster_name = configmap.data["AZURE_RESOURCE_NAME"]
         if connected_cluster_exists(client, configmap_rg_name, configmap_cluster_name):
@@ -404,187 +624,355 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
             public_key = None
 
             try:
-                preview_cluster_resource = get_connectedk8s_2023_11_01(cmd,
-                                                                       configmap_rg_name,
-                                                                       configmap_cluster_name)
+                preview_cluster_resource = get_connectedk8s_2023_11_01(
+                    cmd, configmap_rg_name, configmap_cluster_name
+                )
                 public_key = preview_cluster_resource.agent_public_key_certificate
             except Exception as e:  # pylint: disable=broad-except
-                utils.arm_exception_handler(e,
-                                            consts.Get_ConnectedCluster_Fault_Type,
-                                            'Failed to check if connected cluster resource already exists.')
+                utils.arm_exception_handler(
+                    e,
+                    consts.Get_ConnectedCluster_Fault_Type,
+                    "Failed to check if connected cluster resource already exists.",
+                )
 
-            if (configmap_rg_name.lower() == resource_group_name.lower() and
-                    configmap_cluster_name.lower() == cluster_name.lower()):
+            if (
+                configmap_rg_name.lower() == resource_group_name.lower()
+                and configmap_cluster_name.lower() == cluster_name.lower()
+            ):
                 # Re-put connected cluster
                 # If cluster is of kind provisioned cluster, there are several properties that cannot be updated
-                validate_existing_provisioned_cluster_for_reput(preview_cluster_resource, kubernetes_distro,
-                                                                kubernetes_infra, enable_private_link,
-                                                                private_link_scope_resource_id, distribution_version,
-                                                                azure_hybrid_benefit, location)
+                validate_existing_provisioned_cluster_for_reput(
+                    preview_cluster_resource,
+                    kubernetes_distro,
+                    kubernetes_infra,
+                    enable_private_link,
+                    private_link_scope_resource_id,
+                    distribution_version,
+                    azure_hybrid_benefit,
+                    location,
+                )
 
-                cc = generate_request_payload(location, public_key, tags, kubernetes_distro, kubernetes_infra,
-                                              enable_private_link, private_link_scope_resource_id,
-                                              distribution_version, azure_hybrid_benefit, enable_oidc_issuer,
-                                              enable_workload_identity, gateway, arc_agentry_configurations, arc_agent_profile)
-                cc_response = create_cc_resource(client, resource_group_name, cluster_name, cc, no_wait)
+                cc = generate_request_payload(
+                    location,
+                    public_key,
+                    tags,
+                    kubernetes_distro,
+                    kubernetes_infra,
+                    enable_private_link,
+                    private_link_scope_resource_id,
+                    distribution_version,
+                    azure_hybrid_benefit,
+                    enable_oidc_issuer,
+                    enable_workload_identity,
+                    gateway,
+                    arc_agentry_configurations,
+                    arc_agent_profile,
+                )
+                cc_response = create_cc_resource(
+                    client, resource_group_name, cluster_name, cc, no_wait
+                )
                 dp_request_payload = cc_response.result()
                 cc_response = LongRunningOperation(cmd.cli_ctx)(cc_response)
                 # Disabling cluster-connect if private link is getting enabled
                 if enable_private_link is True:
-                    disable_cluster_connect(cmd, client, resource_group_name, cluster_name, kube_config,
-                                            kube_context, values_file, release_namespace, helm_client_location)
-                
+                    disable_cluster_connect(
+                        cmd,
+                        client,
+                        resource_group_name,
+                        cluster_name,
+                        kube_config,
+                        kube_context,
+                        values_file,
+                        release_namespace,
+                        helm_client_location,
+                    )
+
                 # Perform helm upgrade if gateway
                 if gateway is not None:
                     # Update arc agent configuration to include protected parameters in dp call
-                    arc_agentry_configurations = generate_arc_agent_configuration(configuration_settings, redacted_protected_values, is_dp_call=True)
-                    dp_request_payload.arc_agentry_configurations = arc_agentry_configurations
+                    arc_agentry_configurations = generate_arc_agent_configuration(
+                        configuration_settings,
+                        redacted_protected_values,
+                        is_dp_call=True,
+                    )
+                    dp_request_payload.arc_agentry_configurations = (
+                        arc_agentry_configurations
+                    )
 
                     # Perform DP health check
                     _ = utils.health_check_dp(cmd, config_dp_endpoint)
 
                     # Retrieving Helm chart OCI Artifact location
-                    helm_values_dp = utils.get_helm_values(cmd, config_dp_endpoint, release_train, request_body=dp_request_payload)
+                    helm_values_dp = utils.get_helm_values(
+                        cmd,
+                        config_dp_endpoint,
+                        release_train,
+                        request_body=dp_request_payload,
+                    )
 
-                    registry_path = os.getenv('HELMREGISTRY') if os.getenv('HELMREGISTRY') else \
-                        helm_values_dp["repositoryPath"]
+                    registry_path = (
+                        os.getenv("HELMREGISTRY")
+                        if os.getenv("HELMREGISTRY")
+                        else helm_values_dp["repositoryPath"]
+                    )
 
                     # Get azure-arc agent version for telemetry
-                    azure_arc_agent_version = registry_path.split(':')[1]
-                    telemetry.add_extension_event('connectedk8s',
-                                                {'Context.Default.AzureCLI.AgentVersion': azure_arc_agent_version})
+                    azure_arc_agent_version = registry_path.split(":")[1]
+                    telemetry.add_extension_event(
+                        "connectedk8s",
+                        {
+                            "Context.Default.AzureCLI.AgentVersion": azure_arc_agent_version
+                        },
+                    )
 
                     # Get helm chart path
-                    chart_path = utils.get_chart_path(registry_path, kube_config, kube_context, helm_client_location)
+                    chart_path = utils.get_chart_path(
+                        registry_path, kube_config, kube_context, helm_client_location
+                    )
 
                     helm_content_values = helm_values_dp["helmValuesContent"]
 
                     # Substitute any protected helm values as the value for that will be 'redacted-<feature>-<protectedSetting>'
                     for helm_parameter, helm_value in helm_content_values.items():
-                        if 'redacted' in helm_value:
-                            _, feature, protectedSetting = helm_value.split('-')
-                            helm_content_values[helm_parameter] = configuration_protected_settings[feature][protectedSetting]
+                        if "redacted" in helm_value:
+                            _, feature, protectedSetting = helm_value.split("-")
+                            helm_content_values[helm_parameter] = (
+                                configuration_protected_settings[
+                                    feature
+                                ][protectedSetting]
+                            )
 
                     # Perform helm upgrade
-                    utils.helm_update_agent(helm_client_location, kube_config, kube_context, helm_content_values,
-                                             values_file, cluster_name, release_namespace, chart_path)
+                    utils.helm_update_agent(
+                        helm_client_location,
+                        kube_config,
+                        kube_context,
+                        helm_content_values,
+                        values_file,
+                        cluster_name,
+                        release_namespace,
+                        chart_path,
+                    )
                 return cc_response
 
             # else
-            telemetry.set_exception(exception='The kubernetes cluster is already onboarded',
-                                    fault_type=consts.Cluster_Already_Onboarded_Fault_Type,
-                                    summary='Kubernetes cluster already onboarded')
-            err_msg = "The kubernetes cluster you are trying to onboard is already onboarded to " \
-                "the resource group '{}' with resource name '{}'.".format(configmap_rg_name, configmap_cluster_name)
+            telemetry.set_exception(
+                exception="The kubernetes cluster is already onboarded",
+                fault_type=consts.Cluster_Already_Onboarded_Fault_Type,
+                summary="Kubernetes cluster already onboarded",
+            )
+            err_msg = (
+                "The kubernetes cluster you are trying to onboard is already onboarded to "
+                "the resource group '{}' with resource name '{}'.".format(
+                    configmap_rg_name, configmap_cluster_name
+                )
+            )
             raise ArgumentUsageError(err_msg)
         # else case
-        logger.warning("Cleaning up the stale arc agents present on the cluster before starting new onboarding.")
+        logger.warning(
+            "Cleaning up the stale arc agents present on the cluster before starting new onboarding."
+        )
         # Explicit CRD Deletion
         crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
         # Cleaning up the cluster
-        utils.delete_arc_agents(release_namespace, kube_config, kube_context, helm_client_location,
-                                is_arm64_cluster, True)
+        utils.delete_arc_agents(
+            release_namespace,
+            kube_config,
+            kube_context,
+            helm_client_location,
+            is_arm64_cluster,
+            True,
+        )
 
     else:
         if connected_cluster_exists(client, resource_group_name, cluster_name):
-            telemetry.set_exception(exception='The connected cluster resource already exists',
-                                    fault_type=consts.Resource_Already_Exists_Fault_Type,
-                                    summary='Connected cluster resource already exists')
-            err_msg = "The connected cluster resource {} already exists ".format(cluster_name) + " in the " \
-                "resource group {} ".format(resource_group_name) + "and corresponds to a different Kubernetes cluster."
-            reco_msg = "To onboard this Kubernetes cluster to Azure, specify different " \
+            telemetry.set_exception(
+                exception="The connected cluster resource already exists",
+                fault_type=consts.Resource_Already_Exists_Fault_Type,
+                summary="Connected cluster resource already exists",
+            )
+            err_msg = (
+                "The connected cluster resource {} already exists ".format(cluster_name)
+                + " in the " "resource group {} ".format(resource_group_name)
+                + "and corresponds to a different Kubernetes cluster."
+            )
+            reco_msg = (
+                "To onboard this Kubernetes cluster to Azure, specify different "
                 "resource name or resource group name."
+            )
             raise ArgumentUsageError(err_msg, recommendation=reco_msg)
         else:
             # cleanup of stuck CRD if release namespace is not present/deleted
             crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
 
-    print("Step: {}: Check if ResourceGroup exists.  Try to create if it doesn't".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Check if ResourceGroup exists.  Try to create if it doesn't".format(
+            utils.get_utctimestring()
+        )
+    )
     # Resource group Creation
-    if resource_group_exists(cmd.cli_ctx, resource_group_name, subscription_id) is False:
+    if (
+        resource_group_exists(cmd.cli_ctx, resource_group_name, subscription_id)
+        is False
+    ):
         from azure.cli.core.profiles import ResourceType
-        ResourceGroup = cmd.get_models('ResourceGroup', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
+
+        ResourceGroup = cmd.get_models(
+            "ResourceGroup", resource_type=ResourceType.MGMT_RESOURCE_RESOURCES
+        )
         parameters = ResourceGroup(location=location)
         try:
             resourceClient.create_or_update(resource_group_name, parameters)
         except Exception as e:  # pylint: disable=broad-except
-            utils.arm_exception_handler(e, consts.Create_ResourceGroup_Fault_Type,
-                                        'Failed to create the resource group')
+            utils.arm_exception_handler(
+                e,
+                consts.Create_ResourceGroup_Fault_Type,
+                "Failed to create the resource group",
+            )
 
-    print("Step: {}: Generating Public-Private Key pair".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Generating Public-Private Key pair".format(utils.get_utctimestring())
+    )
 
     # Generate public-private key pair
     try:
         key_pair = RSA.generate(4096)
     except Exception as e:
-        telemetry.set_exception(exception=e, fault_type=consts.KeyPair_Generate_Fault_Type,
-                                summary='Failed to generate public-private key pair')
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.KeyPair_Generate_Fault_Type,
+            summary="Failed to generate public-private key pair",
+        )
         raise CLIInternalError("Failed to generate public-private key pair. " + str(e))
     try:
         public_key = get_public_key(key_pair)
     except Exception as e:
-        telemetry.set_exception(exception=e, fault_type=consts.PublicKey_Export_Fault_Type,
-                                summary='Failed to export public key')
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.PublicKey_Export_Fault_Type,
+            summary="Failed to export public key",
+        )
         raise CLIInternalError("Failed to export public key." + str(e))
     try:
         private_key_pem = get_private_key(key_pair)
     except Exception as e:
-        telemetry.set_exception(exception=e, fault_type=consts.PrivateKey_Export_Fault_Type,
-                                summary='Failed to export private key')
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.PrivateKey_Export_Fault_Type,
+            summary="Failed to export private key",
+        )
         raise CLIInternalError("Failed to export private key." + str(e))
 
     print("Step: {}: Generating ARM Request Payload".format(utils.get_utctimestring()))
     # Generate request payload
-    cc = generate_request_payload(location, public_key, tags, kubernetes_distro, kubernetes_infra,
-                                  enable_private_link, private_link_scope_resource_id, distribution_version,
-                                  azure_hybrid_benefit, enable_oidc_issuer, enable_workload_identity, gateway,
-                                  arc_agentry_configurations, arc_agent_profile, self_hosted_issuer)
+    cc = generate_request_payload(
+        location,
+        public_key,
+        tags,
+        kubernetes_distro,
+        kubernetes_infra,
+        enable_private_link,
+        private_link_scope_resource_id,
+        distribution_version,
+        azure_hybrid_benefit,
+        enable_oidc_issuer,
+        enable_workload_identity,
+        gateway,
+        arc_agentry_configurations,
+        arc_agent_profile,
+        self_hosted_issuer,
+    )
 
-    print("Step: {}: Azure resource provisioning has begun.".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Azure resource provisioning has begun.".format(
+            utils.get_utctimestring()
+        )
+    )
     # Create connected cluster resource
-    put_cc_response = create_cc_resource(client, resource_group_name, cluster_name, cc, no_wait)
+    put_cc_response = create_cc_resource(
+        client, resource_group_name, cluster_name, cc, no_wait
+    )
     dp_request_payload = put_cc_response.result()
     put_cc_response = LongRunningOperation(cmd.cli_ctx)(put_cc_response)
-    print("Step: {}: Azure resource provisioning has finished.".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Azure resource provisioning has finished.".format(
+            utils.get_utctimestring()
+        )
+    )
 
     # Checking if custom locations rp is registered and fetching oid if it is registered
-    enable_custom_locations, custom_locations_oid = check_cl_registration_and_get_oid(cmd, cl_oid, subscription_id)
+    enable_custom_locations, custom_locations_oid = check_cl_registration_and_get_oid(
+        cmd, cl_oid, subscription_id
+    )
 
     # Update arc agent configuration to include protected parameters in dp call
-    arc_agentry_configurations = generate_arc_agent_configuration(configuration_settings, redacted_protected_values, is_dp_call=True)
+    arc_agentry_configurations = generate_arc_agent_configuration(
+        configuration_settings, redacted_protected_values, is_dp_call=True
+    )
     dp_request_payload.arc_agentry_configurations = arc_agentry_configurations
 
     # Perform DP health check
     _ = utils.health_check_dp(cmd, config_dp_endpoint)
 
     # Retrieving Helm chart OCI Artifact location
-    helm_values_dp = utils.get_helm_values(cmd, config_dp_endpoint, release_train, request_body=dp_request_payload)
+    helm_values_dp = utils.get_helm_values(
+        cmd, config_dp_endpoint, release_train, request_body=dp_request_payload
+    )
 
-    registry_path = os.getenv('HELMREGISTRY') if os.getenv('HELMREGISTRY') else \
-        helm_values_dp["repositoryPath"]
+    registry_path = (
+        os.getenv("HELMREGISTRY")
+        if os.getenv("HELMREGISTRY")
+        else helm_values_dp["repositoryPath"]
+    )
 
     # Get azure-arc agent version for telemetry
-    azure_arc_agent_version = registry_path.split(':')[1]
-    telemetry.add_extension_event('connectedk8s',
-                                  {'Context.Default.AzureCLI.AgentVersion': azure_arc_agent_version})
+    azure_arc_agent_version = registry_path.split(":")[1]
+    telemetry.add_extension_event(
+        "connectedk8s",
+        {"Context.Default.AzureCLI.AgentVersion": azure_arc_agent_version},
+    )
 
     # Get helm chart path
-    chart_path = utils.get_chart_path(registry_path, kube_config, kube_context, helm_client_location)
+    chart_path = utils.get_chart_path(
+        registry_path, kube_config, kube_context, helm_client_location
+    )
 
     helm_content_values = helm_values_dp["helmValuesContent"]
 
     # Substitute any protected helm values as the value for that will be 'redacted-<feature>-<protectedSetting>'
     for helm_parameter, helm_value in helm_content_values.items():
-        if 'redacted' in helm_value:
-            _, feature, protectedSetting = helm_value.split('-')
-            helm_content_values[helm_parameter] = configuration_protected_settings[feature][protectedSetting]
+        if "redacted" in helm_value:
+            _, feature, protectedSetting = helm_value.split("-")
+            helm_content_values[helm_parameter] = configuration_protected_settings[
+                feature
+            ][protectedSetting]
 
-    print("Step: {}: Starting to install Azure arc agents on the Kubernetes cluster.".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Starting to install Azure arc agents on the Kubernetes cluster.".format(
+            utils.get_utctimestring()
+        )
+    )
     # Install azure-arc agents
-    utils.helm_install_release(cmd.cli_ctx.cloud.endpoints.resource_manager, chart_path, kubernetes_distro,
-                               kubernetes_infra, location, private_key_pem, kube_config, kube_context, no_wait,
-                               values_file, azure_cloud, enable_custom_locations, custom_locations_oid, helm_client_location,
-                               enable_private_link, arm_metadata, onboarding_timeout, helm_content_values)
+    utils.helm_install_release(
+        cmd.cli_ctx.cloud.endpoints.resource_manager,
+        chart_path,
+        kubernetes_distro,
+        kubernetes_infra,
+        location,
+        private_key_pem,
+        kube_config,
+        kube_context,
+        no_wait,
+        values_file,
+        azure_cloud,
+        enable_custom_locations,
+        custom_locations_oid,
+        helm_client_location,
+        enable_private_link,
+        arm_metadata,
+        onboarding_timeout,
+        helm_content_values,
+    )
 
     """
     Long Running Operation for Agent State
@@ -597,39 +985,74 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
         - If workload identity is enabled, extension is installed, poll for agent state.
     """
     if (enable_oidc_issuer and self_hosted_issuer == "") or enable_workload_identity:
-        print("Step: {}: Wait for Agent State to reach terminal state, with timeout of {}".format(utils.get_utctimestring(), 
-                                                                                                consts.Agent_State_Timeout))
+        print(
+            "Step: {}: Wait for Agent State to reach terminal state, with timeout of {}".format(
+                utils.get_utctimestring(), consts.Agent_State_Timeout
+            )
+        )
         if poll_for_agent_state(cmd, resource_group_name, cluster_name):
-            connected_cluster = get_connectedk8s_2024_07_01(cmd, resource_group_name, cluster_name)
-            print("Step: {}: Agent state has reached terminal state of {}.".format(utils.get_utctimestring(), 
-                                                                                connected_cluster.arc_agent_profile.agent_state))
+            connected_cluster = get_connectedk8s_2024_07_01(
+                cmd, resource_group_name, cluster_name
+            )
+            print(
+                "Step: {}: Agent state has reached terminal state of {}.".format(
+                    utils.get_utctimestring(),
+                    connected_cluster.arc_agent_profile.agent_state,
+                )
+            )
         else:
-            raise CLIInternalError("Timed out waiting for Agent State to reach terminal state.")
-    
+            raise CLIInternalError(
+                "Timed out waiting for Agent State to reach terminal state."
+            )
+
     return put_cc_response
 
 
-def poll_for_agent_state(cmd, resource_group_name, cluster_name, timeout_minutes=consts.Agent_State_Timeout, 
-                        interval=5):
+def poll_for_agent_state(
+    cmd,
+    resource_group_name,
+    cluster_name,
+    timeout_minutes=consts.Agent_State_Timeout,
+    interval=5,
+):
     start_time = time.time()
     while True:
-        connected_cluster = get_connectedk8s_2024_07_01(cmd, resource_group_name, cluster_name)
-        if connected_cluster.arc_agent_profile.agent_state == consts.Agent_State_Succeeded or \
-            connected_cluster.arc_agent_profile.agent_state == consts.Agent_State_Failed:
+        connected_cluster = get_connectedk8s_2024_07_01(
+            cmd, resource_group_name, cluster_name
+        )
+        if (
+            connected_cluster.arc_agent_profile.agent_state
+            == consts.Agent_State_Succeeded
+            or connected_cluster.arc_agent_profile.agent_state
+            == consts.Agent_State_Failed
+        ):
             return True
         elapsed_time = time.time() - start_time
         if elapsed_time >= timeout_minutes * 60:
             return False
         time.sleep(interval)
 
-def validate_existing_provisioned_cluster_for_reput(cluster_resource, kubernetes_distro, kubernetes_infra,
-                                                    enable_private_link, private_link_scope_resource_id,
-                                                    distribution_version, azure_hybrid_benefit, location):
-    if ((cluster_resource is not None) and (cluster_resource.kind is not None) and
-            (cluster_resource.kind.lower() == consts.Provisioned_Cluster_Kind)):
-        err_msg = "Updating the 'azure hybrid benefit' property of a Provisioned Cluster is not supported from the " \
-            "Connected Cluster CLI. Please use the 'az aksarc update' CLI command.\n" + \
-            consts.Doc_Provisioned_Cluster_Update_Url
+
+def validate_existing_provisioned_cluster_for_reput(
+    cluster_resource,
+    kubernetes_distro,
+    kubernetes_infra,
+    enable_private_link,
+    private_link_scope_resource_id,
+    distribution_version,
+    azure_hybrid_benefit,
+    location,
+):
+    if (
+        (cluster_resource is not None)
+        and (cluster_resource.kind is not None)
+        and (cluster_resource.kind.lower() == consts.Provisioned_Cluster_Kind)
+    ):
+        err_msg = (
+            "Updating the 'azure hybrid benefit' property of a Provisioned Cluster is not supported from the "
+            "Connected Cluster CLI. Please use the 'az aksarc update' CLI command.\n"
+            + consts.Doc_Provisioned_Cluster_Update_Url
+        )
         if azure_hybrid_benefit is not None:
             raise InvalidArgumentValueError(err_msg)
 
@@ -644,16 +1067,20 @@ def validate_existing_provisioned_cluster_for_reput(cluster_resource, kubernetes
 
         for value in validation_values:
             if value is not None:
-                err_msg = "Updating the following properties of a Provisioned Cluster are not supported from the " \
-                    "Connected Cluster CLI: kubernetes_distro, kubernetes_infra, enable_private_link, " \
-                    "private_link_scope_resource_id, distribution_version, azure_hybrid_benefit, location, " \
-                    "public_key.\n\nPlease use the 'az aksarc update' CLI command. " + \
-                    consts.Doc_Provisioned_Cluster_Update_Url
+                err_msg = (
+                    "Updating the following properties of a Provisioned Cluster are not supported from the "
+                    "Connected Cluster CLI: kubernetes_distro, kubernetes_infra, enable_private_link, "
+                    "private_link_scope_resource_id, distribution_version, azure_hybrid_benefit, location, "
+                    "public_key.\n\nPlease use the 'az aksarc update' CLI command. "
+                    + consts.Doc_Provisioned_Cluster_Update_Url
+                )
                 raise InvalidArgumentValueError(err_msg)
 
 
 def send_cloud_telemetry(cmd):
-    telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AzureCloud': cmd.cli_ctx.cloud.name})
+    telemetry.add_extension_event(
+        "connectedk8s", {"Context.Default.AzureCLI.AzureCloud": cmd.cli_ctx.cloud.name}
+    )
     cloud_name = cmd.cli_ctx.cloud.name.upper()
     # Setting cloud name to format that is understood by golang SDK.
     if cloud_name == consts.PublicCloud_OriginalName:
@@ -666,37 +1093,59 @@ def send_cloud_telemetry(cmd):
 def validate_env_file_dogfood(values_file):
     if not values_file:
         telemetry.set_exception(
-            exception='Helm environment file not provided',
+            exception="Helm environment file not provided",
             fault_type=consts.Helm_Environment_File_Fault_Type,
-            summary='Helm environment file missing')
+            summary="Helm environment file missing",
+        )
         raise ValidationError(
             "Helm environment file is required when using Dogfood environment for onboarding the cluster.",
-            recommendation="Please set the environment variable 'HELMVALUESPATH' to point to the file.")
+            recommendation="Please set the environment variable 'HELMVALUESPATH' to point to the file.",
+        )
 
-    with open(values_file, 'r') as f:
+    with open(values_file, "r") as f:
         try:
             env_dict = yaml.safe_load(f)
-        except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Helm_Environment_File_Fault_Type,
-                                    summary='Problem loading the helm environment file')
-            raise FileOperationError("Problem loading the helm environment file: " + str(e))
-        try:
-            assert env_dict.get('global').get('azureEnvironment') == 'AZUREDOGFOOD'
-            assert env_dict.get('systemDefaultValues').get('azureArcAgents').get('config_dp_endpoint_override')
         except Exception as e:
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Helm_Environment_File_Fault_Type,
-                summary='Problem loading the helm environment variables')
-            reco_str = "Please check the values 'global.azureEnvironment' and " \
+                summary="Problem loading the helm environment file",
+            )
+            raise FileOperationError(
+                "Problem loading the helm environment file: " + str(e)
+            )
+        try:
+            assert env_dict.get("global").get("azureEnvironment") == "AZUREDOGFOOD"
+            assert (
+                env_dict.get("systemDefaultValues")
+                .get("azureArcAgents")
+                .get("config_dp_endpoint_override")
+            )
+        except Exception as e:
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Helm_Environment_File_Fault_Type,
+                summary="Problem loading the helm environment variables",
+            )
+            reco_str = (
+                "Please check the values 'global.azureEnvironment' and "
                 "'systemDefaultValues.azureArcAgents.config_dp_endpoint_override' in the file."
-            err_msg = "The required helm environment variables for dogfood onboarding are either not present in the " \
+            )
+            err_msg = (
+                "The required helm environment variables for dogfood onboarding are either not present in the "
                 "file or incorrectly set."
+            )
             raise FileOperationError(err_msg, recommendation=reco_str)
 
     # Return the dp endpoint and release train
-    dp_endpoint = env_dict.get('systemDefaultValues').get('azureArcAgents').get('config_dp_endpoint_override')
-    release_train = env_dict.get('systemDefaultValues').get('azureArcAgents').get('releaseTrain')
+    dp_endpoint = (
+        env_dict.get("systemDefaultValues")
+        .get("azureArcAgents")
+        .get("config_dp_endpoint_override")
+    )
+    release_train = (
+        env_dict.get("systemDefaultValues").get("azureArcAgents").get("releaseTrain")
+    )
     return dp_endpoint, release_train
 
 
@@ -704,9 +1153,9 @@ def set_kube_config(kube_config):
     print("Step: {}: Setting KubeConfig".format(utils.get_utctimestring()))
     if kube_config:
         # Trim kubeconfig. This is required for windows os.
-        if (kube_config.startswith("'") or kube_config.startswith('"')):
+        if kube_config.startswith("'") or kube_config.startswith('"'):
             kube_config = kube_config[1:]
-        if (kube_config.endswith("'") or kube_config.endswith('"')):
+        if kube_config.endswith("'") or kube_config.endswith('"'):
             kube_config = kube_config[:-1]
         return kube_config
     return None
@@ -715,13 +1164,15 @@ def set_kube_config(kube_config):
 def escape_proxy_settings(proxy_setting):
     if proxy_setting is None:
         return ""
-    proxy_setting = proxy_setting.replace(',', r'\,')
-    proxy_setting = proxy_setting.replace('/', r'\/')
+    proxy_setting = proxy_setting.replace(",", r"\,")
+    proxy_setting = proxy_setting.replace("/", r"\/")
     return proxy_setting
 
 
 def check_kube_connection():
-    print("Step: {}: Checking Connectivity to Cluster".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Checking Connectivity to Cluster".format(utils.get_utctimestring())
+    )
     api_instance = kube_client.VersionApi()
     try:
         api_response = api_instance.get_code()
@@ -731,44 +1182,55 @@ def check_kube_connection():
         utils.kubernetes_exception_handler(
             e,
             consts.Kubernetes_Connectivity_FaultType,
-            'Unable to verify connectivity to the Kubernetes cluster')
+            "Unable to verify connectivity to the Kubernetes cluster",
+        )
 
 
 def install_helm_client():
-    print("Step: {}: Install Helm client if it does not exist".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Install Helm client if it does not exist".format(
+            utils.get_utctimestring()
+        )
+    )
     # Return helm client path set by user
-    if os.getenv('HELM_CLIENT_PATH'):
-        return os.getenv('HELM_CLIENT_PATH')
+    if os.getenv("HELM_CLIENT_PATH"):
+        return os.getenv("HELM_CLIENT_PATH")
 
     # Fetch system related info
     operating_system = platform.system().lower()
     machine_type = platform.machine()
 
     # Send machine telemetry
-    telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.MachineType': machine_type})
+    telemetry.add_extension_event(
+        "connectedk8s", {"Context.Default.AzureCLI.MachineType": machine_type}
+    )
 
     # Set helm binary download & install locations
-    if operating_system == 'windows':
-        download_location_string = \
-            f'.azure\\helm\\{consts.HELM_VERSION}\\helm-{consts.HELM_VERSION}-{operating_system}-amd64.zip'
-        install_location_string = f'.azure\\helm\\{consts.HELM_VERSION}\\{operating_system}-amd64\\helm.exe'
-        requestUri = f'{consts.HELM_STORAGE_URL}/helmsigned/helm-{consts.HELM_VERSION}-{operating_system}-amd64.zip'
-    elif operating_system == 'linux' or operating_system == 'darwin':
-        download_location_string = \
-            f'.azure/helm/{consts.HELM_VERSION}/helm-{consts.HELM_VERSION}-{operating_system}-amd64.tar.gz'
-        install_location_string = f'.azure/helm/{consts.HELM_VERSION}/{operating_system}-amd64/helm'
-        requestUri = f'{consts.HELM_STORAGE_URL}/helm/helm-{consts.HELM_VERSION}-{operating_system}-amd64.tar.gz'
+    if operating_system == "windows":
+        download_location_string = f".azure\\helm\\{consts.HELM_VERSION}\\helm-{consts.HELM_VERSION}-{operating_system}-amd64.zip"
+        install_location_string = (
+            f".azure\\helm\\{consts.HELM_VERSION}\\{operating_system}-amd64\\helm.exe"
+        )
+        requestUri = f"{consts.HELM_STORAGE_URL}/helmsigned/helm-{consts.HELM_VERSION}-{operating_system}-amd64.zip"
+    elif operating_system == "linux" or operating_system == "darwin":
+        download_location_string = f".azure/helm/{consts.HELM_VERSION}/helm-{consts.HELM_VERSION}-{operating_system}-amd64.tar.gz"
+        install_location_string = (
+            f".azure/helm/{consts.HELM_VERSION}/{operating_system}-amd64/helm"
+        )
+        requestUri = f"{consts.HELM_STORAGE_URL}/helm/helm-{consts.HELM_VERSION}-{operating_system}-amd64.tar.gz"
     else:
         telemetry.set_exception(
-            exception='Unsupported OS for installing helm client',
+            exception="Unsupported OS for installing helm client",
             fault_type=consts.Helm_Unsupported_OS_Fault_Type,
-            summary=f'{operating_system} is not supported for installing helm client')
+            summary=f"{operating_system} is not supported for installing helm client",
+        )
         raise ClientRequestError(
-            f'The {operating_system} platform is not currently supported for installing helm client.')
+            f"The {operating_system} platform is not currently supported for installing helm client."
+        )
 
-    download_location = os.path.expanduser(os.path.join('~', download_location_string))
+    download_location = os.path.expanduser(os.path.join("~", download_location_string))
     download_dir = os.path.dirname(download_location)
-    install_location = os.path.expanduser(os.path.join('~', install_location_string))
+    install_location = os.path.expanduser(os.path.join("~", install_location_string))
 
     # Download compressed Helm binary if not already present
     if not os.path.isfile(install_location):
@@ -777,12 +1239,17 @@ def install_helm_client():
             try:
                 os.makedirs(download_dir)
             except Exception as e:
-                telemetry.set_exception(exception=e, fault_type=consts.Create_Directory_Fault_Type,
-                                        summary='Unable to create helm directory')
+                telemetry.set_exception(
+                    exception=e,
+                    fault_type=consts.Create_Directory_Fault_Type,
+                    summary="Unable to create helm directory",
+                )
                 raise ClientRequestError("Failed to create helm directory." + str(e))
 
         # Downloading compressed helm client executable
-        logger.warning("Downloading helm client for first time. This can take few minutes...")
+        logger.warning(
+            "Downloading helm client for first time. This can take few minutes..."
+        )
         retry_count = 3
         retry_delay = 5
         for i in range(retry_count):
@@ -793,10 +1260,16 @@ def install_helm_client():
                 if i == retry_count - 1:
                     if "Connection reset by peer" in str(e):
                         telemetry.set_user_fault()
-                    telemetry.set_exception(exception=e, fault_type=consts.Download_Helm_Fault_Type,
-                                            summary='Unable to download helm client.')
-                    raise CLIInternalError("Failed to download helm client.",
-                                           recommendation="Please check your internet connection." + str(e))
+                    telemetry.set_exception(
+                        exception=e,
+                        fault_type=consts.Download_Helm_Fault_Type,
+                        summary="Unable to download helm client.",
+                    )
+                    raise CLIInternalError(
+                        "Failed to download helm client.",
+                        recommendation="Please check your internet connection."
+                        + str(e),
+                    )
                 time.sleep(retry_delay)
 
         responseContent = response.read()
@@ -804,28 +1277,36 @@ def install_helm_client():
 
         # Creating the compressed helm binaries
         try:
-            with open(download_location, 'wb') as f:
+            with open(download_location, "wb") as f:
                 f.write(responseContent)
         except Exception as e:
             telemetry.set_exception(
                 exception=e,
                 fault_type=consts.Create_HelmExe_Fault_Type,
-                summary='Unable to create helm executable')
-            reco_str = "Please ensure that you delete the directory '{}' before trying again.".format(download_dir)
+                summary="Unable to create helm executable",
+            )
+            reco_str = "Please ensure that you delete the directory '{}' before trying again.".format(
+                download_dir
+            )
             raise ClientRequestError(
-                "Failed to create helm executable." + str(e),
-                recommendation=reco_str)
+                "Failed to create helm executable." + str(e), recommendation=reco_str
+            )
         # Extract the archive.
         try:
             shutil.unpack_archive(download_location, download_dir)
             os.chmod(install_location, os.stat(install_location).st_mode | stat.S_IXUSR)
         except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Extract_HelmExe_Fault_Type,
-                                    summary='Unable to extract helm executable')
-            reco_str = "Please ensure that you delete the directory '{}' before trying again.".format(download_dir)
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Extract_HelmExe_Fault_Type,
+                summary="Unable to extract helm executable",
+            )
+            reco_str = "Please ensure that you delete the directory '{}' before trying again.".format(
+                download_dir
+            )
             raise ClientRequestError(
-                "Failed to extract helm executable." + str(e),
-                recommendation=reco_str)
+                "Failed to extract helm executable." + str(e), recommendation=reco_str
+            )
 
     return install_location
 
@@ -846,14 +1327,18 @@ def connected_cluster_exists(client, resource_group_name, cluster_name):
         utils.arm_exception_handler(
             e,
             consts.Get_ConnectedCluster_Fault_Type,
-            'Failed to check if connected cluster resource already exists.', return_if_not_found=True)
+            "Failed to check if connected cluster resource already exists.",
+            return_if_not_found=True,
+        )
         return False
     return True
 
 
 def get_default_config_dp_endpoint(cmd, location):
-    cloud_based_domain = cmd.cli_ctx.cloud.endpoints.active_directory.split('.')[2]
-    config_dp_endpoint = "https://{}.dp.kubernetesconfiguration.azure.{}".format(location, cloud_based_domain)
+    cloud_based_domain = cmd.cli_ctx.cloud.endpoints.active_directory.split(".")[2]
+    config_dp_endpoint = "https://{}.dp.kubernetesconfiguration.azure.{}".format(
+        location, cloud_based_domain
+    )
     return config_dp_endpoint
 
 
@@ -870,7 +1355,9 @@ def get_config_dp_endpoint(cmd, location, values_file, arm_metadata=None):
         if "arcConfigEndpoint" in arm_metadata["dataplaneEndpoints"]:
             config_dp_endpoint = arm_metadata["dataplaneEndpoints"]["arcConfigEndpoint"]
         else:
-            logger.debug("'arcConfigEndpoint' doesn't exist under 'dataplaneEndpoints' in the ARM metadata.")
+            logger.debug(
+                "'arcConfigEndpoint' doesn't exist under 'dataplaneEndpoints' in the ARM metadata."
+            )
     # Get the default config dataplane endpoint.
     if config_dp_endpoint is None:
         config_dp_endpoint = get_default_config_dp_endpoint(cmd, location)
@@ -881,7 +1368,7 @@ def get_public_key(key_pair):
     pubKey = key_pair.publickey()
     seq = asn1.DerSequence([pubKey.n, pubKey.e])
     enc = seq.encode()
-    return b64encode(enc).decode('utf-8')
+    return b64encode(enc).decode("utf-8")
 
 
 def load_kube_config(kube_config, kube_context, skip_ssl_verification):
@@ -889,17 +1376,21 @@ def load_kube_config(kube_config, kube_context, skip_ssl_verification):
         config.load_kube_config(config_file=kube_config, context=kube_context)
         if skip_ssl_verification:
             from kubernetes.client import Configuration
+
             default_config = Configuration.get_default_copy()
             default_config.verify_ssl = False
             Configuration.set_default(default_config)
     except Exception as e:
-        telemetry.set_exception(exception=e, fault_type=consts.Load_Kubeconfig_Fault_Type,
-                                summary='Problem loading the kubeconfig file')
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Load_Kubeconfig_Fault_Type,
+            summary="Problem loading the kubeconfig file",
+        )
         raise FileOperationError("Problem loading the kubeconfig file." + str(e))
 
 
 def get_private_key(key_pair):
-    privKey_DER = key_pair.exportKey(format='DER')
+    privKey_DER = key_pair.exportKey(format="DER")
     return PEM.encode(privKey_DER, "RSA PRIVATE KEY")
 
 
@@ -915,30 +1406,37 @@ def get_kubernetes_distro(api_response):  # Heuristic
                 return "openshift"
             if labels.get("kubernetes.azure.com/node-image-version"):
                 return "aks"
-            if labels.get("cloud.google.com/gke-nodepool") or labels.get("cloud.google.com/gke-os-distribution"):
+            if labels.get("cloud.google.com/gke-nodepool") or labels.get(
+                "cloud.google.com/gke-os-distribution"
+            ):
                 return "gke"
             if labels.get("eks.amazonaws.com/nodegroup"):
                 return "eks"
             if labels.get("minikube.k8s.io/version"):
                 return "minikube"
-            if annotations.get("node.aksedge.io/distro") == 'aks_edge_k3s':
+            if annotations.get("node.aksedge.io/distro") == "aks_edge_k3s":
                 return "aks_edge_k3s"
-            if annotations.get("node.aksedge.io/distro") == 'aks_edge_k8s':
+            if annotations.get("node.aksedge.io/distro") == "aks_edge_k8s":
                 return "aks_edge_k8s"
             if provider_id.startswith("kind://"):
                 return "kind"
             if provider_id.startswith("k3s://"):
                 return "k3s"
-            if annotations.get("rke.cattle.io/external-ip") or annotations.get("rke.cattle.io/internal-ip"):
+            if annotations.get("rke.cattle.io/external-ip") or annotations.get(
+                "rke.cattle.io/internal-ip"
+            ):
                 return "rancher_rke"
         return "generic"
     except Exception as e:  # pylint: disable=broad-except
-        logger.debug("Error occurred while trying to fetch Kubernetes distribution: %s", e)
+        logger.debug(
+            "Error occurred while trying to fetch Kubernetes distribution: %s", e
+        )
         utils.kubernetes_exception_handler(
             e,
             consts.Get_Kubernetes_Distro_Fault_Type,
-            'Unable to fetch kubernetes distribution',
-            raise_error=False)
+            "Unable to fetch kubernetes distribution",
+            raise_error=False,
+        )
         return "generic"
 
 
@@ -948,7 +1446,7 @@ def get_kubernetes_infra(api_response):  # Heuristic
     try:
         for node in api_response.items:
             provider_id = str(node.spec.provider_id)
-            infra = provider_id.split(':')[0]
+            infra = provider_id.split(":")[0]
             if infra == "k3s" or infra == "kind":
                 return "generic"
             if infra == "azure":
@@ -962,12 +1460,15 @@ def get_kubernetes_infra(api_response):  # Heuristic
                 return k8s_infra
         return "generic"
     except Exception as e:  # pylint: disable=broad-except
-        logger.debug("Error occured while trying to fetch kubernetes infrastructure: %s", e)
+        logger.debug(
+            "Error occured while trying to fetch kubernetes infrastructure: %s", e
+        )
         utils.kubernetes_exception_handler(
             e,
             consts.Get_Kubernetes_Infra_Fault_Type,
-            'Unable to fetch kubernetes infrastructure',
-            raise_error=False)
+            "Unable to fetch kubernetes infrastructure",
+            raise_error=False,
+        )
         return "generic"
 
 
@@ -982,8 +1483,9 @@ def check_linux_node(api_response):
         utils.kubernetes_exception_handler(
             e,
             consts.Kubernetes_Node_Type_Fetch_Fault_OS,
-            'Unable to find a linux node',
-            raise_error=False)
+            "Unable to find a linux node",
+            raise_error=False,
+        )
     return False
 
 
@@ -998,15 +1500,14 @@ def check_arm64_node(api_response):
         utils.kubernetes_exception_handler(
             e,
             consts.Kubernetes_Node_Type_Fetch_Fault_Arch,
-            'Unable to find an arm64 node',
-            raise_error=False)
+            "Unable to find an arm64 node",
+            raise_error=False,
+        )
     return False
 
 
 def set_oidc_issuer_profile(enable_oidc_issuer, self_hosted_issuer=""):
-    oidc_profile = OidcIssuerProfile(
-        enabled=enable_oidc_issuer
-    )
+    oidc_profile = OidcIssuerProfile(enabled=enable_oidc_issuer)
     if self_hosted_issuer != "":
         oidc_profile.self_hosted_issuer_url = self_hosted_issuer
     return oidc_profile
@@ -1021,7 +1522,9 @@ def set_security_profile(enable_workload_identity):
     return security_profile
 
 
-def generate_arc_agent_configuration(configuration_settings, redacted_protected_settings, is_dp_call=False):
+def generate_arc_agent_configuration(
+    configuration_settings, redacted_protected_settings, is_dp_call=False
+):
     arc_agentry_configurations = []
 
     # Initialize configuration_settings and configuration_protected_settings if they are None
@@ -1030,21 +1533,37 @@ def generate_arc_agent_configuration(configuration_settings, redacted_protected_
     if redacted_protected_settings is None:
         redacted_protected_settings = {}
 
-    for feature in set(list(configuration_settings.keys()) + list(redacted_protected_settings.keys())):
+    for feature in set(
+        list(configuration_settings.keys()) + list(redacted_protected_settings.keys())
+    ):
         settings = configuration_settings.get(feature)
         protected_settings = redacted_protected_settings.get(feature)
         configuration = ArcAgentryConfigurations(
             feature=feature,
             settings=settings,
-            protected_settings=protected_settings if is_dp_call else None
+            protected_settings=protected_settings if is_dp_call else None,
         )
         arc_agentry_configurations.append(configuration)
     return arc_agentry_configurations
 
 
-def generate_request_payload(location, public_key, tags, kubernetes_distro, kubernetes_infra, enable_private_link, private_link_scope_resource_id,
-                             distribution_version, azure_hybrid_benefit, enable_oidc_issuer, enable_workload_identity, gateway,
-                             arc_agentry_configurations, arc_agent_profile, self_hosted_issuer=""):
+def generate_request_payload(
+    location,
+    public_key,
+    tags,
+    kubernetes_distro,
+    kubernetes_infra,
+    enable_private_link,
+    private_link_scope_resource_id,
+    distribution_version,
+    azure_hybrid_benefit,
+    enable_oidc_issuer,
+    enable_workload_identity,
+    gateway,
+    arc_agentry_configurations,
+    arc_agent_profile,
+    self_hosted_issuer="",
+):
     # Create connected cluster resource object
     identity = ConnectedClusterIdentity(type="SystemAssigned")
     if tags is None:
@@ -1055,18 +1574,29 @@ def generate_request_payload(location, public_key, tags, kubernetes_distro, kube
         agent_public_key_certificate=public_key,
         tags=tags,
         distribution=kubernetes_distro,
-        infrastructure=kubernetes_infra
+        infrastructure=kubernetes_infra,
     )
 
-    if enable_private_link is not None or distribution_version is not None or azure_hybrid_benefit is not None \
-        or enable_oidc_issuer or enable_workload_identity or gateway is not None or arc_agentry_configurations is not None \
-        or arc_agent_profile is not None:
+    if (
+        enable_private_link is not None
+        or distribution_version is not None
+        or azure_hybrid_benefit is not None
+        or enable_oidc_issuer
+        or enable_workload_identity
+        or gateway is not None
+        or arc_agentry_configurations is not None
+        or arc_agent_profile is not None
+    ):
         # Set additional parameters
         private_link_state, oidc_issuer, security_profile = None, None, None
         if enable_private_link is not None:
-            private_link_state = "Enabled" if enable_private_link is True else "Disabled"
+            private_link_state = (
+                "Enabled" if enable_private_link is True else "Disabled"
+            )
         if enable_oidc_issuer:
-            oidc_issuer = set_oidc_issuer_profile(enable_oidc_issuer, self_hosted_issuer)
+            oidc_issuer = set_oidc_issuer_profile(
+                enable_oidc_issuer, self_hosted_issuer
+            )
         if enable_workload_identity:
             security_profile = set_security_profile(enable_workload_identity)
 
@@ -1085,16 +1615,26 @@ def generate_request_payload(location, public_key, tags, kubernetes_distro, kube
             gateway=gateway,
             arc_agentry_configurations=arc_agentry_configurations,
             oidc_issuer_profile=oidc_issuer,
-            security_profile=security_profile
+            security_profile=security_profile,
         )
 
     return cc
 
 
-def generate_reput_request_payload(cc, enable_oidc_issuer, enable_workload_identity, self_hosted_issuer, gateway, arc_agentry_configurations, arc_agent_profile):
+def generate_reput_request_payload(
+    cc,
+    enable_oidc_issuer,
+    enable_workload_identity,
+    self_hosted_issuer,
+    gateway,
+    arc_agentry_configurations,
+    arc_agent_profile,
+):
     # Update connected cluster resource object
     if enable_oidc_issuer is not None:
-        cc.oidc_issuer_profile = set_oidc_issuer_profile(enable_oidc_issuer, self_hosted_issuer)
+        cc.oidc_issuer_profile = set_oidc_issuer_profile(
+            enable_oidc_issuer, self_hosted_issuer
+        )
 
     if enable_workload_identity is not None:
         cc.security_profile = set_security_profile(enable_workload_identity)
@@ -1104,39 +1644,51 @@ def generate_reput_request_payload(cc, enable_oidc_issuer, enable_workload_ident
 
     if arc_agentry_configurations is not None:
         cc.arc_agentry_configurations = arc_agentry_configurations
-    
+
     if arc_agent_profile is not None:
         cc.arc_agent_profile = arc_agent_profile
 
     return cc
 
 
-def generate_patch_payload(tags, distribution, distribution_version, azure_hybrid_benefit):
+def generate_patch_payload(
+    tags, distribution, distribution_version, azure_hybrid_benefit
+):
     cc = ConnectedClusterPatchPreview(
         tags=tags,
         distribution=distribution,
         distribution_version=distribution_version,
-        azure_hybrid_benefit=azure_hybrid_benefit
+        azure_hybrid_benefit=azure_hybrid_benefit,
     )
     return cc
 
 
 def get_kubeconfig_node_dict(kube_config=None):
     if kube_config is None:
-        kube_config = os.getenv('KUBECONFIG') if os.getenv(
-            'KUBECONFIG') else os.path.join(os.path.expanduser('~'), '.kube', 'config')
+        kube_config = (
+            os.getenv("KUBECONFIG")
+            if os.getenv("KUBECONFIG")
+            else os.path.join(os.path.expanduser("~"), ".kube", "config")
+        )
     try:
-        kubeconfig_data = config.kube_config._get_kube_config_loader_for_yaml_file(kube_config)._config
+        kubeconfig_data = config.kube_config._get_kube_config_loader_for_yaml_file(
+            kube_config
+        )._config
     except Exception as ex:
-        telemetry.set_exception(exception=ex, fault_type=consts.Load_Kubeconfig_Fault_Type,
-                                summary='Error while fetching details from kubeconfig')
-        raise FileOperationError("Error while fetching details from kubeconfig." + str(ex))
+        telemetry.set_exception(
+            exception=ex,
+            fault_type=consts.Load_Kubeconfig_Fault_Type,
+            summary="Error while fetching details from kubeconfig",
+        )
+        raise FileOperationError(
+            "Error while fetching details from kubeconfig." + str(ex)
+        )
     return kubeconfig_data
 
 
 def check_proxy_kubeconfig(kube_config, kube_context, arm_hash):
     server_address = get_server_address(kube_config, kube_context)
-    regex_string = r'https://127.0.0.1:[0-9]{1,5}/' + arm_hash
+    regex_string = r"https://127.0.0.1:[0-9]{1,5}/" + arm_hash
     p = re.compile(regex_string)
     return bool(p.fullmatch(server_address))
 
@@ -1151,30 +1703,34 @@ def check_aks_cluster(kube_config, kube_context):
 def get_server_address(kube_config, kube_context):
     config_data = get_kubeconfig_node_dict(kube_config=kube_config)
     try:
-        all_contexts, current_context = config.list_kube_config_contexts(config_file=kube_config)
+        all_contexts, current_context = config.list_kube_config_contexts(
+            config_file=kube_config
+        )
     except Exception as e:  # pylint: disable=broad-except
         logger.warning("Exception while trying to list kube contexts: %s\n", e)
 
     if kube_context is None:
         # Get name of the cluster from current context as kube_context is none.
-        cluster_name = current_context.get('context').get('cluster')
+        cluster_name = current_context.get("context").get("cluster")
         if cluster_name is None:
-            logger.warning("Cluster not found in currentcontext: %s", str(current_context))
+            logger.warning(
+                "Cluster not found in currentcontext: %s", str(current_context)
+            )
     else:
         cluster_found = False
         for context in all_contexts:
-            if context.get('name') == kube_context:
+            if context.get("name") == kube_context:
                 cluster_found = True
-                cluster_name = context.get('context').get('cluster')
+                cluster_name = context.get("context").get("cluster")
                 break
         if not cluster_found or cluster_name is None:
             logger.warning("Cluster not found in kubecontext: %s", str(kube_context))
 
-    clusters = config_data.safe_get('clusters')
+    clusters = config_data.safe_get("clusters")
     server_address = ""
     for cluster in clusters:
-        if cluster.safe_get('name') == cluster_name:
-            server_address = cluster.safe_get('cluster').get('server')
+        if cluster.safe_get("name") == cluster_name:
+            server_address = cluster.safe_get("cluster").get("server")
             break
     return server_address
 
@@ -1208,28 +1764,46 @@ def list_connectedk8s(cmd, client, resource_group_name=None):
     return client.list_by_resource_group(resource_group_name)
 
 
-def delete_connectedk8s(cmd, client, resource_group_name, cluster_name, kube_config=None, kube_context=None,
-                        no_wait=False, force_delete=False, skip_ssl_verification=False, yes=False):
-
+def delete_connectedk8s(
+    cmd,
+    client,
+    resource_group_name,
+    cluster_name,
+    kube_config=None,
+    kube_context=None,
+    no_wait=False,
+    force_delete=False,
+    skip_ssl_verification=False,
+    yes=False,
+):
     # The force delete prompt is added because it can be used in the case where the config map is missing
     # so we cannot check if the user context is pointing to the cluster that he intends to delete
     if not force_delete:
         confirmation_message = "Are you sure you want to perform delete operation?"
         utils.user_confirmation(confirmation_message, yes)
     elif force_delete:
-        confirmation_message = \
-            "Force delete will clean up all the azure-arc resources, including extensions. Please make sure your " \
+        confirmation_message = (
+            "Force delete will clean up all the azure-arc resources, including extensions. Please make sure your "
             " current kubeconfig is pointing to the right cluster.\nAre you sure you want to perform force delete:"
+        )
         utils.user_confirmation(confirmation_message, yes)
 
     logger.warning("This operation might take a while ...\n")
 
     # Check if the cluster is of supported type for deletion
-    preview_cluster_resource = get_connectedk8s_2023_11_01(cmd, resource_group_name, cluster_name)
-    if (preview_cluster_resource is not None) and (preview_cluster_resource.kind is not None) and \
-            (preview_cluster_resource.kind.lower() == consts.Provisioned_Cluster_Kind):
-        err_msg = "Deleting a Provisioned Cluster is not supported from the Connected Cluster CLI. Please use the " \
-            "'az aksarc delete' CLI command.\n" + consts.Doc_Provisioned_Cluster_Delete_Url
+    preview_cluster_resource = get_connectedk8s_2023_11_01(
+        cmd, resource_group_name, cluster_name
+    )
+    if (
+        (preview_cluster_resource is not None)
+        and (preview_cluster_resource.kind is not None)
+        and (preview_cluster_resource.kind.lower() == consts.Provisioned_Cluster_Kind)
+    ):
+        err_msg = (
+            "Deleting a Provisioned Cluster is not supported from the Connected Cluster CLI. Please use the "
+            "'az aksarc delete' CLI command.\n"
+            + consts.Doc_Provisioned_Cluster_Delete_Url
+        )
         raise InvalidArgumentValueError(err_msg)
 
     # Send cloud information to telemetry
@@ -1250,7 +1824,9 @@ def delete_connectedk8s(cmd, client, resource_group_name, cluster_name, kube_con
     helm_client_location = install_helm_client()
 
     # Check Release Existance
-    release_namespace = utils.get_release_namespace(kube_config, kube_context, helm_client_location)
+    release_namespace = utils.get_release_namespace(
+        kube_config, kube_context, helm_client_location
+    )
 
     print("Step: {}: Do node validations".format(utils.get_utctimestring()))
     utils.try_list_node_fix()
@@ -1259,7 +1835,7 @@ def delete_connectedk8s(cmd, client, resource_group_name, cluster_name, kube_con
     is_arm64_cluster = check_arm64_node(node_api_response)
 
     # Check forced delete flag
-    if (force_delete):
+    if force_delete:
         print("Step: {}: Performing Force Delete".format(utils.get_utctimestring()))
         kubectl_client_location = install_kubectl_client()
 
@@ -1268,9 +1844,15 @@ def delete_connectedk8s(cmd, client, resource_group_name, cluster_name, kube_con
         # Explicit CRD Deletion
         crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
 
-        if (release_namespace):
-            utils.delete_arc_agents(release_namespace, kube_config, kube_context,
-                                    helm_client_location, is_arm64_cluster, True)
+        if release_namespace:
+            utils.delete_arc_agents(
+                release_namespace,
+                kube_config,
+                kube_context,
+                helm_client_location,
+                is_arm64_cluster,
+                True,
+            )
 
         return
 
@@ -1280,90 +1862,145 @@ def delete_connectedk8s(cmd, client, resource_group_name, cluster_name, kube_con
 
     # Loading config map
     try:
-        configmap = api_instance.read_namespaced_config_map('azure-clusterconfig', 'azure-arc')
+        configmap = api_instance.read_namespaced_config_map(
+            "azure-clusterconfig", "azure-arc"
+        )
     except Exception as e:  # pylint: disable=broad-except
-        err_msg = "The helm release 'azure-arc' is present but the azure-arc namespace/configmap " \
-            "is missing. Please run 'helm delete azure-arc --namepace {} --no-hooks' to cleanup the release " \
+        err_msg = (
+            "The helm release 'azure-arc' is present but the azure-arc namespace/configmap "
+            "is missing. Please run 'helm delete azure-arc --namepace {} --no-hooks' to cleanup the release "
             "before onboarding the cluster again.".format(release_namespace)
+        )
         utils.kubernetes_exception_handler(
             e,
             consts.Read_ConfigMap_Fault_Type,
-            'Unable to read ConfigMap',
+            "Unable to read ConfigMap",
             error_message="Unable to read ConfigMap 'azure-clusterconfig' in 'azure-arc' namespace: ",
-            message_for_not_found=err_msg)
+            message_for_not_found=err_msg,
+        )
 
-    subscription_id = os.getenv('AZURE_SUBSCRIPTION_ID') if os.getenv(
-        'AZURE_ACCESS_TOKEN') else get_subscription_id(cmd.cli_ctx)
+    subscription_id = (
+        os.getenv("AZURE_SUBSCRIPTION_ID")
+        if os.getenv("AZURE_ACCESS_TOKEN")
+        else get_subscription_id(cmd.cli_ctx)
+    )
 
-    if (configmap.data["AZURE_RESOURCE_GROUP"].lower() == resource_group_name.lower() and
-            configmap.data["AZURE_RESOURCE_NAME"].lower() == cluster_name.lower() and
-            configmap.data["AZURE_SUBSCRIPTION_ID"].lower() == subscription_id.lower()):
-
+    if (
+        configmap.data["AZURE_RESOURCE_GROUP"].lower() == resource_group_name.lower()
+        and configmap.data["AZURE_RESOURCE_NAME"].lower() == cluster_name.lower()
+        and configmap.data["AZURE_SUBSCRIPTION_ID"].lower() == subscription_id.lower()
+    ):
         armid = "/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Kubernetes/connectedClusters/{}".format(
-            subscription_id, resource_group_name, cluster_name)
-        arm_hash = hashlib.sha256(armid.lower().encode('utf-8')).hexdigest()
+            subscription_id, resource_group_name, cluster_name
+        )
+        arm_hash = hashlib.sha256(armid.lower().encode("utf-8")).hexdigest()
 
         if check_proxy_kubeconfig(kube_config, kube_context, arm_hash):
             telemetry.set_exception(
-                exception='Encountered proxy kubeconfig during deletion.',
+                exception="Encountered proxy kubeconfig during deletion.",
                 fault_type=consts.Proxy_Kubeconfig_During_Deletion_Fault_Type,
-                summary='The resource cannot be deleted as user is using proxy kubeconfig.')
-            reco_str = "Run the az connectedk8s delete command with your kubeconfig file pointing to the actual " \
+                summary="The resource cannot be deleted as user is using proxy kubeconfig.",
+            )
+            reco_str = (
+                "Run the az connectedk8s delete command with your kubeconfig file pointing to the actual "
                 "Kubernetes cluster to ensure that agents are cleaned up successfully as part of the delete command."
+            )
             raise ClientRequestError(
                 "az connectedk8s delete is not supported when using the Cluster Connect kubeconfig.",
-                recommendation=reco_str)
+                recommendation=reco_str,
+            )
 
         delete_cc_resource(client, resource_group_name, cluster_name, no_wait).result()
     else:
         telemetry.set_exception(
-            exception='Unable to delete connected cluster',
+            exception="Unable to delete connected cluster",
             fault_type=consts.Bad_DeleteRequest_Fault_Type,
-            summary='The resource cannot be deleted as kubernetes cluster is onboarded with some other resource id')
+            summary="The resource cannot be deleted as kubernetes cluster is onboarded with some other resource id",
+        )
         raise ArgumentUsageError(
-            "The current context in the kubeconfig file does not correspond " +
-            "to the connected cluster resource specified. Agents installed on this cluster correspond " +
-            "to the resource group name '{}' ".format(configmap.data["AZURE_RESOURCE_GROUP"]) +
-            "and resource name '{}'.".format(configmap.data["AZURE_RESOURCE_NAME"]))
+            "The current context in the kubeconfig file does not correspond "
+            + "to the connected cluster resource specified. Agents installed on this cluster correspond "
+            + "to the resource group name '{}' ".format(
+                configmap.data["AZURE_RESOURCE_GROUP"]
+            )
+            + "and resource name '{}'.".format(configmap.data["AZURE_RESOURCE_NAME"])
+        )
 
     # Deleting the azure-arc agents
-    utils.delete_arc_agents(release_namespace, kube_config, kube_context, helm_client_location, is_arm64_cluster)
+    utils.delete_arc_agents(
+        release_namespace,
+        kube_config,
+        kube_context,
+        helm_client_location,
+        is_arm64_cluster,
+    )
 
-    print("Step: {}: Delete of Connected Cluster ended.".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Delete of Connected Cluster ended.".format(utils.get_utctimestring())
+    )
 
 
 def create_cc_resource(client, resource_group_name, cluster_name, cc, no_wait):
     try:
-        return sdk_no_wait(no_wait, client.begin_create, resource_group_name=resource_group_name,
-                           cluster_name=cluster_name, connected_cluster=cc)
+        return sdk_no_wait(
+            no_wait,
+            client.begin_create,
+            resource_group_name=resource_group_name,
+            cluster_name=cluster_name,
+            connected_cluster=cc,
+        )
     except Exception as e:
-        utils.arm_exception_handler(e, consts.Create_ConnectedCluster_Fault_Type,
-                                    'Unable to create connected cluster resource')
+        utils.arm_exception_handler(
+            e,
+            consts.Create_ConnectedCluster_Fault_Type,
+            "Unable to create connected cluster resource",
+        )
 
 
 def patch_cc_resource(client, resource_group_name, cluster_name, cc):
     try:
-        return client.update(resource_group_name=resource_group_name,
-                             cluster_name=cluster_name, connected_cluster_patch=cc)
+        return client.update(
+            resource_group_name=resource_group_name,
+            cluster_name=cluster_name,
+            connected_cluster_patch=cc,
+        )
     except Exception as e:
-        utils.arm_exception_handler(e, consts.Update_ConnectedCluster_Fault_Type,
-                                    'Unable to update connected cluster resource')
+        utils.arm_exception_handler(
+            e,
+            consts.Update_ConnectedCluster_Fault_Type,
+            "Unable to update connected cluster resource",
+        )
 
 
 def delete_cc_resource(client, resource_group_name, cluster_name, no_wait):
     print("Step: {}: Deleting ARM resource".format(utils.get_utctimestring()))
     try:
-        return sdk_no_wait(no_wait, client.begin_delete,
-                           resource_group_name=resource_group_name,
-                           cluster_name=cluster_name)
+        return sdk_no_wait(
+            no_wait,
+            client.begin_delete,
+            resource_group_name=resource_group_name,
+            cluster_name=cluster_name,
+        )
     except Exception as e:
-        utils.arm_exception_handler(e, consts.Delete_ConnectedCluster_Fault_Type,
-                                    'Unable to delete connected cluster resource')
+        utils.arm_exception_handler(
+            e,
+            consts.Delete_ConnectedCluster_Fault_Type,
+            "Unable to delete connected cluster resource",
+        )
 
 
-def update_connected_cluster_internal(client, resource_group_name, cluster_name, tags=None, distribution=None,
-                                      distribution_version=None, azure_hybrid_benefit=None):
-    cc = generate_patch_payload(tags, distribution, distribution_version, azure_hybrid_benefit)
+def update_connected_cluster_internal(
+    client,
+    resource_group_name,
+    cluster_name,
+    tags=None,
+    distribution=None,
+    distribution_version=None,
+    azure_hybrid_benefit=None,
+):
+    cc = generate_patch_payload(
+        tags, distribution, distribution_version, azure_hybrid_benefit
+    )
     return patch_cc_resource(client, resource_group_name, cluster_name, cc)
 
 
@@ -1374,22 +2011,48 @@ def update_connected_cluster_internal(client, resource_group_name, cluster_name,
 # pylint: disable=line-too-long
 
 
-def update_connected_cluster(cmd, client, resource_group_name, cluster_name, https_proxy="", http_proxy="", no_proxy="", proxy_cert="",
-                             disable_proxy=False, kube_config=None, kube_context=None, auto_upgrade=None, tags=None,
-                             distribution=None, distribution_version=None, azure_hybrid_benefit=None, skip_ssl_verification=False, yes=False,
-                             container_log_path=None, enable_oidc_issuer=None, enable_workload_identity=None, self_hosted_issuer="",
-                             disable_workload_identity=None, gateway_resource_id="", disable_gateway=False,
-                             configuration_settings=None, configuration_protected_settings=None):
-
+def update_connected_cluster(
+    cmd,
+    client,
+    resource_group_name,
+    cluster_name,
+    https_proxy="",
+    http_proxy="",
+    no_proxy="",
+    proxy_cert="",
+    disable_proxy=False,
+    kube_config=None,
+    kube_context=None,
+    auto_upgrade=None,
+    tags=None,
+    distribution=None,
+    distribution_version=None,
+    azure_hybrid_benefit=None,
+    skip_ssl_verification=False,
+    yes=False,
+    container_log_path=None,
+    enable_oidc_issuer=None,
+    enable_workload_identity=None,
+    self_hosted_issuer="",
+    disable_workload_identity=None,
+    gateway_resource_id="",
+    disable_gateway=False,
+    configuration_settings=None,
+    configuration_protected_settings=None,
+):
     # Prompt for confirmation for few parameters
     if azure_hybrid_benefit == "True":
-        confirmation_message = "I confirm I have an eligible Windows Server license with Azure Hybrid Benefit to " \
+        confirmation_message = (
+            "I confirm I have an eligible Windows Server license with Azure Hybrid Benefit to "
             "apply this benefit to AKS on HCI or Windows Server. Visit https://aka.ms/ahb-aks for details"
+        )
         utils.user_confirmation(confirmation_message, yes)
 
     # Validation for the workload identity webhook parameter
     if enable_workload_identity is not None and disable_workload_identity is not None:
-        raise InvalidArgumentValueError("Do not specify both enable-workload-identity and disable-workload-identity at the same time.")
+        raise InvalidArgumentValueError(
+            "Do not specify both enable-workload-identity and disable-workload-identity at the same time."
+        )
     if disable_workload_identity is True:
         enable_workload_identity = False
 
@@ -1411,25 +2074,53 @@ def update_connected_cluster(cmd, client, resource_group_name, cluster_name, htt
     # check whether proxy cert path exists
     if proxy_cert != "" and (not os.path.exists(proxy_cert)):
         telemetry.set_exception(
-            exception='Proxy cert path does not exist',
+            exception="Proxy cert path does not exist",
             fault_type=consts.Proxy_Cert_Path_Does_Not_Exist_Fault_Type,
-            summary='Proxy cert path does not exist')
-        raise InvalidArgumentValueError(str.format(consts.Proxy_Cert_Path_Does_Not_Exist_Error, proxy_cert))
+            summary="Proxy cert path does not exist",
+        )
+        raise InvalidArgumentValueError(
+            str.format(consts.Proxy_Cert_Path_Does_Not_Exist_Error, proxy_cert)
+        )
 
-    proxy_cert = proxy_cert.replace('\\', r'\\\\')
+    proxy_cert = proxy_cert.replace("\\", r"\\\\")
 
-    configuration_settings, configuration_protected_settings, redacted_protected_values = add_config_protected_settings(http_proxy, https_proxy, no_proxy, proxy_cert, container_log_path, configuration_settings, configuration_protected_settings)
+    (
+        configuration_settings,
+        configuration_protected_settings,
+        redacted_protected_values,
+    ) = add_config_protected_settings(
+        http_proxy,
+        https_proxy,
+        no_proxy,
+        proxy_cert,
+        container_log_path,
+        configuration_settings,
+        configuration_protected_settings,
+    )
     arc_agentry_configurations = None
-    if configuration_protected_settings is not None or configuration_settings is not None:
-        arc_agentry_configurations = generate_arc_agent_configuration(configuration_settings, redacted_protected_values)
+    if (
+        configuration_protected_settings is not None
+        or configuration_settings is not None
+    ):
+        arc_agentry_configurations = generate_arc_agent_configuration(
+            configuration_settings, redacted_protected_values
+        )
 
     # Fetch Connected Cluster for agent version
-    connected_cluster = get_connectedk8s_2024_07_01(cmd, resource_group_name, cluster_name)
+    connected_cluster = get_connectedk8s_2024_07_01(
+        cmd, resource_group_name, cluster_name
+    )
 
-    if (connected_cluster is not None) and (connected_cluster.kind is not None) and \
-            (connected_cluster.kind.lower() == consts.Provisioned_Cluster_Kind):
-        err_msg = "Updating a Provisioned Cluster is not supported from the Connected Cluster CLI. " \
-            "Please use the 'az aksarc update' CLI command.\n" + consts.Doc_Provisioned_Cluster_Update_Url
+    if (
+        (connected_cluster is not None)
+        and (connected_cluster.kind is not None)
+        and (connected_cluster.kind.lower() == consts.Provisioned_Cluster_Kind)
+    ):
+        err_msg = (
+            "Updating a Provisioned Cluster is not supported from the Connected Cluster CLI. "
+            "Please use the 'az aksarc update' CLI command.\n"
+            + consts.Doc_Provisioned_Cluster_Update_Url
+        )
         raise InvalidArgumentValueError(err_msg)
 
     # Set preview client as most of the patchable fields are available in preview api-version
@@ -1437,18 +2128,43 @@ def update_connected_cluster(cmd, client, resource_group_name, cluster_name, htt
 
     # Patching the connected cluster ARM resource
     arm_properties_unset = (
-        tags is None and distribution is None and distribution_version is None and azure_hybrid_benefit is None)
+        tags is None
+        and distribution is None
+        and distribution_version is None
+        and azure_hybrid_benefit is None
+    )
     if not arm_properties_unset:
         patch_cc_response = update_connected_cluster_internal(
-            client, resource_group_name, cluster_name, tags, distribution, distribution_version, azure_hybrid_benefit)
+            client,
+            resource_group_name,
+            cluster_name,
+            tags,
+            distribution,
+            distribution_version,
+            azure_hybrid_benefit,
+        )
 
-    proxy_params_unset = (https_proxy == "" and http_proxy == "" and no_proxy ==
-                          "" and proxy_cert == "" and not disable_proxy)
+    proxy_params_unset = (
+        https_proxy == ""
+        and http_proxy == ""
+        and no_proxy == ""
+        and proxy_cert == ""
+        and not disable_proxy
+    )
 
     # Returning the ARM response if only AHB is being updated
     arm_properties_only_ahb_set = (
-        tags is None and distribution is None and distribution_version is None and azure_hybrid_benefit is not None)
-    if proxy_params_unset and auto_upgrade is None and container_log_path is None and arm_properties_only_ahb_set:
+        tags is None
+        and distribution is None
+        and distribution_version is None
+        and azure_hybrid_benefit is not None
+    )
+    if (
+        proxy_params_unset
+        and auto_upgrade is None
+        and container_log_path is None
+        and arm_properties_only_ahb_set
+    ):
         return patch_cc_response
 
     if (
@@ -1483,80 +2199,117 @@ def update_connected_cluster(cmd, client, resource_group_name, cluster_name, htt
     helm_client_location = install_helm_client()
 
     release_namespace = validate_release_namespace(
-        client, cluster_name, resource_group_name, kube_config, kube_context, helm_client_location)
+        client,
+        cluster_name,
+        resource_group_name,
+        kube_config,
+        kube_context,
+        helm_client_location,
+    )
 
     # Fetch Connected Cluster for agent version
     connected_cluster = get_connectedk8s(cmd, client, resource_group_name, cluster_name)
 
-    kubernetes_properties = {'Context.Default.AzureCLI.KubernetesVersion': kubernetes_version}
+    kubernetes_properties = {
+        "Context.Default.AzureCLI.KubernetesVersion": kubernetes_version
+    }
 
-    if hasattr(connected_cluster, 'distribution') and (connected_cluster.distribution is not None):
+    if hasattr(connected_cluster, "distribution") and (
+        connected_cluster.distribution is not None
+    ):
         kubernetes_distro = connected_cluster.distribution
-        kubernetes_properties['Context.Default.AzureCLI.KubernetesDistro'] = kubernetes_distro
+        kubernetes_properties["Context.Default.AzureCLI.KubernetesDistro"] = (
+            kubernetes_distro
+        )
 
-    if hasattr(connected_cluster, 'infrastructure') and (connected_cluster.infrastructure is not None):
+    if hasattr(connected_cluster, "infrastructure") and (
+        connected_cluster.infrastructure is not None
+    ):
         kubernetes_infra = connected_cluster.infrastructure
-        kubernetes_properties['Context.Default.AzureCLI.KubernetesInfra'] = kubernetes_infra
+        kubernetes_properties["Context.Default.AzureCLI.KubernetesInfra"] = (
+            kubernetes_infra
+        )
 
-    telemetry.add_extension_event('connectedk8s', kubernetes_properties)
+    telemetry.add_extension_event("connectedk8s", kubernetes_properties)
 
     # If gateway is enabled
     gateway = None
     if gateway_resource_id != "":
-        gateway = Gateway(
-            enabled=True,
-            resource_id=gateway_resource_id
-        )
+        gateway = Gateway(enabled=True, resource_id=gateway_resource_id)
     if disable_gateway:
-        gateway = Gateway(
-            enabled=False
-        )
+        gateway = Gateway(enabled=False)
 
     # Set arc agent profile when auto-upgrade is set
     arc_agent_profile = None
     if auto_upgrade is not None:
-        arc_agent_profile = ArcAgentProfile(agent_auto_upgrade="Enabled") if auto_upgrade else ArcAgentProfile(agent_auto_upgrade="Disabled")
+        arc_agent_profile = (
+            ArcAgentProfile(agent_auto_upgrade="Enabled")
+            if auto_upgrade
+            else ArcAgentProfile(agent_auto_upgrade="Disabled")
+        )
 
     # Get the connected cluster resource using latest api version and generate reput request payload
-    connected_cluster = get_connectedk8s_2024_07_01(cmd, resource_group_name, cluster_name)
-    cc = generate_reput_request_payload(connected_cluster, enable_oidc_issuer, enable_workload_identity, self_hosted_issuer, gateway, 
-                                        arc_agentry_configurations, arc_agent_profile)
+    connected_cluster = get_connectedk8s_2024_07_01(
+        cmd, resource_group_name, cluster_name
+    )
+    cc = generate_reput_request_payload(
+        connected_cluster,
+        enable_oidc_issuer,
+        enable_workload_identity,
+        self_hosted_issuer,
+        gateway,
+        arc_agentry_configurations,
+        arc_agent_profile,
+    )
 
     # Update connected cluster resource
-    reput_cc_response = create_cc_resource(client, resource_group_name, cluster_name, cc, False)
+    reput_cc_response = create_cc_resource(
+        client, resource_group_name, cluster_name, cc, False
+    )
     dp_request_payload = reput_cc_response.result()
     reput_cc_response = LongRunningOperation(cmd.cli_ctx)(reput_cc_response)
 
     # Adding helm repo
-    if os.getenv('HELMREPONAME') and os.getenv('HELMREPOURL'):
+    if os.getenv("HELMREPONAME") and os.getenv("HELMREPOURL"):
         utils.add_helm_repo(kube_config, kube_context, helm_client_location)
 
-    config_dp_endpoint, release_train = get_config_dp_endpoint(cmd, connected_cluster.location, values_file)
+    config_dp_endpoint, release_train = get_config_dp_endpoint(
+        cmd, connected_cluster.location, values_file
+    )
 
     # Update arc agent configuration to include protected parameters in dp call
-    arc_agentry_configurations = generate_arc_agent_configuration(configuration_settings, redacted_protected_values, is_dp_call=True)
+    arc_agentry_configurations = generate_arc_agent_configuration(
+        configuration_settings, redacted_protected_values, is_dp_call=True
+    )
     dp_request_payload.arc_agentry_configurations = arc_agentry_configurations
 
     # Perform DP health check
     _ = utils.health_check_dp(cmd, config_dp_endpoint)
 
     # Retrieving Helm chart OCI Artifact location
-    helm_values_dp = utils.get_helm_values(cmd, config_dp_endpoint, release_train, request_body=dp_request_payload)
+    helm_values_dp = utils.get_helm_values(
+        cmd, config_dp_endpoint, release_train, request_body=dp_request_payload
+    )
 
-    registry_path = os.getenv('HELMREGISTRY') if os.getenv('HELMREGISTRY') else \
-        helm_values_dp["repositoryPath"]
+    registry_path = (
+        os.getenv("HELMREGISTRY")
+        if os.getenv("HELMREGISTRY")
+        else helm_values_dp["repositoryPath"]
+    )
 
     # Get azure-arc agent version for telemetry
-    reg_path_array = registry_path.split(':')
+    reg_path_array = registry_path.split(":")
     agent_version = reg_path_array[1]
 
     helm_content_values = helm_values_dp["helmValuesContent"]
 
     # Substitute any protected helm values as the value for that will be 'redacted-<feature>-<protectedSetting>'
     for helm_parameter, helm_value in helm_content_values.items():
-        if 'redacted' in helm_value:
-            _, feature, protectedSetting = helm_value.split('-')
-            helm_content_values[helm_parameter] = configuration_protected_settings[feature][protectedSetting]
+        if "redacted" in helm_value:
+            _, feature, protectedSetting = helm_value.split("-")
+            helm_content_values[helm_parameter] = configuration_protected_settings[
+                feature
+            ][protectedSetting]
 
     # Set agent version in registry path
     if connected_cluster.agent_version is not None:
@@ -1565,14 +2318,26 @@ def update_connected_cluster(cmd, client, resource_group_name, cluster_name, htt
 
     check_operation_support("update (properties)", agent_version)
 
-    telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
+    telemetry.add_extension_event(
+        "connectedk8s", {"Context.Default.AzureCLI.AgentVersion": agent_version}
+    )
 
     # Get Helm chart path
-    chart_path = utils.get_chart_path(registry_path, kube_config, kube_context, helm_client_location)
+    chart_path = utils.get_chart_path(
+        registry_path, kube_config, kube_context, helm_client_location
+    )
 
     # Perform helm upgrade
-    utils.helm_update_agent(helm_client_location, kube_config, kube_context, helm_content_values,
-                            values_file, cluster_name, release_namespace, chart_path)
+    utils.helm_update_agent(
+        helm_client_location,
+        kube_config,
+        kube_context,
+        helm_content_values,
+        values_file,
+        cluster_name,
+        release_namespace,
+        chart_path,
+    )
     if not arm_properties_unset:
         return patch_cc_response
 
@@ -1587,27 +2352,55 @@ def update_connected_cluster(cmd, client, resource_group_name, cluster_name, htt
         - If workload identity is enabled, extension is installed, poll for agent state.
     """
     if (enable_oidc_issuer and self_hosted_issuer == "") or enable_workload_identity:
-        print("Step: {}: Wait for Agent State to reach terminal state, with timeout of {}".format(utils.get_utctimestring(), 
-                                                                                                consts.Agent_State_Timeout))
+        print(
+            "Step: {}: Wait for Agent State to reach terminal state, with timeout of {}".format(
+                utils.get_utctimestring(), consts.Agent_State_Timeout
+            )
+        )
         if poll_for_agent_state(cmd, resource_group_name, cluster_name):
-            connected_cluster = get_connectedk8s_2024_07_01(cmd, resource_group_name, cluster_name)
-            print("Step: {}: Agent state has reached terminal state of {}.".format(utils.get_utctimestring(), 
-                                                                                connected_cluster.arc_agent_profile.agent_state))
+            connected_cluster = get_connectedk8s_2024_07_01(
+                cmd, resource_group_name, cluster_name
+            )
+            print(
+                "Step: {}: Agent state has reached terminal state of {}.".format(
+                    utils.get_utctimestring(),
+                    connected_cluster.arc_agent_profile.agent_state,
+                )
+            )
         else:
-            raise CLIInternalError("Timed out waiting for Agent State to reach terminal state.")
+            raise CLIInternalError(
+                "Timed out waiting for Agent State to reach terminal state."
+            )
 
     return reput_cc_response
 
 
-def upgrade_agents(cmd, client, resource_group_name, cluster_name, kube_config=None, kube_context=None,
-                   skip_ssl_verification=False, arc_agent_version=None, upgrade_timeout="600"):
+def upgrade_agents(
+    cmd,
+    client,
+    resource_group_name,
+    cluster_name,
+    kube_config=None,
+    kube_context=None,
+    skip_ssl_verification=False,
+    arc_agent_version=None,
+    upgrade_timeout="600",
+):
     # Check if cluster supports upgrading
-    connected_cluster = get_connectedk8s_2023_11_01(cmd, resource_group_name, cluster_name)
+    connected_cluster = get_connectedk8s_2023_11_01(
+        cmd, resource_group_name, cluster_name
+    )
 
-    if (connected_cluster is not None) and (connected_cluster.kind is not None) and \
-            (connected_cluster.kind.lower() == consts.Provisioned_Cluster_Kind):
-        err_msg = "Upgrading a Provisioned Cluster is not supported from the Connected Cluster CLI. Please use the " \
-            "'az aksarc upgrade' CLI command. \n" + consts.Doc_Provisioned_Cluster_Upgrade_Url
+    if (
+        (connected_cluster is not None)
+        and (connected_cluster.kind is not None)
+        and (connected_cluster.kind.lower() == consts.Provisioned_Cluster_Kind)
+    ):
+        err_msg = (
+            "Upgrading a Provisioned Cluster is not supported from the Connected Cluster CLI. Please use the "
+            "'az aksarc upgrade' CLI command. \n"
+            + consts.Doc_Provisioned_Cluster_Upgrade_Url
+        )
         raise InvalidArgumentValueError(err_msg)
 
     logger.warning("This operation might take a while...\n")
@@ -1636,112 +2429,169 @@ def upgrade_agents(cmd, client, resource_group_name, cluster_name, kube_config=N
     helm_client_location = install_helm_client()
 
     # Check Release Existence
-    release_namespace = utils.get_release_namespace(kube_config, kube_context, helm_client_location)
+    release_namespace = utils.get_release_namespace(
+        kube_config, kube_context, helm_client_location
+    )
     if release_namespace:
         # Loading config map
         api_instance = kube_client.CoreV1Api()
         try:
-            configmap = api_instance.read_namespaced_config_map('azure-clusterconfig', 'azure-arc')
+            configmap = api_instance.read_namespaced_config_map(
+                "azure-clusterconfig", "azure-arc"
+            )
         except Exception as e:  # pylint: disable=broad-except
-            not_found_msg = "The helm release 'azure-arc' is present but the azure-arc namespace/configmap is " \
-                "missing. Please run 'helm delete azure-arc --namespace {} --no-hooks' to cleanup the release " \
+            not_found_msg = (
+                "The helm release 'azure-arc' is present but the azure-arc namespace/configmap is "
+                "missing. Please run 'helm delete azure-arc --namespace {} --no-hooks' to cleanup the release "
                 "before onboarding the cluster again.".format(release_namespace)
+            )
             utils.kubernetes_exception_handler(
                 e,
                 consts.Read_ConfigMap_Fault_Type,
-                'Unable to read ConfigMap',
+                "Unable to read ConfigMap",
                 error_message="Unable to read ConfigMap 'azure-clusterconfig' in 'azure-arc' namespace: ",
-                message_for_not_found=not_found_msg)
+                message_for_not_found=not_found_msg,
+            )
         configmap_rg_name = configmap.data["AZURE_RESOURCE_GROUP"]
         configmap_cluster_name = configmap.data["AZURE_RESOURCE_NAME"]
         if connected_cluster_exists(client, configmap_rg_name, configmap_cluster_name):
-            if not (configmap_rg_name.lower() == resource_group_name.lower() and
-                    configmap_cluster_name.lower() == cluster_name.lower()):
-                err_msg = "The provided cluster name and resource group name do not correspond to the kubernetes " \
+            if not (
+                configmap_rg_name.lower() == resource_group_name.lower()
+                and configmap_cluster_name.lower() == cluster_name.lower()
+            ):
+                err_msg = (
+                    "The provided cluster name and resource group name do not correspond to the kubernetes "
                     "cluster being upgraded."
+                )
                 telemetry.set_exception(
-                    exception='The provided cluster name and rg correspond to different cluster',
+                    exception="The provided cluster name and rg correspond to different cluster",
                     fault_type=consts.Upgrade_RG_Cluster_Name_Conflict,
-                    summary=err_msg)
-                reco_msg = "Please upgrade the cluster, with correct resource group and cluster name, using " \
+                    summary=err_msg,
+                )
+                reco_msg = (
+                    "Please upgrade the cluster, with correct resource group and cluster name, using "
                     "'az upgrade agents -g <rg_name> -n <cluster_name>'."
+                )
                 raise ArgumentUsageError(err_msg, recommendation=reco_msg)
         else:
             telemetry.set_exception(
-                exception='The corresponding CC resource does not exist',
+                exception="The corresponding CC resource does not exist",
                 fault_type=consts.Corresponding_CC_Resource_Deleted_Fault,
-                summary='CC resource corresponding to this cluster has been deleted by the customer')
+                summary="CC resource corresponding to this cluster has been deleted by the customer",
+            )
             err_msg = "There exist no ConnectedCluster resource corresponding to this kubernetes Cluster."
-            reco_msg = "Please cleanup the helm release first using 'az connectedk8s delete -n " \
-                "<connected-cluster-name> -g <resource-group-name>' and re-onboard the cluster using " \
+            reco_msg = (
+                "Please cleanup the helm release first using 'az connectedk8s delete -n "
+                "<connected-cluster-name> -g <resource-group-name>' and re-onboard the cluster using "
                 "'az connectedk8s connect -n <connected-cluster-name> -g <resource-group-name>'"
+            )
             raise ArgumentUsageError(err_msg, recommendation=reco_msg)
 
         auto_update_enabled = configmap.data["AZURE_ARC_AUTOUPDATE"]
         if auto_update_enabled == "true":
-            summary_msg = "az connectedk8s upgrade to manually upgrade agents and extensions is only supported when " \
+            summary_msg = (
+                "az connectedk8s upgrade to manually upgrade agents and extensions is only supported when "
                 "auto-upgrade is set to false."
+            )
             telemetry.set_exception(
-                exception='connectedk8s upgrade called when auto-update is set to true',
+                exception="connectedk8s upgrade called when auto-update is set to true",
                 fault_type=consts.Manual_Upgrade_Called_In_Auto_Update_Enabled,
-                summary=summary_msg)
-            err_msg = "az connectedk8s upgrade to manually upgrade agents and extensions is only supported when " \
+                summary=summary_msg,
+            )
+            err_msg = (
+                "az connectedk8s upgrade to manually upgrade agents and extensions is only supported when "
                 "auto-upgrade is set to false."
-            reco_msg = "Please run 'az connectedk8s update -n <connected-cluster-name> -g " \
+            )
+            reco_msg = (
+                "Please run 'az connectedk8s update -n <connected-cluster-name> -g "
                 "<resource-group-name> --auto-upgrade false' before performing manual upgrade"
+            )
             raise ClientRequestError(err_msg, recommendation=reco_msg)
 
     else:
-        summary_msg = "The azure-arc release namespace couldn't be retrieved, which implies that the kubernetes " \
+        summary_msg = (
+            "The azure-arc release namespace couldn't be retrieved, which implies that the kubernetes "
             "cluster has not been onboarded to azure-arc."
+        )
         telemetry.set_exception(
             exception="The azure-arc release namespace couldn't be retrieved",
             fault_type=consts.Release_Namespace_Not_Found,
-            summary=summary_msg)
-        err_msg = "The azure-arc release namespace couldn't be retrieved, which implies that the kubernetes cluster " \
+            summary=summary_msg,
+        )
+        err_msg = (
+            "The azure-arc release namespace couldn't be retrieved, which implies that the kubernetes cluster "
             "has not been onboarded to azure-arc."
-        reco_msg = "Please run 'az connectedk8s connect -n <connected-cluster-name> -g " \
+        )
+        reco_msg = (
+            "Please run 'az connectedk8s connect -n <connected-cluster-name> -g "
             "<resource-group-name>' to onboard the cluster"
+        )
         raise ClientRequestError(err_msg, recommendation=reco_msg)
 
     # Fetch Connected Cluster for agent version
     connected_cluster = get_connectedk8s(cmd, client, resource_group_name, cluster_name)
 
-    kubernetes_properties = {'Context.Default.AzureCLI.KubernetesVersion': kubernetes_version}
+    kubernetes_properties = {
+        "Context.Default.AzureCLI.KubernetesVersion": kubernetes_version
+    }
 
-    if hasattr(connected_cluster, 'distribution') and (connected_cluster.distribution is not None):
+    if hasattr(connected_cluster, "distribution") and (
+        connected_cluster.distribution is not None
+    ):
         kubernetes_distro = connected_cluster.distribution
-        kubernetes_properties['Context.Default.AzureCLI.KubernetesDistro'] = kubernetes_distro
+        kubernetes_properties["Context.Default.AzureCLI.KubernetesDistro"] = (
+            kubernetes_distro
+        )
 
-    if hasattr(connected_cluster, 'infrastructure') and (connected_cluster.infrastructure is not None):
+    if hasattr(connected_cluster, "infrastructure") and (
+        connected_cluster.infrastructure is not None
+    ):
         kubernetes_infra = connected_cluster.infrastructure
-        kubernetes_properties['Context.Default.AzureCLI.KubernetesInfra'] = kubernetes_infra
+        kubernetes_properties["Context.Default.AzureCLI.KubernetesInfra"] = (
+            kubernetes_infra
+        )
 
-    telemetry.add_extension_event('connectedk8s', kubernetes_properties)
+    telemetry.add_extension_event("connectedk8s", kubernetes_properties)
 
     # Adding helm repo
-    if os.getenv('HELMREPONAME') and os.getenv('HELMREPOURL'):
+    if os.getenv("HELMREPONAME") and os.getenv("HELMREPOURL"):
         utils.add_helm_repo(kube_config, kube_context, helm_client_location)
 
-    config_dp_endpoint, release_train = get_config_dp_endpoint(cmd, connected_cluster.location, values_file)
+    config_dp_endpoint, release_train = get_config_dp_endpoint(
+        cmd, connected_cluster.location, values_file
+    )
 
     # Retrieving Helm chart OCI Artifact location
-    registry_path = os.getenv('HELMREGISTRY') if os.getenv(
-        'HELMREGISTRY') else utils.get_helm_registry(cmd, config_dp_endpoint, release_train)
+    registry_path = (
+        os.getenv("HELMREGISTRY")
+        if os.getenv("HELMREGISTRY")
+        else utils.get_helm_registry(cmd, config_dp_endpoint, release_train)
+    )
 
-    reg_path_array = registry_path.split(':')
+    reg_path_array = registry_path.split(":")
     agent_version = reg_path_array[1]
 
     if arc_agent_version is not None:
         agent_version = arc_agent_version
         registry_path = reg_path_array[0] + ":" + agent_version
 
-    telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
+    telemetry.add_extension_event(
+        "connectedk8s", {"Context.Default.AzureCLI.AgentVersion": agent_version}
+    )
 
     # Get Helm chart path
-    chart_path = utils.get_chart_path(registry_path, kube_config, kube_context, helm_client_location)
+    chart_path = utils.get_chart_path(
+        registry_path, kube_config, kube_context, helm_client_location
+    )
 
-    cmd_helm_values = [helm_client_location, "get", "values", "azure-arc", "--namespace", release_namespace]
+    cmd_helm_values = [
+        helm_client_location,
+        "get",
+        "values",
+        "azure-arc",
+        "--namespace",
+        release_namespace,
+    ]
     if kube_config:
         cmd_helm_values.extend(["--kubeconfig", kube_config])
     if kube_context:
@@ -1750,14 +2600,22 @@ def upgrade_agents(cmd, client, resource_group_name, cluster_name, kube_config=N
     response_helm_values_get = Popen(cmd_helm_values, stdout=PIPE, stderr=PIPE)
     output_helm_values, error_helm_get_values = response_helm_values_get.communicate()
     if response_helm_values_get.returncode != 0:
-        if ('forbidden' in error_helm_get_values.decode("ascii") or
-                'timed out waiting for the condition' in error_helm_get_values.decode("ascii")):
+        if "forbidden" in error_helm_get_values.decode(
+            "ascii"
+        ) or "timed out waiting for the condition" in error_helm_get_values.decode(
+            "ascii"
+        ):
             telemetry.set_user_fault()
         telemetry.set_exception(
             exception=error_helm_get_values.decode("ascii"),
             fault_type=consts.Get_Helm_Values_Failed,
-            summary='Error while doing helm get values azure-arc')
-        raise CLIInternalError(str.format(consts.Upgrade_Agent_Failure, error_helm_get_values.decode("ascii")))
+            summary="Error while doing helm get values azure-arc",
+        )
+        raise CLIInternalError(
+            str.format(
+                consts.Upgrade_Agent_Failure, error_helm_get_values.decode("ascii")
+            )
+        )
 
     output_helm_values = output_helm_values.decode("ascii")
 
@@ -1767,13 +2625,28 @@ def upgrade_agents(cmd, client, resource_group_name, cluster_name, kube_config=N
         telemetry.set_exception(
             exception=e,
             fault_type=consts.Helm_Existing_User_Supplied_Value_Get_Fault,
-            summary='Problem loading the helm existing user supplied values')
-        raise CLIInternalError("Problem loading the helm existing user supplied values: " + str(e))
+            summary="Problem loading the helm existing user supplied values",
+        )
+        raise CLIInternalError(
+            "Problem loading the helm existing user supplied values: " + str(e)
+        )
 
     # Change --timeout format for helm client to understand
     upgrade_timeout = upgrade_timeout + "s"
-    cmd_helm_upgrade = [helm_client_location, "upgrade", "azure-arc", chart_path, "--namespace", release_namespace,
-                        "--output", "json", "--atomic", "--wait", "--timeout", "{}".format(upgrade_timeout)]
+    cmd_helm_upgrade = [
+        helm_client_location,
+        "upgrade",
+        "azure-arc",
+        chart_path,
+        "--namespace",
+        release_namespace,
+        "--output",
+        "json",
+        "--atomic",
+        "--wait",
+        "--timeout",
+        "{}".format(upgrade_timeout),
+    ]
 
     proxy_enabled_param_added = False
     infra_added = False
@@ -1781,10 +2654,16 @@ def upgrade_agents(cmd, client, resource_group_name, cluster_name, kube_config=N
         if value is not None:
             if key == "global.isProxyEnabled":
                 proxy_enabled_param_added = True
-            if (key == "global.httpProxy" or key == "global.httpsProxy" or key == "global.noProxy"):
+            if (
+                key == "global.httpProxy"
+                or key == "global.httpsProxy"
+                or key == "global.noProxy"
+            ):
                 value = escape_proxy_settings(value)
                 if value and not proxy_enabled_param_added:
-                    cmd_helm_upgrade.extend(["--set", "global.isProxyEnabled={}".format(True)])
+                    cmd_helm_upgrade.extend(
+                        ["--set", "global.isProxyEnabled={}".format(True)]
+                    )
                     proxy_enabled_param_added = True
             if key == "global.kubernetesDistro" and value == "default":
                 value = "generic"
@@ -1796,7 +2675,9 @@ def upgrade_agents(cmd, client, resource_group_name, cluster_name, kube_config=N
         cmd_helm_upgrade.extend(["--set", "global.isProxyEnabled={}".format(False)])
 
     if not infra_added:
-        cmd_helm_upgrade.extend(["--set", "global.kubernetesInfra={}".format("generic")])
+        cmd_helm_upgrade.extend(
+            ["--set", "global.kubernetesInfra={}".format("generic")]
+        )
 
     if values_file:
         cmd_helm_upgrade.extend(["-f", values_file])
@@ -1809,74 +2690,116 @@ def upgrade_agents(cmd, client, resource_group_name, cluster_name, kube_config=N
 
     if response_helm_upgrade.returncode != 0:
         helm_upgrade_error_message = error_helm_upgrade.decode("ascii")
-        if any(message in helm_upgrade_error_message for message in consts.Helm_Install_Release_Userfault_Messages):
+        if any(
+            message in helm_upgrade_error_message
+            for message in consts.Helm_Install_Release_Userfault_Messages
+        ):
             telemetry.set_user_fault()
         telemetry.set_exception(
             exception=error_helm_upgrade.decode("ascii"),
             fault_type=consts.Install_HelmRelease_Fault_Type,
-            summary='Unable to install helm release')
-        raise CLIInternalError(str.format(consts.Upgrade_Agent_Failure, error_helm_upgrade.decode("ascii")))
+            summary="Unable to install helm release",
+        )
+        raise CLIInternalError(
+            str.format(consts.Upgrade_Agent_Failure, error_helm_upgrade.decode("ascii"))
+        )
 
     return str.format(consts.Upgrade_Agent_Success, connected_cluster.name)
 
 
-def validate_release_namespace(client, cluster_name, resource_group_name, kube_config, kube_context,
-                               helm_client_location):
+def validate_release_namespace(
+    client,
+    cluster_name,
+    resource_group_name,
+    kube_config,
+    kube_context,
+    helm_client_location,
+):
     # Check Release Existance
-    release_namespace = utils.get_release_namespace(kube_config, kube_context, helm_client_location)
+    release_namespace = utils.get_release_namespace(
+        kube_config, kube_context, helm_client_location
+    )
     if release_namespace:
         # Loading config map
         api_instance = kube_client.CoreV1Api()
         try:
-            configmap = api_instance.read_namespaced_config_map('azure-clusterconfig', 'azure-arc')
+            configmap = api_instance.read_namespaced_config_map(
+                "azure-clusterconfig", "azure-arc"
+            )
         except Exception as e:  # pylint: disable=broad-except
-            not_found_msg = "The helm release 'azure-arc' is present but the azure-arc namespace/configmap is " \
-                "missing. Please run 'helm delete azure-arc --namespace {} --no-hooks' to cleanup the release " \
+            not_found_msg = (
+                "The helm release 'azure-arc' is present but the azure-arc namespace/configmap is "
+                "missing. Please run 'helm delete azure-arc --namespace {} --no-hooks' to cleanup the release "
                 "before onboarding the cluster again.".format(release_namespace)
+            )
             utils.kubernetes_exception_handler(
                 e,
                 consts.Read_ConfigMap_Fault_Type,
-                'Unable to read ConfigMap',
+                "Unable to read ConfigMap",
                 error_message="Unable to read ConfigMap 'azure-clusterconfig' in 'azure-arc' namespace: ",
-                message_for_not_found=not_found_msg)
+                message_for_not_found=not_found_msg,
+            )
         configmap_rg_name = configmap.data["AZURE_RESOURCE_GROUP"]
         configmap_cluster_name = configmap.data["AZURE_RESOURCE_NAME"]
         if connected_cluster_exists(client, configmap_rg_name, configmap_cluster_name):
-            if not (configmap_rg_name.lower() == resource_group_name.lower() and
-                    configmap_cluster_name.lower() == cluster_name.lower()):
-                err_msg = "The provided cluster name and resource group name do not correspond to the kubernetes " \
+            if not (
+                configmap_rg_name.lower() == resource_group_name.lower()
+                and configmap_cluster_name.lower() == cluster_name.lower()
+            ):
+                err_msg = (
+                    "The provided cluster name and resource group name do not correspond to the kubernetes "
                     "cluster being operated on."
+                )
                 reco_msg = "Please use the cluster, with correct resource group and cluster name."
                 telemetry.set_exception(
-                    exception='The provided cluster name and rg correspond to different cluster',
+                    exception="The provided cluster name and rg correspond to different cluster",
                     fault_type=consts.Operate_RG_Cluster_Name_Conflict,
-                    summary=err_msg)
+                    summary=err_msg,
+                )
                 raise ArgumentUsageError(err_msg, recommendation=reco_msg)
         else:
             telemetry.set_exception(
-                exception='The corresponding CC resource does not exist',
+                exception="The corresponding CC resource does not exist",
                 fault_type=consts.Corresponding_CC_Resource_Deleted_Fault,
-                summary='CC resource corresponding to this cluster has been deleted by the customer')
+                summary="CC resource corresponding to this cluster has been deleted by the customer",
+            )
             err_msg = "There exist no ConnectedCluster resource corresponding to this kubernetes Cluster."
-            reco_msg = "Please cleanup the helm release first using 'az connectedk8s delete -n " \
-                "<connected-cluster-name> -g <resource-group-name>' and re-onboard the cluster using " \
+            reco_msg = (
+                "Please cleanup the helm release first using 'az connectedk8s delete -n "
+                "<connected-cluster-name> -g <resource-group-name>' and re-onboard the cluster using "
                 "'az connectedk8s connect -n <connected-cluster-name> -g <resource-group-name>'"
+            )
             raise ClientRequestError(err_msg, recommendation=reco_msg)
     else:
-        err_msg = "The azure-arc release namespace couldn't be retrieved, which implies that the kubernetes " \
+        err_msg = (
+            "The azure-arc release namespace couldn't be retrieved, which implies that the kubernetes "
             "cluster has not been onboarded to azure-arc."
+        )
         telemetry.set_exception(
             exception="The azure-arc release namespace couldn't be retrieved",
             fault_type=consts.Release_Namespace_Not_Found,
-            summary=err_msg)
-        reco_msg = "Please run 'az connectedk8s connect -n <connected-cluster-name> -g " \
+            summary=err_msg,
+        )
+        reco_msg = (
+            "Please run 'az connectedk8s connect -n <connected-cluster-name> -g "
             "<resource-group-name>' to onboard the cluster"
+        )
         raise ClientRequestError(err_msg, recommendation=reco_msg)
     return release_namespace
 
 
-def get_all_helm_values(release_namespace, kube_config, kube_context, helm_client_location):
-    cmd_helm_values = [helm_client_location, "get", "values", "--all", "azure-arc", "--namespace", release_namespace]
+def get_all_helm_values(
+    release_namespace, kube_config, kube_context, helm_client_location
+):
+    cmd_helm_values = [
+        helm_client_location,
+        "get",
+        "values",
+        "--all",
+        "azure-arc",
+        "--namespace",
+        release_namespace,
+    ]
     if kube_config:
         cmd_helm_values.extend(["--kubeconfig", kube_config])
     if kube_context:
@@ -1885,14 +2808,17 @@ def get_all_helm_values(release_namespace, kube_config, kube_context, helm_clien
     response_helm_values_get = Popen(cmd_helm_values, stdout=PIPE, stderr=PIPE)
     output_helm_values, error_helm_get_values = response_helm_values_get.communicate()
     if response_helm_values_get.returncode != 0:
-        if 'forbidden' in error_helm_get_values.decode("ascii"):
+        if "forbidden" in error_helm_get_values.decode("ascii"):
             telemetry.set_user_fault()
         telemetry.set_exception(
             exception=error_helm_get_values.decode("ascii"),
             fault_type=consts.Get_Helm_Values_Failed,
-            summary='Error while doing helm get values azure-arc')
-        raise CLIInternalError("Error while getting the helm values in the azure-arc namespace: " +
-                               error_helm_get_values.decode("ascii"))
+            summary="Error while doing helm get values azure-arc",
+        )
+        raise CLIInternalError(
+            "Error while getting the helm values in the azure-arc namespace: "
+            + error_helm_get_values.decode("ascii")
+        )
 
     output_helm_values = output_helm_values.decode("ascii")
 
@@ -1900,37 +2826,69 @@ def get_all_helm_values(release_namespace, kube_config, kube_context, helm_clien
         existing_values = yaml.safe_load(output_helm_values)
         return existing_values
     except Exception as e:
-        telemetry.set_exception(exception=e, fault_type=consts.Helm_Existing_User_Supplied_Value_Get_Fault,
-                                summary='Problem loading the helm existing values')
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Helm_Existing_User_Supplied_Value_Get_Fault,
+            summary="Problem loading the helm existing values",
+        )
         raise CLIInternalError("Problem loading the helm existing values: " + str(e))
 
 
-def enable_features(cmd, client, resource_group_name, cluster_name, features, kube_config=None, kube_context=None,
-                    azrbac_client_id=None, azrbac_client_secret=None, azrbac_skip_authz_check=None,
-                    skip_ssl_verification=False, cl_oid=None):
+def enable_features(
+    cmd,
+    client,
+    resource_group_name,
+    cluster_name,
+    features,
+    kube_config=None,
+    kube_context=None,
+    azrbac_client_id=None,
+    azrbac_client_secret=None,
+    azrbac_skip_authz_check=None,
+    skip_ssl_verification=False,
+    cl_oid=None,
+):
     logger.warning("This operation might take a while...\n")
 
     # Validate custom token operation
-    custom_token_passed, _ = utils.validate_custom_token(cmd, resource_group_name, "dummyLocation")
+    custom_token_passed, _ = utils.validate_custom_token(
+        cmd, resource_group_name, "dummyLocation"
+    )
 
     features = [x.lower() for x in features]
-    enable_cluster_connect, enable_azure_rbac, enable_cl = utils.check_features_to_update(features)
+    enable_cluster_connect, enable_azure_rbac, enable_cl = (
+        utils.check_features_to_update(features)
+    )
 
     # Check if cluster is private link enabled
-    connected_cluster = get_connectedk8s_2023_11_01(cmd, resource_group_name, cluster_name)
+    connected_cluster = get_connectedk8s_2023_11_01(
+        cmd, resource_group_name, cluster_name
+    )
 
-    if (connected_cluster is not None) and (connected_cluster.kind is not None) and \
-            (connected_cluster.kind.lower() == consts.Provisioned_Cluster_Kind):
-        err_msg = "Enable feature of a Provisioned Cluster is not supported from the Connected Cluster CLI. For " \
-            "information on how to enable a feature on a Provisioned Cluster using a cluster extension, " \
+    if (
+        (connected_cluster is not None)
+        and (connected_cluster.kind is not None)
+        and (connected_cluster.kind.lower() == consts.Provisioned_Cluster_Kind)
+    ):
+        err_msg = (
+            "Enable feature of a Provisioned Cluster is not supported from the Connected Cluster CLI. For "
+            "information on how to enable a feature on a Provisioned Cluster using a cluster extension, "
             "please refer to: https://learn.microsoft.com/en-us/azure/aks/deploy-extensions-az-cli"
+        )
         raise InvalidArgumentValueError(err_msg)
 
-    if connected_cluster.private_link_state.lower() == "enabled" and (enable_cluster_connect or enable_cl):
-        telemetry.set_exception(exception='Invalid arguments provided', fault_type=consts.Invalid_Argument_Fault_Type,
-                                summary='Invalid arguments provided')
-        err_msg = "The features 'cluster-connect' and 'custom-locations' cannot be enabled for a private link " \
+    if connected_cluster.private_link_state.lower() == "enabled" and (
+        enable_cluster_connect or enable_cl
+    ):
+        telemetry.set_exception(
+            exception="Invalid arguments provided",
+            fault_type=consts.Invalid_Argument_Fault_Type,
+            summary="Invalid arguments provided",
+        )
+        err_msg = (
+            "The features 'cluster-connect' and 'custom-locations' cannot be enabled for a private link "
             "enabled connected cluster."
+        )
         raise InvalidArgumentValueError(err_msg)
 
     if enable_azure_rbac:
@@ -1939,12 +2897,19 @@ def enable_features(cmd, client, resource_group_name, cluster_name, features, ku
         azrbac_skip_authz_check = escape_proxy_settings(azrbac_skip_authz_check)
 
     if enable_cl:
-        subscription_id = os.getenv(
-            'AZURE_SUBSCRIPTION_ID') if custom_token_passed is True else get_subscription_id(cmd.cli_ctx)
-        enable_cl, custom_locations_oid = check_cl_registration_and_get_oid(cmd, cl_oid, subscription_id)
+        subscription_id = (
+            os.getenv("AZURE_SUBSCRIPTION_ID")
+            if custom_token_passed is True
+            else get_subscription_id(cmd.cli_ctx)
+        )
+        enable_cl, custom_locations_oid = check_cl_registration_and_get_oid(
+            cmd, cl_oid, subscription_id
+        )
         if not enable_cluster_connect and enable_cl:
             enable_cluster_connect = True
-            logger.warning("Enabling 'custom-locations' feature will enable 'cluster-connect' feature too.")
+            logger.warning(
+                "Enabling 'custom-locations' feature will enable 'cluster-connect' feature too."
+            )
         if not enable_cl:
             features.remove("custom-locations")
             if len(features) == 0:
@@ -1973,34 +2938,55 @@ def enable_features(cmd, client, resource_group_name, cluster_name, features, ku
     helm_client_location = install_helm_client()
 
     release_namespace = validate_release_namespace(
-        client, cluster_name, resource_group_name, kube_config, kube_context, helm_client_location)
+        client,
+        cluster_name,
+        resource_group_name,
+        kube_config,
+        kube_context,
+        helm_client_location,
+    )
 
     # Fetch Connected Cluster for agent version
     connected_cluster = get_connectedk8s(cmd, client, resource_group_name, cluster_name)
 
-    kubernetes_properties = {'Context.Default.AzureCLI.KubernetesVersion': kubernetes_version}
+    kubernetes_properties = {
+        "Context.Default.AzureCLI.KubernetesVersion": kubernetes_version
+    }
 
-    if hasattr(connected_cluster, 'distribution') and (connected_cluster.distribution is not None):
+    if hasattr(connected_cluster, "distribution") and (
+        connected_cluster.distribution is not None
+    ):
         kubernetes_distro = connected_cluster.distribution
-        kubernetes_properties['Context.Default.AzureCLI.KubernetesDistro'] = kubernetes_distro
+        kubernetes_properties["Context.Default.AzureCLI.KubernetesDistro"] = (
+            kubernetes_distro
+        )
 
-    if hasattr(connected_cluster, 'infrastructure') and (connected_cluster.infrastructure is not None):
+    if hasattr(connected_cluster, "infrastructure") and (
+        connected_cluster.infrastructure is not None
+    ):
         kubernetes_infra = connected_cluster.infrastructure
-        kubernetes_properties['Context.Default.AzureCLI.KubernetesInfra'] = kubernetes_infra
+        kubernetes_properties["Context.Default.AzureCLI.KubernetesInfra"] = (
+            kubernetes_infra
+        )
 
-    telemetry.add_extension_event('connectedk8s', kubernetes_properties)
+    telemetry.add_extension_event("connectedk8s", kubernetes_properties)
 
     # Adding helm repo
-    if os.getenv('HELMREPONAME') and os.getenv('HELMREPOURL'):
+    if os.getenv("HELMREPONAME") and os.getenv("HELMREPOURL"):
         utils.add_helm_repo(kube_config, kube_context, helm_client_location)
 
-    config_dp_endpoint, release_train = get_config_dp_endpoint(cmd, connected_cluster.location, values_file)
+    config_dp_endpoint, release_train = get_config_dp_endpoint(
+        cmd, connected_cluster.location, values_file
+    )
 
     # Retrieving Helm chart OCI Artifact location
-    registry_path = os.getenv('HELMREGISTRY') if os.getenv(
-        'HELMREGISTRY') else utils.get_helm_registry(cmd, config_dp_endpoint, release_train)
+    registry_path = (
+        os.getenv("HELMREGISTRY")
+        if os.getenv("HELMREGISTRY")
+        else utils.get_helm_registry(cmd, config_dp_endpoint, release_train)
+    )
 
-    reg_path_array = registry_path.split(':')
+    reg_path_array = registry_path.split(":")
     agent_version = reg_path_array[1]
 
     # Set agent version in registry path
@@ -2010,14 +2996,27 @@ def enable_features(cmd, client, resource_group_name, cluster_name, features, ku
 
     check_operation_support("enable-features", agent_version)
 
-    telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
+    telemetry.add_extension_event(
+        "connectedk8s", {"Context.Default.AzureCLI.AgentVersion": agent_version}
+    )
 
     # Get Helm chart path
-    chart_path = utils.get_chart_path(registry_path, kube_config, kube_context, helm_client_location)
+    chart_path = utils.get_chart_path(
+        registry_path, kube_config, kube_context, helm_client_location
+    )
 
-    cmd_helm_upgrade = [helm_client_location, "upgrade", "azure-arc", chart_path, "--namespace", release_namespace,
-                        "--reuse-values",
-                        "--wait", "--output", "json"]
+    cmd_helm_upgrade = [
+        helm_client_location,
+        "upgrade",
+        "azure-arc",
+        chart_path,
+        "--namespace",
+        release_namespace,
+        "--reuse-values",
+        "--wait",
+        "--output",
+        "json",
+    ]
     if values_file:
         cmd_helm_upgrade.extend(["-f", values_file])
     if kube_config:
@@ -2031,52 +3030,99 @@ def enable_features(cmd, client, resource_group_name, cluster_name, features, ku
         cmd_helm_upgrade.extend(["--set", "systemDefaultValues.guard.authnMode=arc"])
         logger.warning(
             "Please use the kubelogin version v0.0.32 or higher which has support for generating PoP token(s). "
-            "This is needed by guard running in 'arc' authN mode.")
+            "This is needed by guard running in 'arc' authN mode."
+        )
         cmd_helm_upgrade.extend(
-            ["--set", "systemDefaultValues.guard.skipAuthzCheck={}".format(azrbac_skip_authz_check)])
+            [
+                "--set",
+                "systemDefaultValues.guard.skipAuthzCheck={}".format(
+                    azrbac_skip_authz_check
+                ),
+            ]
+        )
     if enable_cluster_connect:
-        cmd_helm_upgrade.extend(["--set", "systemDefaultValues.clusterconnect-agent.enabled=true"])
+        cmd_helm_upgrade.extend(
+            ["--set", "systemDefaultValues.clusterconnect-agent.enabled=true"]
+        )
     if enable_cl:
-        cmd_helm_upgrade.extend(["--set", "systemDefaultValues.customLocations.enabled=true"])
-        cmd_helm_upgrade.extend(["--set", "systemDefaultValues.customLocations.oid={}".format(custom_locations_oid)])
+        cmd_helm_upgrade.extend(
+            ["--set", "systemDefaultValues.customLocations.enabled=true"]
+        )
+        cmd_helm_upgrade.extend(
+            [
+                "--set",
+                "systemDefaultValues.customLocations.oid={}".format(
+                    custom_locations_oid
+                ),
+            ]
+        )
 
     response_helm_upgrade = Popen(cmd_helm_upgrade, stdout=PIPE, stderr=PIPE)
     _, error_helm_upgrade = response_helm_upgrade.communicate()
     if response_helm_upgrade.returncode != 0:
         helm_upgrade_error_message = error_helm_upgrade.decode("ascii")
-        if any(message in helm_upgrade_error_message for message in consts.Helm_Install_Release_Userfault_Messages):
+        if any(
+            message in helm_upgrade_error_message
+            for message in consts.Helm_Install_Release_Userfault_Messages
+        ):
             telemetry.set_user_fault()
         telemetry.set_exception(
             exception=error_helm_upgrade.decode("ascii"),
             fault_type=consts.Install_HelmRelease_Fault_Type,
-            summary='Unable to install helm release')
-        raise CLIInternalError(str.format(consts.Error_enabling_Features, error_helm_upgrade.decode("ascii")))
+            summary="Unable to install helm release",
+        )
+        raise CLIInternalError(
+            str.format(
+                consts.Error_enabling_Features, error_helm_upgrade.decode("ascii")
+            )
+        )
 
-    return str.format(consts.Successfully_Enabled_Features, features, connected_cluster.name)
+    return str.format(
+        consts.Successfully_Enabled_Features, features, connected_cluster.name
+    )
 
 
-def disable_features(cmd, client, resource_group_name, cluster_name, features, kube_config=None, kube_context=None,
-                     yes=False, skip_ssl_verification=False):
-
+def disable_features(
+    cmd,
+    client,
+    resource_group_name,
+    cluster_name,
+    features,
+    kube_config=None,
+    kube_context=None,
+    yes=False,
+    skip_ssl_verification=False,
+):
     features = [x.lower() for x in features]
-    confirmation_message = "Disabling few of the features may adversely impact dependent resources. Learn more " \
-        "about this at https://aka.ms/ArcK8sDependentResources. \n" + \
-        "Are you sure you want to disable these features: {}".format(features)
+    confirmation_message = (
+        "Disabling few of the features may adversely impact dependent resources. Learn more "
+        "about this at https://aka.ms/ArcK8sDependentResources. \n"
+        + "Are you sure you want to disable these features: {}".format(features)
+    )
     utils.user_confirmation(confirmation_message, yes)
 
     # Fetch Connected Cluster for agent version
-    connected_cluster = get_connectedk8s_2023_11_01(cmd, resource_group_name, cluster_name)
+    connected_cluster = get_connectedk8s_2023_11_01(
+        cmd, resource_group_name, cluster_name
+    )
 
-    if (connected_cluster is not None) and (connected_cluster.kind is not None) and \
-            (connected_cluster.kind.lower() == consts.Provisioned_Cluster_Kind):
-        err_msg = "Disable feature of a Provisioned Cluster is not supported from the Connected Cluster CLI. For " \
-            "information on how to disable a feature on a Provisioned Cluster using a cluster extension, please " \
+    if (
+        (connected_cluster is not None)
+        and (connected_cluster.kind is not None)
+        and (connected_cluster.kind.lower() == consts.Provisioned_Cluster_Kind)
+    ):
+        err_msg = (
+            "Disable feature of a Provisioned Cluster is not supported from the Connected Cluster CLI. For "
+            "information on how to disable a feature on a Provisioned Cluster using a cluster extension, please "
             "refer to: https://learn.microsoft.com/en-us/azure/aks/deploy-extensions-az-cli"
+        )
         raise InvalidArgumentValueError(err_msg)
 
     logger.warning("This operation might take a while...\n")
 
-    disable_clstr_connect, disable_azure_rbac, disable_cl = utils.check_features_to_update(features)
+    disable_clstr_connect, disable_azure_rbac, disable_cl = (
+        utils.check_features_to_update(features)
+    )
 
     # Send cloud information to telemetry
     send_cloud_telemetry(cmd)
@@ -2101,28 +3147,53 @@ def disable_features(cmd, client, resource_group_name, cluster_name, features, k
     helm_client_location = install_helm_client()
 
     release_namespace = validate_release_namespace(
-        client, cluster_name, resource_group_name, kube_config, kube_context, helm_client_location)
+        client,
+        cluster_name,
+        resource_group_name,
+        kube_config,
+        kube_context,
+        helm_client_location,
+    )
 
-    kubernetes_properties = {'Context.Default.AzureCLI.KubernetesVersion': kubernetes_version}
+    kubernetes_properties = {
+        "Context.Default.AzureCLI.KubernetesVersion": kubernetes_version
+    }
 
-    if hasattr(connected_cluster, 'distribution') and (connected_cluster.distribution is not None):
+    if hasattr(connected_cluster, "distribution") and (
+        connected_cluster.distribution is not None
+    ):
         kubernetes_distro = connected_cluster.distribution
-        kubernetes_properties['Context.Default.AzureCLI.KubernetesDistro'] = kubernetes_distro
+        kubernetes_properties["Context.Default.AzureCLI.KubernetesDistro"] = (
+            kubernetes_distro
+        )
 
-    if hasattr(connected_cluster, 'infrastructure') and (connected_cluster.infrastructure is not None):
+    if hasattr(connected_cluster, "infrastructure") and (
+        connected_cluster.infrastructure is not None
+    ):
         kubernetes_infra = connected_cluster.infrastructure
-        kubernetes_properties['Context.Default.AzureCLI.KubernetesInfra'] = kubernetes_infra
+        kubernetes_properties["Context.Default.AzureCLI.KubernetesInfra"] = (
+            kubernetes_infra
+        )
 
-    telemetry.add_extension_event('connectedk8s', kubernetes_properties)
+    telemetry.add_extension_event("connectedk8s", kubernetes_properties)
 
     if disable_clstr_connect:
         try:
-            helm_values = get_all_helm_values(release_namespace, kube_config, kube_context, helm_client_location)
-            cl_enabled = helm_values.get('systemDefaultValues').get('customLocations').get('enabled')
-            cl_oid = helm_values.get('systemDefaultValues').get('customLocations').get('oid')
-            if (not disable_cl and cl_enabled is True and cl_oid != ""):
+            helm_values = get_all_helm_values(
+                release_namespace, kube_config, kube_context, helm_client_location
+            )
+            cl_enabled = (
+                helm_values.get("systemDefaultValues")
+                .get("customLocations")
+                .get("enabled")
+            )
+            cl_oid = (
+                helm_values.get("systemDefaultValues").get("customLocations").get("oid")
+            )
+            if not disable_cl and cl_enabled is True and cl_oid != "":
                 raise Exception(
-                    "Disabling 'cluster-connect' feature is not allowed when 'custom-locations' feature is enabled")
+                    "Disabling 'cluster-connect' feature is not allowed when 'custom-locations' feature is enabled"
+                )
         except AttributeError:
             pass
         except Exception as ex:
@@ -2131,30 +3202,55 @@ def disable_features(cmd, client, resource_group_name, cluster_name, features, k
     if disable_cl:
         logger.warning(
             "Disabling 'custom-locations' feature might impact some dependent resources. Learn more about this at "
-            "https://aka.ms/ArcK8sDependentResources.")
+            "https://aka.ms/ArcK8sDependentResources."
+        )
 
     # Adding helm repo
-    if os.getenv('HELMREPONAME') and os.getenv('HELMREPOURL'):
+    if os.getenv("HELMREPONAME") and os.getenv("HELMREPOURL"):
         utils.add_helm_repo(kube_config, kube_context, helm_client_location)
 
-    get_chart_and_disable_features(cmd, connected_cluster, kube_config, kube_context,
-                                   helm_client_location, release_namespace, values_file, disable_azure_rbac,
-                                   disable_clstr_connect, disable_cl)
+    get_chart_and_disable_features(
+        cmd,
+        connected_cluster,
+        kube_config,
+        kube_context,
+        helm_client_location,
+        release_namespace,
+        values_file,
+        disable_azure_rbac,
+        disable_clstr_connect,
+        disable_cl,
+    )
 
-    return str.format(consts.Successfully_Disabled_Features, features, connected_cluster.name)
+    return str.format(
+        consts.Successfully_Disabled_Features, features, connected_cluster.name
+    )
 
 
-def get_chart_and_disable_features(cmd, connected_cluster, kube_config, kube_context,
-                                   helm_client_location, release_namespace, values_file, disable_azure_rbac=False,
-                                   disable_clstr_connect=False, disable_cl=False):
-
-    config_dp_endpoint, release_train = get_config_dp_endpoint(cmd, connected_cluster.location, values_file)
+def get_chart_and_disable_features(
+    cmd,
+    connected_cluster,
+    kube_config,
+    kube_context,
+    helm_client_location,
+    release_namespace,
+    values_file,
+    disable_azure_rbac=False,
+    disable_clstr_connect=False,
+    disable_cl=False,
+):
+    config_dp_endpoint, release_train = get_config_dp_endpoint(
+        cmd, connected_cluster.location, values_file
+    )
 
     # Retrieving Helm chart OCI Artifact location
-    registry_path = os.getenv('HELMREGISTRY') if os.getenv(
-        'HELMREGISTRY') else utils.get_helm_registry(cmd, config_dp_endpoint, release_train)
+    registry_path = (
+        os.getenv("HELMREGISTRY")
+        if os.getenv("HELMREGISTRY")
+        else utils.get_helm_registry(cmd, config_dp_endpoint, release_train)
+    )
 
-    reg_path_array = registry_path.split(':')
+    reg_path_array = registry_path.split(":")
     agent_version = reg_path_array[1]
 
     # Set agent version in registry path
@@ -2164,14 +3260,27 @@ def get_chart_and_disable_features(cmd, connected_cluster, kube_config, kube_con
 
     check_operation_support("disable-features", agent_version)
 
-    telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
+    telemetry.add_extension_event(
+        "connectedk8s", {"Context.Default.AzureCLI.AgentVersion": agent_version}
+    )
 
     # Get Helm chart path
-    chart_path = utils.get_chart_path(registry_path, kube_config, kube_context, helm_client_location)
+    chart_path = utils.get_chart_path(
+        registry_path, kube_config, kube_context, helm_client_location
+    )
 
-    cmd_helm_upgrade = [helm_client_location, "upgrade", "azure-arc", chart_path, "--namespace", release_namespace,
-                        "--reuse-values",
-                        "--wait", "--output", "json"]
+    cmd_helm_upgrade = [
+        helm_client_location,
+        "upgrade",
+        "azure-arc",
+        chart_path,
+        "--namespace",
+        release_namespace,
+        "--reuse-values",
+        "--wait",
+        "--output",
+        "json",
+    ]
     if values_file:
         cmd_helm_upgrade.extend(["-f", values_file])
     if kube_config:
@@ -2181,32 +3290,64 @@ def get_chart_and_disable_features(cmd, connected_cluster, kube_config, kube_con
     if disable_azure_rbac:
         cmd_helm_upgrade.extend(["--set", "systemDefaultValues.guard.enabled=false"])
     if disable_clstr_connect:
-        cmd_helm_upgrade.extend(["--set", "systemDefaultValues.clusterconnect-agent.enabled=false"])
+        cmd_helm_upgrade.extend(
+            ["--set", "systemDefaultValues.clusterconnect-agent.enabled=false"]
+        )
     if disable_cl:
-        cmd_helm_upgrade.extend(["--set", "systemDefaultValues.customLocations.enabled=false"])
-        cmd_helm_upgrade.extend(["--set", "systemDefaultValues.customLocations.oid={}".format("")])
+        cmd_helm_upgrade.extend(
+            ["--set", "systemDefaultValues.customLocations.enabled=false"]
+        )
+        cmd_helm_upgrade.extend(
+            ["--set", "systemDefaultValues.customLocations.oid={}".format("")]
+        )
 
     response_helm_upgrade = Popen(cmd_helm_upgrade, stdout=PIPE, stderr=PIPE)
     _, error_helm_upgrade = response_helm_upgrade.communicate()
     if response_helm_upgrade.returncode != 0:
         helm_upgrade_error_message = error_helm_upgrade.decode("ascii")
-        if any(message in helm_upgrade_error_message for message in consts.Helm_Install_Release_Userfault_Messages):
+        if any(
+            message in helm_upgrade_error_message
+            for message in consts.Helm_Install_Release_Userfault_Messages
+        ):
             telemetry.set_user_fault()
         telemetry.set_exception(
             exception=error_helm_upgrade.decode("ascii"),
             fault_type=consts.Install_HelmRelease_Fault_Type,
-            summary='Unable to install helm release')
-        raise CLIInternalError(str.format(consts.Error_disabling_Features, error_helm_upgrade.decode("ascii")))
+            summary="Unable to install helm release",
+        )
+        raise CLIInternalError(
+            str.format(
+                consts.Error_disabling_Features, error_helm_upgrade.decode("ascii")
+            )
+        )
 
 
-def disable_cluster_connect(cmd, client, resource_group_name, cluster_name, kube_config, kube_context, values_file,
-                            release_namespace, helm_client_location):
+def disable_cluster_connect(
+    cmd,
+    client,
+    resource_group_name,
+    cluster_name,
+    kube_config,
+    kube_context,
+    values_file,
+    release_namespace,
+    helm_client_location,
+):
     # Fetch Connected Cluster for agent version
     connected_cluster = get_connectedk8s(cmd, client, resource_group_name, cluster_name)
 
-    get_chart_and_disable_features(cmd, connected_cluster, kube_config, kube_context,
-                                   helm_client_location, release_namespace, values_file, False,
-                                   True, True)
+    get_chart_and_disable_features(
+        cmd,
+        connected_cluster,
+        kube_config,
+        kube_context,
+        helm_client_location,
+        release_namespace,
+        values_file,
+        False,
+        True,
+        True,
+    )
 
 
 def load_kubernetes_configuration(filename):
@@ -2214,14 +3355,20 @@ def load_kubernetes_configuration(filename):
         with open(filename) as stream:
             return yaml.safe_load(stream)
     except (IOError, OSError) as ex:
-        if getattr(ex, 'errno', 0) == errno.ENOENT:
-            telemetry.set_exception(exception=ex, fault_type=consts.Kubeconfig_Failed_To_Load_Fault_Type,
-                                    summary='{} does not exist'.format(filename))
-            raise FileOperationError('{} does not exist'.format(filename))
+        if getattr(ex, "errno", 0) == errno.ENOENT:
+            telemetry.set_exception(
+                exception=ex,
+                fault_type=consts.Kubeconfig_Failed_To_Load_Fault_Type,
+                summary="{} does not exist".format(filename),
+            )
+            raise FileOperationError("{} does not exist".format(filename))
     except (yaml.parser.ParserError, UnicodeDecodeError) as ex:
-        telemetry.set_exception(exception=ex, fault_type=consts.Kubeconfig_Failed_To_Load_Fault_Type,
-                                summary='Error parsing {} ({})'.format(filename, str(ex)))
-        raise FileOperationError('Error parsing {} ({})'.format(filename, str(ex)))
+        telemetry.set_exception(
+            exception=ex,
+            fault_type=consts.Kubeconfig_Failed_To_Load_Fault_Type,
+            summary="Error parsing {} ({})".format(filename, str(ex)),
+        )
+        raise FileOperationError("Error parsing {} ({})".format(filename, str(ex)))
 
 
 def print_or_merge_credentials(path, kubeconfig, overwrite_existing, context_name):
@@ -2240,83 +3387,112 @@ def print_or_merge_credentials(path, kubeconfig, overwrite_existing, context_nam
             os.makedirs(directory)
         except OSError as ex:
             if ex.errno != errno.EEXIST:
-                telemetry.set_exception(exception=ex, fault_type=consts.Failed_To_Merge_Credentials_Fault_Type,
-                                        summary='Could not create a kubeconfig directory.')
-                raise FileOperationError("Could not create a kubeconfig directory." + str(ex))
+                telemetry.set_exception(
+                    exception=ex,
+                    fault_type=consts.Failed_To_Merge_Credentials_Fault_Type,
+                    summary="Could not create a kubeconfig directory.",
+                )
+                raise FileOperationError(
+                    "Could not create a kubeconfig directory." + str(ex)
+                )
     if not os.path.exists(path):
-        with os.fdopen(os.open(path, os.O_CREAT | os.O_WRONLY, 0o600), 'wt'):
+        with os.fdopen(os.open(path, os.O_CREAT | os.O_WRONLY, 0o600), "wt"):
             pass
 
     # merge the new kubeconfig into the existing one
     fd, temp_path = tempfile.mkstemp()
-    additional_file = os.fdopen(fd, 'w+t')
+    additional_file = os.fdopen(fd, "w+t")
     try:
         additional_file.write(kubeconfig)
         additional_file.flush()
-        merge_kubernetes_configurations(path, temp_path, overwrite_existing, context_name)
+        merge_kubernetes_configurations(
+            path, temp_path, overwrite_existing, context_name
+        )
     except yaml.YAMLError as ex:
-        logger.warning('Failed to merge credentials to kube config file: %s', ex)
+        logger.warning("Failed to merge credentials to kube config file: %s", ex)
     finally:
         additional_file.close()
         os.remove(temp_path)
 
 
-def merge_kubernetes_configurations(existing_file, addition_file, replace, context_name=None):
+def merge_kubernetes_configurations(
+    existing_file, addition_file, replace, context_name=None
+):
     try:
         existing = load_kubernetes_configuration(existing_file)
         addition = load_kubernetes_configuration(addition_file)
     except Exception as ex:
-        telemetry.set_exception(exception=ex, fault_type=consts.Failed_To_Load_K8s_Configuration_Fault_Type,
-                                summary='Exception while loading kubernetes configuration')
-        raise CLIInternalError('Exception while loading kubernetes configuration.' + str(ex))
+        telemetry.set_exception(
+            exception=ex,
+            fault_type=consts.Failed_To_Load_K8s_Configuration_Fault_Type,
+            summary="Exception while loading kubernetes configuration",
+        )
+        raise CLIInternalError(
+            "Exception while loading kubernetes configuration." + str(ex)
+        )
 
     if context_name is not None:
-        addition['contexts'][0]['name'] = context_name
-        addition['contexts'][0]['context']['cluster'] = context_name
-        addition['clusters'][0]['name'] = context_name
-        addition['current-context'] = context_name
+        addition["contexts"][0]["name"] = context_name
+        addition["contexts"][0]["context"]["cluster"] = context_name
+        addition["clusters"][0]["name"] = context_name
+        addition["current-context"] = context_name
 
     # rename the admin context so it doesn't overwrite the user context
-    for ctx in addition.get('contexts', []):
+    for ctx in addition.get("contexts", []):
         try:
-            if ctx['context']['user'].startswith('clusterAdmin'):
-                admin_name = ctx['name'] + '-admin'
-                addition['current-context'] = ctx['name'] = admin_name
+            if ctx["context"]["user"].startswith("clusterAdmin"):
+                admin_name = ctx["name"] + "-admin"
+                addition["current-context"] = ctx["name"] = admin_name
                 break
         except (KeyError, TypeError):
             continue
 
     if addition is None:
         telemetry.set_exception(
-            exception='Failed to load additional configuration',
+            exception="Failed to load additional configuration",
             fault_type=consts.Failed_To_Load_K8s_Configuration_Fault_Type,
-            summary='failed to load additional configuration from {}'.format(addition_file))
-        raise CLIInternalError('failed to load additional configuration from {}'.format(addition_file))
+            summary="failed to load additional configuration from {}".format(
+                addition_file
+            ),
+        )
+        raise CLIInternalError(
+            "failed to load additional configuration from {}".format(addition_file)
+        )
 
     if existing is None:
         existing = addition
     else:
-        handle_merge(existing, addition, 'clusters', replace)
-        handle_merge(existing, addition, 'users', replace)
-        handle_merge(existing, addition, 'contexts', replace)
-        existing['current-context'] = addition['current-context']
+        handle_merge(existing, addition, "clusters", replace)
+        handle_merge(existing, addition, "users", replace)
+        handle_merge(existing, addition, "contexts", replace)
+        existing["current-context"] = addition["current-context"]
 
     # check that ~/.kube/config is only read- and writable by its owner
-    if platform.system() != 'Windows':
-        existing_file_perms = "{:o}".format(stat.S_IMODE(os.lstat(existing_file).st_mode))
-        if not existing_file_perms.endswith('600'):
-            logger.warning('%s has permissions "%s".\nIt should be readable and writable only by its owner.',
-                           existing_file, existing_file_perms)
+    if platform.system() != "Windows":
+        existing_file_perms = "{:o}".format(
+            stat.S_IMODE(os.lstat(existing_file).st_mode)
+        )
+        if not existing_file_perms.endswith("600"):
+            logger.warning(
+                '%s has permissions "%s".\nIt should be readable and writable only by its owner.',
+                existing_file,
+                existing_file_perms,
+            )
 
-    with open(existing_file, 'w+') as stream:
+    with open(existing_file, "w+") as stream:
         try:
             yaml.safe_dump(existing, stream, default_flow_style=False)
         except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Failed_To_Merge_Kubeconfig_File,
-                                    summary='Exception while merging the kubeconfig file')
-            raise CLIInternalError('Exception while merging the kubeconfig file.' + str(e))
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Failed_To_Merge_Kubeconfig_File,
+                summary="Exception while merging the kubeconfig file",
+            )
+            raise CLIInternalError(
+                "Exception while merging the kubeconfig file." + str(e)
+            )
 
-    current_context = addition.get('current-context', 'UNKNOWN')
+    current_context = addition.get("current-context", "UNKNOWN")
     msg = 'Merged "{}" as current context in {}'.format(current_context, existing_file)
     print(msg)
 
@@ -2332,27 +3508,28 @@ def handle_merge(existing, addition, key, replace):
     temp_list = []
     for j in existing[key]:
         remove_flag = False
-        if not i.get('name', False) or not j.get('name', False):
+        if not i.get("name", False) or not j.get("name", False):
             continue
-        if i['name'] == j['name']:
+        if i["name"] == j["name"]:
             if replace or i == j:
                 remove_flag = True
             else:
-                msg = 'A different object named {} already exists in your kubeconfig file.\nOverwrite?'
+                msg = "A different object named {} already exists in your kubeconfig file.\nOverwrite?"
                 overwrite = False
                 try:
-                    overwrite = prompt_y_n(msg.format(i['name']))
+                    overwrite = prompt_y_n(msg.format(i["name"]))
                 except NoTTYException:
                     pass
                 if overwrite:
                     remove_flag = True
                 else:
-                    msg = 'A different object named {} already exists in {} in your kubeconfig file.'
+                    msg = "A different object named {} already exists in {} in your kubeconfig file."
                     telemetry.set_exception(
-                        exception='A different object with same name exists in the kubeconfig file',
+                        exception="A different object with same name exists in the kubeconfig file",
                         fault_type=consts.Different_Object_With_Same_Name_Fault_Type,
-                        summary=msg.format(i['name'], key))
-                    raise FileOperationError(msg.format(i['name'], key))
+                        summary=msg.format(i["name"], key),
+                    )
+                    raise FileOperationError(msg.format(i["name"], key))
         if not remove_flag:
             temp_list.append(j)
 
@@ -2360,53 +3537,68 @@ def handle_merge(existing, addition, key, replace):
     existing[key].append(i)
 
 
-def client_side_proxy_wrapper(cmd,
-                              client,
-                              resource_group_name,
-                              cluster_name,
-                              token=None,
-                              path=os.path.join(os.path.expanduser('~'), '.kube', 'config'),
-                              context_name=None,
-                              api_server_port=consts.API_SERVER_PORT):
-
+def client_side_proxy_wrapper(
+    cmd,
+    client,
+    resource_group_name,
+    cluster_name,
+    token=None,
+    path=os.path.join(os.path.expanduser("~"), ".kube", "config"),
+    context_name=None,
+    api_server_port=consts.API_SERVER_PORT,
+):
     cloud = send_cloud_telemetry(cmd)
     profile = Profile()
-    tenant_id = profile.get_subscription()['tenantId']
+    tenant_id = profile.get_subscription()["tenantId"]
 
     client_proxy_port = consts.CLIENT_PROXY_PORT
 
     # Check if the internal port is already open. If so and the user has specified a port,
     # try using the port before the user specified port instead.
-    if clientproxyutils.check_if_port_is_open(client_proxy_port) and api_server_port != consts.API_SERVER_PORT:
+    if (
+        clientproxyutils.check_if_port_is_open(client_proxy_port)
+        and api_server_port != consts.API_SERVER_PORT
+    ):
         client_proxy_port = int(api_server_port) - 1
 
     if int(client_proxy_port) == int(api_server_port):
-        raise ClientRequestError(f'Proxy uses port {client_proxy_port} internally.',
-                                 recommendation='Please pass some other unused port through --port option.')
+        raise ClientRequestError(
+            f"Proxy uses port {client_proxy_port} internally.",
+            recommendation="Please pass some other unused port through --port option.",
+        )
 
     args = []
     operating_system = platform.system()
-    proc_name = f'arcProxy{operating_system}'
+    proc_name = f"arcProxy{operating_system}"
 
-    telemetry.set_debug_info('CSP Version is ', consts.CLIENT_PROXY_VERSION)
-    telemetry.set_debug_info('OS is ', operating_system)
+    telemetry.set_debug_info("CSP Version is ", consts.CLIENT_PROXY_VERSION)
+    telemetry.set_debug_info("OS is ", operating_system)
 
-    if (clientproxyutils.check_process(proc_name)) and clientproxyutils.check_if_port_is_open(api_server_port):
-        err_msg = 'The proxy port is already in use, potentially by another proxy instance.'
-        reco_msg = 'Please stop the existing proxy instance or pass a different port through --port option.'
+    if (
+        clientproxyutils.check_process(proc_name)
+    ) and clientproxyutils.check_if_port_is_open(api_server_port):
+        err_msg = (
+            "The proxy port is already in use, potentially by another proxy instance."
+        )
+        reco_msg = "Please stop the existing proxy instance or pass a different port through --port option."
         raise ClientRequestError(err_msg, recommendation=reco_msg)
 
     port_error_string = ""
     if clientproxyutils.check_if_port_is_open(api_server_port):
-        port_error_string += f'Port {api_server_port} is already in use. Please select a different port with ' \
-            '--port option.\n'
+        port_error_string += (
+            f"Port {api_server_port} is already in use. Please select a different port with "
+            "--port option.\n"
+        )
     if clientproxyutils.check_if_port_is_open(client_proxy_port):
         telemetry.set_exception(
-            exception='Client proxy port was in use.',
+            exception="Client proxy port was in use.",
             fault_type=consts.Client_Proxy_Port_Fault_Type,
-            summary='Client proxy port was in use.')
-        port_error_string += f"Port {client_proxy_port} is already in use. This is an internal port that proxy " \
+            summary="Client proxy port was in use.",
+        )
+        port_error_string += (
+            f"Port {client_proxy_port} is already in use. This is an internal port that proxy "
             "uses. Please ensure that this port is open before running 'az connectedk8s proxy'.\n"
+        )
     if port_error_string != "":
         raise ClientRequestError(port_error_string)
 
@@ -2418,40 +3610,52 @@ def client_side_proxy_wrapper(cmd,
         CSP_Url = consts.CSP_Storage_Url_Fairfax
 
     # Creating installation location, request uri and older version exe location depending on OS
-    if (operating_system == 'Windows'):
-        install_location_string = f'.clientproxy\\arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}.exe'
-        requestUri = \
-            f'{CSP_Url}/{consts.RELEASE_DATE_WINDOWS}/arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}.exe'
-        older_version_string = f'.clientproxy\\arcProxy{operating_system}*.exe'
-        creds_string = r'.azure\accessTokens.json'
+    if operating_system == "Windows":
+        install_location_string = (
+            f".clientproxy\\arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}.exe"
+        )
+        requestUri = f"{CSP_Url}/{consts.RELEASE_DATE_WINDOWS}/arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}.exe"
+        older_version_string = f".clientproxy\\arcProxy{operating_system}*.exe"
+        creds_string = r".azure\accessTokens.json"
 
-    elif (operating_system == 'Linux' or operating_system == 'Darwin'):
-        install_location_string = f'.clientproxy/arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}'
-        requestUri = f'{CSP_Url}/{consts.RELEASE_DATE_LINUX}/arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}'
-        older_version_string = f'.clientproxy/arcProxy{operating_system}*'
-        creds_string = r'.azure/accessTokens.json'
+    elif operating_system == "Linux" or operating_system == "Darwin":
+        install_location_string = (
+            f".clientproxy/arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}"
+        )
+        requestUri = f"{CSP_Url}/{consts.RELEASE_DATE_LINUX}/arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}"
+        older_version_string = f".clientproxy/arcProxy{operating_system}*"
+        creds_string = r".azure/accessTokens.json"
 
     else:
-        telemetry.set_exception(exception='Unsupported OS', fault_type=consts.Unsupported_Fault_Type,
-                                summary=f'{operating_system} is not supported yet')
-        raise ClientRequestError(f'The {operating_system} platform is not currently supported.')
+        telemetry.set_exception(
+            exception="Unsupported OS",
+            fault_type=consts.Unsupported_Fault_Type,
+            summary=f"{operating_system} is not supported yet",
+        )
+        raise ClientRequestError(
+            f"The {operating_system} platform is not currently supported."
+        )
 
-    install_location = os.path.expanduser(os.path.join('~', install_location_string))
+    install_location = os.path.expanduser(os.path.join("~", install_location_string))
     args.append(install_location)
     install_dir = os.path.dirname(install_location)
 
     # If version specified by install location doesnt exist, then download the executable
     if not os.path.isfile(install_location):
-
         print("Setting up environment for first time use. This can take few minutes...")
         # Downloading the executable
         try:
             response = urllib.request.urlopen(requestUri)
         except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Download_Exe_Fault_Type,
-                                    summary='Unable to download clientproxy executable.')
-            raise CLIInternalError("Failed to download executable with client.",
-                                   recommendation="Please check your internet connection." + str(e))
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Download_Exe_Fault_Type,
+                summary="Unable to download clientproxy executable.",
+            )
+            raise CLIInternalError(
+                "Failed to download executable with client.",
+                recommendation="Please check your internet connection." + str(e),
+            )
 
         responseContent = response.read()
         response.close()
@@ -2461,11 +3665,18 @@ def client_side_proxy_wrapper(cmd,
             try:
                 os.makedirs(install_dir)
             except Exception as e:
-                telemetry.set_exception(exception=e, fault_type=consts.Create_Directory_Fault_Type,
-                                        summary='Unable to create installation directory')
-                raise ClientRequestError("Failed to create installation directory." + str(e))
+                telemetry.set_exception(
+                    exception=e,
+                    fault_type=consts.Create_Directory_Fault_Type,
+                    summary="Unable to create installation directory",
+                )
+                raise ClientRequestError(
+                    "Failed to create installation directory." + str(e)
+                )
         else:
-            older_version_string = os.path.expanduser(os.path.join('~', older_version_string))
+            older_version_string = os.path.expanduser(
+                os.path.join("~", older_version_string)
+            )
             older_version_files = glob(older_version_string)
 
             # Removing older executables from the directory
@@ -2476,71 +3687,96 @@ def client_side_proxy_wrapper(cmd,
                     logger.warning("failed to delete older version files")
 
         try:
-            with open(install_location, 'wb') as f:
+            with open(install_location, "wb") as f:
                 f.write(responseContent)
         except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Create_CSPExe_Fault_Type,
-                                    summary='Unable to create proxy executable')
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Create_CSPExe_Fault_Type,
+                summary="Unable to create proxy executable",
+            )
             raise ClientRequestError("Failed to create proxy executable." + str(e))
 
         os.chmod(install_location, os.stat(install_location).st_mode | stat.S_IXUSR)
 
     # Creating config file to pass config to clientproxy
-    config_file_location = os.path.join(install_dir, 'config.yml')
+    config_file_location = os.path.join(install_dir, "config.yml")
 
     if os.path.isfile(config_file_location):
         try:
             os.remove(config_file_location)
         except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Remove_Config_Fault_Type,
-                                    summary='Unable to remove old config file')
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Remove_Config_Fault_Type,
+                summary="Unable to remove old config file",
+            )
             raise FileOperationError("Failed to remove old config." + str(e))
 
     # initializations
-    user_type = 'sat'
-    creds = ''
+    user_type = "sat"
+    creds = ""
 
     # if service account token is not passed
     if token is None:
         # Identifying type of logged in entity
         subscription_id = get_subscription_id(cmd.cli_ctx)
         account = Profile().get_subscription(subscription_id)
-        user_type = account['user']['type']
+        user_type = account["user"]["type"]
 
-        if user_type == 'user':
-            dict_file = {'server': {'httpPort': int(client_proxy_port), 'httpsPort': int(api_server_port)},
-                         'identity': {'tenantID': tenant_id, 'clientID': consts.CLIENTPROXY_CLIENT_ID}}
+        if user_type == "user":
+            dict_file = {
+                "server": {
+                    "httpPort": int(client_proxy_port),
+                    "httpsPort": int(api_server_port),
+                },
+                "identity": {
+                    "tenantID": tenant_id,
+                    "clientID": consts.CLIENTPROXY_CLIENT_ID,
+                },
+            }
         else:
-            dict_file = {'server': {'httpPort': int(client_proxy_port), 'httpsPort': int(api_server_port)},
-                         'identity': {'tenantID': tenant_id, 'clientID': account['user']['name']}}
+            dict_file = {
+                "server": {
+                    "httpPort": int(client_proxy_port),
+                    "httpsPort": int(api_server_port),
+                },
+                "identity": {
+                    "tenantID": tenant_id,
+                    "clientID": account["user"]["name"],
+                },
+            }
 
-        if cloud == 'DOGFOOD':
-            dict_file['cloud'] = 'AzureDogFood'
+        if cloud == "DOGFOOD":
+            dict_file["cloud"] = "AzureDogFood"
 
         if cloud == consts.Azure_ChinaCloudName:
-            dict_file['cloud'] = 'AzureChinaCloud'
+            dict_file["cloud"] = "AzureChinaCloud"
         elif cloud == consts.Azure_USGovCloudName:
-            dict_file['cloud'] = 'AzureUSGovernmentCloud'
+            dict_file["cloud"] = "AzureUSGovernmentCloud"
 
         if not utils.is_cli_using_msal_auth():
             # Fetching creds
-            creds_location = os.path.expanduser(os.path.join('~', creds_string))
+            creds_location = os.path.expanduser(os.path.join("~", creds_string))
             try:
                 with open(creds_location) as f:
                     creds_list = json.load(f)
             except Exception as e:
-                telemetry.set_exception(exception=e, fault_type=consts.Load_Creds_Fault_Type,
-                                        summary='Unable to load accessToken.json')
+                telemetry.set_exception(
+                    exception=e,
+                    fault_type=consts.Load_Creds_Fault_Type,
+                    summary="Unable to load accessToken.json",
+                )
                 raise FileOperationError("Failed to load credentials." + str(e))
 
-            user_name = account['user']['name']
+            user_name = account["user"]["name"]
 
-            if user_type == 'user':
-                key = 'userId'
-                key2 = 'refreshToken'
+            if user_type == "user":
+                key = "userId"
+                key2 = "refreshToken"
             else:
-                key = 'servicePrincipalId'
-                key2 = 'accessToken'
+                key = "servicePrincipalId"
+                key2 = "accessToken"
 
             for i in range(len(creds_list)):
                 creds_obj = creds_list[i]
@@ -2549,137 +3785,204 @@ def client_side_proxy_wrapper(cmd,
                     creds = creds_obj[key2]
                     break
 
-            if creds == '':
-                telemetry.set_exception(exception='Credentials of user not found.',
-                                        fault_type=consts.Creds_NotFound_Fault_Type,
-                                        summary='Unable to find creds of user')
+            if creds == "":
+                telemetry.set_exception(
+                    exception="Credentials of user not found.",
+                    fault_type=consts.Creds_NotFound_Fault_Type,
+                    summary="Unable to find creds of user",
+                )
                 raise UnclassifiedUserFault("Credentials of user not found.")
 
-            if user_type != 'user':
-                dict_file['identity']['clientSecret'] = creds
+            if user_type != "user":
+                dict_file["identity"]["clientSecret"] = creds
     else:
-        dict_file = {'server': {'httpPort': int(client_proxy_port), 'httpsPort': int(api_server_port)}}
+        dict_file = {
+            "server": {
+                "httpPort": int(client_proxy_port),
+                "httpsPort": int(api_server_port),
+            }
+        }
         if cloud == consts.Azure_ChinaCloudName:
-            dict_file['cloud'] = 'AzureChinaCloud'
+            dict_file["cloud"] = "AzureChinaCloud"
         elif cloud == consts.Azure_USGovCloudName:
-            dict_file['cloud'] = 'AzureUSGovernmentCloud'
+            dict_file["cloud"] = "AzureUSGovernmentCloud"
 
-    telemetry.set_debug_info('User type is ', user_type)
+    telemetry.set_debug_info("User type is ", user_type)
 
     try:
-        with open(config_file_location, 'w') as f:
+        with open(config_file_location, "w") as f:
             yaml.dump(dict_file, f, default_flow_style=False)
     except Exception as e:
-        telemetry.set_exception(exception=e, fault_type=consts.Create_Config_Fault_Type,
-                                summary='Unable to create config file for proxy.')
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Create_Config_Fault_Type,
+            summary="Unable to create config file for proxy.",
+        )
         raise FileOperationError("Failed to create config for proxy." + str(e))
 
     args.append("-c")
     args.append(config_file_location)
 
     debug_mode = False
-    if '--debug' in cmd.cli_ctx.data['safe_params']:
+    if "--debug" in cmd.cli_ctx.data["safe_params"]:
         args.append("-d")
         debug_mode = True
 
-    client_side_proxy_main(cmd, tenant_id, client, resource_group_name, cluster_name, 0, args, client_proxy_port,
-                           api_server_port, operating_system, creds, user_type, debug_mode, token=token, path=path,
-                           context_name=context_name, clientproxy_process=None)
+    client_side_proxy_main(
+        cmd,
+        tenant_id,
+        client,
+        resource_group_name,
+        cluster_name,
+        0,
+        args,
+        client_proxy_port,
+        api_server_port,
+        operating_system,
+        creds,
+        user_type,
+        debug_mode,
+        token=token,
+        path=path,
+        context_name=context_name,
+        clientproxy_process=None,
+    )
 
 
 # Prepare data as needed by client proxy executable
 def prepare_clientproxy_data(response):
     data = {}
-    data['kubeconfigs'] = []
+    data["kubeconfigs"] = []
     kubeconfig = {}
-    kubeconfig['name'] = 'Kubeconfig'
-    kubeconfig['value'] = b64encode(response.kubeconfigs[0].value).decode("utf-8")
-    data['kubeconfigs'].append(kubeconfig)
-    data['hybridConnectionConfig'] = {}
-    data['hybridConnectionConfig']['relay'] = response.hybrid_connection_config.relay
-    data['hybridConnectionConfig']['hybridConnectionName'] = response.hybrid_connection_config.hybrid_connection_name
-    data['hybridConnectionConfig']['token'] = response.hybrid_connection_config.token
-    data['hybridConnectionConfig']['expirationTime'] = response.hybrid_connection_config.expiration_time
+    kubeconfig["name"] = "Kubeconfig"
+    kubeconfig["value"] = b64encode(response.kubeconfigs[0].value).decode("utf-8")
+    data["kubeconfigs"].append(kubeconfig)
+    data["hybridConnectionConfig"] = {}
+    data["hybridConnectionConfig"]["relay"] = response.hybrid_connection_config.relay
+    data["hybridConnectionConfig"]["hybridConnectionName"] = (
+        response.hybrid_connection_config.hybrid_connection_name
+    )
+    data["hybridConnectionConfig"]["token"] = response.hybrid_connection_config.token
+    data["hybridConnectionConfig"]["expirationTime"] = (
+        response.hybrid_connection_config.expiration_time
+    )
     return data
 
 
-def client_side_proxy_main(cmd,
-                           tenant_id,
-                           client,
-                           resource_group_name,
-                           cluster_name,
-                           flag,
-                           args,
-                           client_proxy_port,
-                           api_server_port,
-                           operating_system,
-                           creds,
-                           user_type,
-                           debug_mode,
-                           token=None,
-                           path=os.path.join(os.path.expanduser('~'), '.kube', 'config'),
-                           context_name=None,
-                           clientproxy_process=None):
-    expiry, clientproxy_process = client_side_proxy(cmd, tenant_id, client, resource_group_name, cluster_name, 0, args,
-                                                    client_proxy_port, api_server_port, operating_system, creds,
-                                                    user_type, debug_mode, token=token, path=path,
-                                                    context_name=context_name, clientproxy_process=None)
+def client_side_proxy_main(
+    cmd,
+    tenant_id,
+    client,
+    resource_group_name,
+    cluster_name,
+    flag,
+    args,
+    client_proxy_port,
+    api_server_port,
+    operating_system,
+    creds,
+    user_type,
+    debug_mode,
+    token=None,
+    path=os.path.join(os.path.expanduser("~"), ".kube", "config"),
+    context_name=None,
+    clientproxy_process=None,
+):
+    expiry, clientproxy_process = client_side_proxy(
+        cmd,
+        tenant_id,
+        client,
+        resource_group_name,
+        cluster_name,
+        0,
+        args,
+        client_proxy_port,
+        api_server_port,
+        operating_system,
+        creds,
+        user_type,
+        debug_mode,
+        token=token,
+        path=path,
+        context_name=context_name,
+        clientproxy_process=None,
+    )
     next_refresh_time = expiry - consts.CSP_REFRESH_TIME
 
-    while (True):
+    while True:
         time.sleep(60)
-        if (clientproxyutils.check_if_csp_is_running(clientproxy_process)):
+        if clientproxyutils.check_if_csp_is_running(clientproxy_process):
             if time.time() >= next_refresh_time:
-                expiry, clientproxy_process = \
-                    client_side_proxy(cmd, tenant_id, client, resource_group_name, cluster_name, 1, args,
-                                      client_proxy_port, api_server_port, operating_system, creds, user_type,
-                                      debug_mode, token=token, path=path, context_name=context_name,
-                                      clientproxy_process=clientproxy_process)
+                expiry, clientproxy_process = client_side_proxy(
+                    cmd,
+                    tenant_id,
+                    client,
+                    resource_group_name,
+                    cluster_name,
+                    1,
+                    args,
+                    client_proxy_port,
+                    api_server_port,
+                    operating_system,
+                    creds,
+                    user_type,
+                    debug_mode,
+                    token=token,
+                    path=path,
+                    context_name=context_name,
+                    clientproxy_process=clientproxy_process,
+                )
                 next_refresh_time = expiry - consts.CSP_REFRESH_TIME
         else:
             telemetry.set_exception(
-                exception='Process closed externally.',
+                exception="Process closed externally.",
                 fault_type=consts.Proxy_Closed_Externally_Fault_Type,
-                summary='Process closed externally.')
-            raise ManualInterrupt('Proxy closed externally.')
+                summary="Process closed externally.",
+            )
+            raise ManualInterrupt("Proxy closed externally.")
 
 
-def client_side_proxy(cmd,
-                      tenant_id,
-                      client,
-                      resource_group_name,
-                      cluster_name,
-                      flag,
-                      args,
-                      client_proxy_port,
-                      api_server_port,
-                      operating_system,
-                      creds,
-                      user_type,
-                      debug_mode,
-                      token=None,
-                      path=os.path.join(os.path.expanduser('~'), '.kube', 'config'),
-                      context_name=None,
-                      clientproxy_process=None):
-
+def client_side_proxy(
+    cmd,
+    tenant_id,
+    client,
+    resource_group_name,
+    cluster_name,
+    flag,
+    args,
+    client_proxy_port,
+    api_server_port,
+    operating_system,
+    creds,
+    user_type,
+    debug_mode,
+    token=None,
+    path=os.path.join(os.path.expanduser("~"), ".kube", "config"),
+    context_name=None,
+    clientproxy_process=None,
+):
     subscription_id = get_subscription_id(cmd.cli_ctx)
     if token is not None:
-        auth_method = 'Token'
+        auth_method = "Token"
     else:
-        auth_method = 'AAD'
+        auth_method = "AAD"
 
     # Fetching hybrid connection details from Userrp
     try:
         list_prop = ListClusterUserCredentialProperties(
-            authentication_method=auth_method,
-            client_proxy=True
+            authentication_method=auth_method, client_proxy=True
         )
-        response = client.list_cluster_user_credential(resource_group_name, cluster_name, list_prop)
+        response = client.list_cluster_user_credential(
+            resource_group_name, cluster_name, list_prop
+        )
     except Exception as e:
         if flag == 1:
             clientproxy_process.terminate()
-        utils.arm_exception_handler(e, consts.Get_Credentials_Failed_Fault_Type,
-                                    'Unable to list cluster user credentials')
+        utils.arm_exception_handler(
+            e,
+            consts.Get_Credentials_Failed_Fault_Type,
+            "Unable to list cluster user credentials",
+        )
         raise CLIInternalError("Failed to get credentials." + str(e))
 
     # Starting the client proxy process, if this is the first time that this function is invoked
@@ -2689,82 +3992,122 @@ def client_side_proxy(cmd,
                 clientproxy_process = Popen(args)
             else:
                 clientproxy_process = Popen(args, stdout=DEVNULL, stderr=DEVNULL)
-            print(f'Proxy is listening on port {api_server_port}')
+            print(f"Proxy is listening on port {api_server_port}")
 
         except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Run_Clientproxy_Fault_Type,
-                                    summary='Unable to run client proxy executable')
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Run_Clientproxy_Fault_Type,
+                summary="Unable to run client proxy executable",
+            )
             raise CLIInternalError("Failed to start proxy process." + str(e))
 
-        if not utils.is_cli_using_msal_auth():  # refresh token approach if cli is using ADAL auth (for cli < 2.30.0)
-            if user_type == 'user':
+        if (
+            not utils.is_cli_using_msal_auth()
+        ):  # refresh token approach if cli is using ADAL auth (for cli < 2.30.0)
+            if user_type == "user":
                 identity_data = {}
-                identity_data['refreshToken'] = creds
-                identity_uri = f'https://localhost:{api_server_port}/identity/rt'
+                identity_data["refreshToken"] = creds
+                identity_uri = f"https://localhost:{api_server_port}/identity/rt"
 
                 # Needed to prevent skip tls warning from printing to the console
                 original_stderr = sys.stderr
-                f = open(os.devnull, 'w')
+                f = open(os.devnull, "w")
                 sys.stderr = f
 
-                clientproxyutils.make_api_call_with_retries(identity_uri, identity_data, "post", False,
-                                                            consts.Post_RefreshToken_Fault_Type,
-                                                            'Unable to post refresh token details to clientproxy',
-                                                            "Failed to pass refresh token details to proxy.",
-                                                            clientproxy_process)
+                clientproxyutils.make_api_call_with_retries(
+                    identity_uri,
+                    identity_data,
+                    "post",
+                    False,
+                    consts.Post_RefreshToken_Fault_Type,
+                    "Unable to post refresh token details to clientproxy",
+                    "Failed to pass refresh token details to proxy.",
+                    clientproxy_process,
+                )
                 sys.stderr = original_stderr
 
     if token is None:
-        if utils.is_cli_using_msal_auth():  # jwt token approach if cli is using MSAL. This is for cli >= 2.30.0
-            kid = clientproxyutils.fetch_pop_publickey_kid(api_server_port, clientproxy_process)
+        if (
+            utils.is_cli_using_msal_auth()
+        ):  # jwt token approach if cli is using MSAL. This is for cli >= 2.30.0
+            kid = clientproxyutils.fetch_pop_publickey_kid(
+                api_server_port, clientproxy_process
+            )
             post_at_response = clientproxyutils.fetch_and_post_at_to_csp(
-                cmd, api_server_port, tenant_id, kid, clientproxy_process)
+                cmd, api_server_port, tenant_id, kid, clientproxy_process
+            )
 
             if post_at_response.status_code != 200:
-                if post_at_response.status_code == 500 and "public key expired" in post_at_response.text:
+                if (
+                    post_at_response.status_code == 500
+                    and "public key expired" in post_at_response.text
+                ):
                     # pop public key must have been rotated
                     telemetry.set_exception(
                         exception=post_at_response.text,
                         fault_type=consts.PoP_Public_Key_Expried_Fault_Type,
-                        summary='PoP public key has expired')
+                        summary="PoP public key has expired",
+                    )
                     kid = clientproxyutils.fetch_pop_publickey_kid(
-                        api_server_port, clientproxy_process)  # fetch the rotated PoP public key
+                        api_server_port, clientproxy_process
+                    )  # fetch the rotated PoP public key
                     # fetch and post the at corresponding to the new public key
-                    clientproxyutils.fetch_and_post_at_to_csp(cmd, api_server_port, tenant_id, kid, clientproxy_process)
+                    clientproxyutils.fetch_and_post_at_to_csp(
+                        cmd, api_server_port, tenant_id, kid, clientproxy_process
+                    )
                 else:
                     telemetry.set_exception(
                         exception=post_at_response.text,
                         fault_type=consts.Post_AT_To_ClientProxy_Failed_Fault_Type,
-                        summary='Failed to post access token to client proxy')
+                        summary="Failed to post access token to client proxy",
+                    )
                     clientproxyutils.close_subprocess_and_raise_cli_error(
-                        clientproxy_process, 'Failed to post access token to client proxy' + post_at_response.text)
+                        clientproxy_process,
+                        "Failed to post access token to client proxy"
+                        + post_at_response.text,
+                    )
 
     data = prepare_clientproxy_data(response)
-    expiry = data['hybridConnectionConfig']['expirationTime']
+    expiry = data["hybridConnectionConfig"]["expirationTime"]
 
     if token is not None:
-        data['kubeconfigs'][0]['value'] = clientproxyutils.insert_token_in_kubeconfig(data, token)
+        data["kubeconfigs"][0]["value"] = clientproxyutils.insert_token_in_kubeconfig(
+            data, token
+        )
 
-    uri = f"http://localhost:{client_proxy_port}/subscriptions/{subscription_id}/resourceGroups/{resource_group_name}" \
+    uri = (
+        f"http://localhost:{client_proxy_port}/subscriptions/{subscription_id}/resourceGroups/{resource_group_name}"
         "/providers/Microsoft.Kubernetes/connectedClusters/{cluster_name}/register?api-version=2020-10-01"
+    )
 
     # Posting hybrid connection details to proxy in order to get kubeconfig
-    response = clientproxyutils.make_api_call_with_retries(uri, data, "post", False, consts.Post_Hybridconn_Fault_Type,
-                                                           'Unable to post hybrid connection details to clientproxy',
-                                                           "Failed to pass hybrid connection details to proxy.",
-                                                           clientproxy_process)
+    response = clientproxyutils.make_api_call_with_retries(
+        uri,
+        data,
+        "post",
+        False,
+        consts.Post_Hybridconn_Fault_Type,
+        "Unable to post hybrid connection details to clientproxy",
+        "Failed to pass hybrid connection details to proxy.",
+        clientproxy_process,
+    )
 
     if flag == 0:
         # Decoding kubeconfig into a string
         try:
             kubeconfig = json.loads(response.text)
         except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Load_Kubeconfig_Fault_Type,
-                                    summary='Unable to load Kubeconfig')
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Load_Kubeconfig_Fault_Type,
+                summary="Unable to load Kubeconfig",
+            )
             clientproxyutils.close_subprocess_and_raise_cli_error(
-                clientproxy_process, "Failed to load kubeconfig." + str(e))
+                clientproxy_process, "Failed to load kubeconfig." + str(e)
+            )
 
-        kubeconfig = kubeconfig['kubeconfigs'][0]['value']
+        kubeconfig = kubeconfig["kubeconfigs"][0]["value"]
         kubeconfig = b64decode(kubeconfig).decode("utf-8")
 
         try:
@@ -2772,37 +4115,49 @@ def client_side_proxy(cmd,
             if path != "-":
                 if context_name is None:
                     kubeconfig_obj = load_kubernetes_configuration(path)
-                    temp_context_name = kubeconfig_obj['current-context']
+                    temp_context_name = kubeconfig_obj["current-context"]
                 else:
                     temp_context_name = context_name
-                msg = "Start sending kubectl requests on '{}' context using kubeconfig " \
+                msg = (
+                    "Start sending kubectl requests on '{}' context using kubeconfig "
                     "at {}".format(temp_context_name, path)
+                )
                 print(msg)
 
             print("Press Ctrl+C to close proxy.")
 
         except Exception as e:
-            telemetry.set_exception(exception=e, fault_type=consts.Merge_Kubeconfig_Fault_Type,
-                                    summary='Unable to merge kubeconfig.')
+            telemetry.set_exception(
+                exception=e,
+                fault_type=consts.Merge_Kubeconfig_Fault_Type,
+                summary="Unable to merge kubeconfig.",
+            )
             clientproxyutils.close_subprocess_and_raise_cli_error(
-                clientproxy_process, "Failed to merge kubeconfig." + str(e))
+                clientproxy_process, "Failed to merge kubeconfig." + str(e)
+            )
 
     return expiry, clientproxy_process
 
 
 def check_cl_registration_and_get_oid(cmd, cl_oid, subscription_id):
-    print("Step: {}: Checking Microsoft.ExtendedLocation RP Registration state for this Subscription, and get OID, "
-          "if registered ".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Checking Microsoft.ExtendedLocation RP Registration state for this Subscription, and get OID, "
+        "if registered ".format(utils.get_utctimestring())
+    )
     enable_custom_locations = True
     custom_locations_oid = ""
     try:
         rp_client = resource_providers_client(cmd.cli_ctx, subscription_id)
-        cl_registration_state = rp_client.get(consts.Custom_Locations_Provider_Namespace).registration_state
+        cl_registration_state = rp_client.get(
+            consts.Custom_Locations_Provider_Namespace
+        ).registration_state
         if cl_registration_state != "Registered":
             enable_custom_locations = False
-            warn_msg = "'Custom-locations' feature couldn't be enabled on this cluster as the pre-requisite " \
-                "registration of 'Microsoft.ExtendedLocation' was not met. More details for enabling this" \
+            warn_msg = (
+                "'Custom-locations' feature couldn't be enabled on this cluster as the pre-requisite "
+                "registration of 'Microsoft.ExtendedLocation' was not met. More details for enabling this"
                 " feature later on this cluster can be found here - https://aka.ms/EnableCustomLocations"
+            )
             logger.warning(warn_msg)
         else:
             custom_locations_oid = get_custom_locations_oid(cmd, cl_oid)
@@ -2810,11 +4165,16 @@ def check_cl_registration_and_get_oid(cmd, cl_oid, subscription_id):
                 enable_custom_locations = False
     except Exception as e:
         enable_custom_locations = False
-        warn_msg = "Unable to fetch registration state of 'Microsoft.ExtendedLocation'. Failed to enable " \
+        warn_msg = (
+            "Unable to fetch registration state of 'Microsoft.ExtendedLocation'. Failed to enable "
             "'custom-locations' feature. This is fine if not required. Proceeding with helm install."
+        )
         logger.warning(warn_msg)
-        telemetry.set_exception(exception=e, fault_type=consts.Custom_Locations_Registration_Check_Fault_Type,
-                                summary='Unable to fetch status of Custom Locations RP registration.')
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Custom_Locations_Registration_Check_Fault_Type,
+            summary="Unable to fetch status of Custom Locations RP registration.",
+        )
     return enable_custom_locations, custom_locations_oid
 
 
@@ -2826,27 +4186,34 @@ def get_custom_locations_oid(cmd, cl_oid):
         # https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/
         # custom-locations#enable-custom-locations-on-your-cluster
         # Get Application Object for the CL App Id
-        app_object = graph_client.service_principal_list(filter="appId eq '{}'".format(app_id))
+        app_object = graph_client.service_principal_list(
+            filter="appId eq '{}'".format(app_id)
+        )
         # If we successfully obtained it
         if len(app_object) != 0:
             # If a CL OID was input and it did not match the one we fetched, log a warning
-            if cl_oid is not None and cl_oid != app_object[0]['id']:
-                debug_msg = "The 'Custom-locations' OID passed is different from the actual OID(%s) of the Custom " \
-                    "Locations RP app. Proceeding with the correct one...", app_object[0]['id']
+            if cl_oid is not None and cl_oid != app_object[0]["id"]:
+                debug_msg = (
+                    "The 'Custom-locations' OID passed is different from the actual OID(%s) of the Custom "
+                    "Locations RP app. Proceeding with the correct one...",
+                    app_object[0]["id"],
+                )
                 logger.debug(debug_msg)
             # We return the fetched CL OID, if we successfully retrieved it - irrespective of CL OID was input or not
-            return app_object[0]['id']  # Using the fetched OID
+            return app_object[0]["id"]  # Using the fetched OID
 
         # If a Cl OID was not input and we failed to fetch the CL App object, log a warning
         if cl_oid is None:
             logger.warning(
                 "Failed to enable Custom Locations feature on the cluster. Unable to fetch Object ID of Azure AD "
                 "application used by Azure Arc service. Try enabling the feature by passing the "
-                "--custom-locations-oid parameter directly. Learn more at https://aka.ms/CustomLocationsObjectID")
+                "--custom-locations-oid parameter directly. Learn more at https://aka.ms/CustomLocationsObjectID"
+            )
             telemetry.set_exception(
-                exception='Unable to fetch oid of custom locations app.',
+                exception="Unable to fetch oid of custom locations app.",
                 fault_type=consts.Custom_Locations_OID_Fetch_Fault_Type_CLOid_None,
-                summary='Unable to fetch oid for custom locations app.')
+                summary="Unable to fetch oid for custom locations app.",
+            )
             # Return empty for OID
             return ""
         # Else return the input OID
@@ -2854,8 +4221,11 @@ def get_custom_locations_oid(cmd, cl_oid):
     except Exception as e:
         # Encountered exeption while fetching OID, log error
         log_string = "Unable to fetch the Object ID of the Azure AD application used by Azure Arc service. "
-        telemetry.set_exception(exception=e, fault_type=consts.Custom_Locations_OID_Fetch_Fault_Type_Exception,
-                                summary='Unable to fetch oid for custom locations app.')
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Custom_Locations_OID_Fetch_Fault_Type_Exception,
+            summary="Unable to fetch oid for custom locations app.",
+        )
         # If Cl OID was input, use that
         if cl_oid:
             log_string += "Proceeding with the Object ID provided to enable the 'custom-locations' feature."
@@ -2867,11 +4237,18 @@ def get_custom_locations_oid(cmd, cl_oid):
         return ""
 
 
-def troubleshoot(cmd, client, resource_group_name, cluster_name, kube_config=None, kube_context=None,
-                 skip_ssl_verification=False, no_wait=False, tags=None):
-
+def troubleshoot(
+    cmd,
+    client,
+    resource_group_name,
+    cluster_name,
+    kube_config=None,
+    kube_context=None,
+    skip_ssl_verification=False,
+    no_wait=False,
+    tags=None,
+):
     try:
-
         logger.warning("Diagnoser running. This may take a while ...\n")
         absolute_path = os.path.abspath(os.path.dirname(__file__))
 
@@ -2880,19 +4257,21 @@ def troubleshoot(cmd, client, resource_group_name, cluster_name, kube_config=Non
         probable_sufficient_resource_for_agents = True
 
         # Setting default values for all checks as True
-        diagnostic_checks = {consts.Fetch_Kubectl_Cluster_Info: consts.Diagnostic_Check_Incomplete,
-                             consts.Retrieve_Arc_Agents_Event_Logs: consts.Diagnostic_Check_Incomplete,
-                             consts.Retrieve_Arc_Agents_Logs: consts.Diagnostic_Check_Incomplete,
-                             consts.Retrieve_Deployments_Logs: consts.Diagnostic_Check_Incomplete,
-                             consts.Fetch_Connected_Cluster_Resource: consts.Diagnostic_Check_Incomplete,
-                             consts.Storing_Diagnoser_Results_Logs: consts.Diagnostic_Check_Incomplete,
-                             consts.MSI_Cert_Expiry_Check: consts.Diagnostic_Check_Incomplete,
-                             consts.KAP_Security_Policy_Check: consts.Diagnostic_Check_Incomplete,
-                             consts.KAP_Cert_Check: consts.Diagnostic_Check_Incomplete,
-                             consts.Diagnoser_Check: consts.Diagnostic_Check_Incomplete,
-                             consts.MSI_Cert_Check: consts.Diagnostic_Check_Incomplete,
-                             consts.Agent_Version_Check: consts.Diagnostic_Check_Incomplete,
-                             consts.Arc_Agent_State_Check: consts.Diagnostic_Check_Incomplete}
+        diagnostic_checks = {
+            consts.Fetch_Kubectl_Cluster_Info: consts.Diagnostic_Check_Incomplete,
+            consts.Retrieve_Arc_Agents_Event_Logs: consts.Diagnostic_Check_Incomplete,
+            consts.Retrieve_Arc_Agents_Logs: consts.Diagnostic_Check_Incomplete,
+            consts.Retrieve_Deployments_Logs: consts.Diagnostic_Check_Incomplete,
+            consts.Fetch_Connected_Cluster_Resource: consts.Diagnostic_Check_Incomplete,
+            consts.Storing_Diagnoser_Results_Logs: consts.Diagnostic_Check_Incomplete,
+            consts.MSI_Cert_Expiry_Check: consts.Diagnostic_Check_Incomplete,
+            consts.KAP_Security_Policy_Check: consts.Diagnostic_Check_Incomplete,
+            consts.KAP_Cert_Check: consts.Diagnostic_Check_Incomplete,
+            consts.Diagnoser_Check: consts.Diagnostic_Check_Incomplete,
+            consts.MSI_Cert_Check: consts.Diagnostic_Check_Incomplete,
+            consts.Agent_Version_Check: consts.Diagnostic_Check_Incomplete,
+            consts.Arc_Agent_State_Check: consts.Diagnostic_Check_Incomplete,
+        }
 
         # Setting kube_config
         kube_config = set_kube_config(kube_config)
@@ -2907,7 +4286,13 @@ def troubleshoot(cmd, client, resource_group_name, cluster_name, kube_config=Non
         # Install kubectl client
         kubectl_client_location = install_kubectl_client()
         release_namespace = validate_release_namespace(
-            client, cluster_name, resource_group_name, kube_config, kube_context, helm_client_location)
+            client,
+            cluster_name,
+            resource_group_name,
+            kube_config,
+            kube_context,
+            helm_client_location,
+        )
 
         # Checking the connection to kubernetes cluster.
         # This check was added to avoid large timeouts when connecting to AAD Enabled AKS clusters
@@ -2916,186 +4301,294 @@ def troubleshoot(cmd, client, resource_group_name, cluster_name, kube_config=Non
         utils.try_list_node_fix()
 
         # Fetch Connected Cluster for agent version
-        connected_cluster = get_connectedk8s(cmd, client, resource_group_name, cluster_name)
+        connected_cluster = get_connectedk8s(
+            cmd, client, resource_group_name, cluster_name
+        )
 
         # Creating timestamp folder to store all the diagnoser logs
         current_time = time.ctime(time.time())
         time_stamp = ""
         for elements in current_time:
-            if (elements == ' '):
-                time_stamp += '-'
+            if elements == " ":
+                time_stamp += "-"
                 continue
-            if (elements == ':'):
-                time_stamp += '.'
+            if elements == ":":
+                time_stamp += "."
                 continue
             time_stamp += elements
-        time_stamp = cluster_name + '-' + time_stamp
+        time_stamp = cluster_name + "-" + time_stamp
         # Generate the diagnostic folder in a given location
-        filepath_with_timestamp, diagnostic_folder_status = utils.create_folder_diagnosticlogs(
-            time_stamp, consts.Arc_Diagnostic_Logs)
+        filepath_with_timestamp, diagnostic_folder_status = (
+            utils.create_folder_diagnosticlogs(time_stamp, consts.Arc_Diagnostic_Logs)
+        )
 
-        if (diagnostic_folder_status is not True):
+        if diagnostic_folder_status is not True:
             storage_space_available = False
 
         # To store the cluster-info of the cluster in current-context
-        diagnostic_checks[consts.Fetch_Kubectl_Cluster_Info], storage_space_available = \
-            troubleshootutils.fetch_kubectl_cluster_info(filepath_with_timestamp,
-                                                         storage_space_available,
-                                                         kubectl_client_location,
-                                                         kube_config, kube_context)
+        (
+            diagnostic_checks[consts.Fetch_Kubectl_Cluster_Info],
+            storage_space_available,
+        ) = troubleshootutils.fetch_kubectl_cluster_info(
+            filepath_with_timestamp,
+            storage_space_available,
+            kubectl_client_location,
+            kube_config,
+            kube_context,
+        )
 
         # To store the connected cluster resource logs in the diagnostic folder
-        diagnostic_checks[consts.Fetch_Connected_Cluster_Resource], storage_space_available = \
-            troubleshootutils.fetch_connected_cluster_resource(filepath_with_timestamp,
-                                                               connected_cluster,
-                                                               storage_space_available)
+        (
+            diagnostic_checks[consts.Fetch_Connected_Cluster_Resource],
+            storage_space_available,
+        ) = troubleshootutils.fetch_connected_cluster_resource(
+            filepath_with_timestamp, connected_cluster, storage_space_available
+        )
         corev1_api_instance = kube_client.CoreV1Api()
 
         # Check if agents have been added to the cluster
-        arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(namespace="azure-arc")
+        arc_agents_pod_list = corev1_api_instance.list_namespaced_pod(
+            namespace="azure-arc"
+        )
 
         # To verify if arc agents have been added to the cluster
         if arc_agents_pod_list.items:
-
             # For storing all arc agent logs using the CoreV1Api
-            diagnostic_checks[consts.Retrieve_Arc_Agents_Logs], storage_space_available = \
-                troubleshootutils.retrieve_arc_agents_logs(corev1_api_instance,
-                                                           filepath_with_timestamp,
-                                                           storage_space_available)
+            (
+                diagnostic_checks[consts.Retrieve_Arc_Agents_Logs],
+                storage_space_available,
+            ) = troubleshootutils.retrieve_arc_agents_logs(
+                corev1_api_instance, filepath_with_timestamp, storage_space_available
+            )
 
             # For storing all arc agents events logs
-            diagnostic_checks[consts.Retrieve_Arc_Agents_Event_Logs], storage_space_available = \
-                troubleshootutils.retrieve_arc_agents_event_logs(filepath_with_timestamp,
-                                                                 storage_space_available,
-                                                                 kubectl_client_location,
-                                                                 kube_config, kube_context)
+            (
+                diagnostic_checks[consts.Retrieve_Arc_Agents_Event_Logs],
+                storage_space_available,
+            ) = troubleshootutils.retrieve_arc_agents_event_logs(
+                filepath_with_timestamp,
+                storage_space_available,
+                kubectl_client_location,
+                kube_config,
+                kube_context,
+            )
 
             # For storing all the deployments logs using the AppsV1Api
             appv1_api_instance = kube_client.AppsV1Api()
-            diagnostic_checks[consts.Retrieve_Deployments_Logs], storage_space_available = \
-                troubleshootutils.retrieve_deployments_logs(appv1_api_instance,
-                                                            filepath_with_timestamp,
-                                                            storage_space_available)
+            (
+                diagnostic_checks[consts.Retrieve_Deployments_Logs],
+                storage_space_available,
+            ) = troubleshootutils.retrieve_deployments_logs(
+                appv1_api_instance, filepath_with_timestamp, storage_space_available
+            )
 
             # Check for the azure arc agent states
-            diagnostic_checks[consts.Arc_Agent_State_Check], \
-                storage_space_available, all_agents_stuck, probable_sufficient_resource_for_agents = \
-                troubleshootutils.check_agent_state(corev1_api_instance, filepath_with_timestamp,
-                                                    storage_space_available)
+            (
+                diagnostic_checks[consts.Arc_Agent_State_Check],
+                storage_space_available,
+                all_agents_stuck,
+                probable_sufficient_resource_for_agents,
+            ) = troubleshootutils.check_agent_state(
+                corev1_api_instance, filepath_with_timestamp, storage_space_available
+            )
 
             # Check for msi certificate
             if all_agents_stuck is False:
-                diagnostic_checks[consts.MSI_Cert_Check] = troubleshootutils.check_msi_certificate_presence(
-                    corev1_api_instance)
+                diagnostic_checks[consts.MSI_Cert_Check] = (
+                    troubleshootutils.check_msi_certificate_presence(
+                        corev1_api_instance
+                    )
+                )
 
             # If msi certificate present then only we will perform msi certificate expiry check
-            if diagnostic_checks[consts.MSI_Cert_Check] == consts.Diagnostic_Check_Passed:
-                diagnostic_checks[consts.MSI_Cert_Expiry_Check] = troubleshootutils.check_msi_expiry(connected_cluster)
+            if (
+                diagnostic_checks[consts.MSI_Cert_Check]
+                == consts.Diagnostic_Check_Passed
+            ):
+                diagnostic_checks[consts.MSI_Cert_Expiry_Check] = (
+                    troubleshootutils.check_msi_expiry(connected_cluster)
+                )
 
             # If msi certificate present then only we will do Kube aad proxy checks
-            if diagnostic_checks[consts.MSI_Cert_Check] == consts.Diagnostic_Check_Passed:
-                diagnostic_checks[consts.KAP_Security_Policy_Check] = \
-                    troubleshootutils.check_probable_cluster_security_policy(corev1_api_instance,
-                                                                             helm_client_location,
-                                                                             release_namespace,
-                                                                             kube_config,
-                                                                             kube_context)
+            if (
+                diagnostic_checks[consts.MSI_Cert_Check]
+                == consts.Diagnostic_Check_Passed
+            ):
+                diagnostic_checks[consts.KAP_Security_Policy_Check] = (
+                    troubleshootutils.check_probable_cluster_security_policy(
+                        corev1_api_instance,
+                        helm_client_location,
+                        release_namespace,
+                        kube_config,
+                        kube_context,
+                    )
+                )
 
                 # If no security policy is present in cluster then we can check for the Kube aad proxy certificate
-                if diagnostic_checks[consts.KAP_Security_Policy_Check] == consts.Diagnostic_Check_Passed:
-                    diagnostic_checks[consts.KAP_Cert_Check] = troubleshootutils.check_kap_cert(corev1_api_instance)
+                if (
+                    diagnostic_checks[consts.KAP_Security_Policy_Check]
+                    == consts.Diagnostic_Check_Passed
+                ):
+                    diagnostic_checks[consts.KAP_Cert_Check] = (
+                        troubleshootutils.check_kap_cert(corev1_api_instance)
+                    )
 
             # Checking whether optional extra values file has been provided.
             values_file = utils.get_values_file()
 
             # Adding helm repo
-            if os.getenv('HELMREPONAME') and os.getenv('HELMREPOURL'):
+            if os.getenv("HELMREPONAME") and os.getenv("HELMREPOURL"):
                 utils.add_helm_repo(kube_config, kube_context, helm_client_location)
 
-            config_dp_endpoint, release_train = get_config_dp_endpoint(cmd, connected_cluster.location, values_file)
+            config_dp_endpoint, release_train = get_config_dp_endpoint(
+                cmd, connected_cluster.location, values_file
+            )
 
             # Retrieving Helm chart OCI Artifact location
-            registry_path = os.getenv('HELMREGISTRY') if os.getenv(
-                'HELMREGISTRY') else utils.get_helm_registry(cmd, config_dp_endpoint, release_train)
+            registry_path = (
+                os.getenv("HELMREGISTRY")
+                if os.getenv("HELMREGISTRY")
+                else utils.get_helm_registry(cmd, config_dp_endpoint, release_train)
+            )
 
             # Get azure-arc agent version for telemetry
-            azure_arc_agent_version = registry_path.split(':')[1]
+            azure_arc_agent_version = registry_path.split(":")[1]
 
             # Check for agent version compatibility
-            diagnostic_checks[consts.Agent_Version_Check] = troubleshootutils.check_agent_version(
-                connected_cluster, azure_arc_agent_version)
+            diagnostic_checks[consts.Agent_Version_Check] = (
+                troubleshootutils.check_agent_version(
+                    connected_cluster, azure_arc_agent_version
+                )
+            )
         else:
             logger.warning(
                 "Error: Azure Arc agents are not present on the cluster. Please verify whether Arc onboarding of "
-                "the Kubernetes cluster has been attempted.\n")
+                "the Kubernetes cluster has been attempted.\n"
+            )
 
         batchv1_api_instance = kube_client.BatchV1Api()
         # Performing diagnoser container check
-        diagnostic_checks[consts.Diagnoser_Check], storage_space_available = \
-            troubleshootutils.check_diagnoser_container(corev1_api_instance, batchv1_api_instance,
-                                                        filepath_with_timestamp, storage_space_available, absolute_path,
-                                                        probable_sufficient_resource_for_agents, helm_client_location,
-                                                        kubectl_client_location, release_namespace,
-                                                        diagnostic_checks[consts.KAP_Security_Policy_Check],
-                                                        kube_config, kube_context)
+        diagnostic_checks[consts.Diagnoser_Check], storage_space_available = (
+            troubleshootutils.check_diagnoser_container(
+                corev1_api_instance,
+                batchv1_api_instance,
+                filepath_with_timestamp,
+                storage_space_available,
+                absolute_path,
+                probable_sufficient_resource_for_agents,
+                helm_client_location,
+                kubectl_client_location,
+                release_namespace,
+                diagnostic_checks[consts.KAP_Security_Policy_Check],
+                kube_config,
+                kube_context,
+            )
+        )
 
         # saving secrets in azure-arc namespace
-        storage_space_available = \
-            troubleshootutils.get_secrets_azure_arc(corev1_api_instance, kubectl_client_location, kube_config,
-                                                    kube_context, filepath_with_timestamp, storage_space_available)
+        storage_space_available = troubleshootutils.get_secrets_azure_arc(
+            corev1_api_instance,
+            kubectl_client_location,
+            kube_config,
+            kube_context,
+            filepath_with_timestamp,
+            storage_space_available,
+        )
 
         # saving helm values of azure-arc release
-        storage_space_available = \
-            troubleshootutils.get_helm_values_azure_arc(corev1_api_instance, helm_client_location, release_namespace,
-                                                        kube_config, kube_context, filepath_with_timestamp,
-                                                        storage_space_available)
+        storage_space_available = troubleshootutils.get_helm_values_azure_arc(
+            corev1_api_instance,
+            helm_client_location,
+            release_namespace,
+            kube_config,
+            kube_context,
+            filepath_with_timestamp,
+            storage_space_available,
+        )
 
         # saving metadata CR sanpshot
-        storage_space_available = \
-            troubleshootutils.get_metadata_cr_snapshot(corev1_api_instance, kubectl_client_location, kube_config,
-                                                       kube_context, filepath_with_timestamp, storage_space_available)
+        storage_space_available = troubleshootutils.get_metadata_cr_snapshot(
+            corev1_api_instance,
+            kubectl_client_location,
+            kube_config,
+            kube_context,
+            filepath_with_timestamp,
+            storage_space_available,
+        )
 
         # saving kube-aad-proxy CR snapshot only in the case private link is disabled
         if connected_cluster.private_link_state == "Disabled":
-            storage_space_available = \
-                troubleshootutils.get_kubeaadproxy_cr_snapshot(corev1_api_instance, kubectl_client_location,
-                                                               kube_config, kube_context, filepath_with_timestamp,
-                                                               storage_space_available)
-                
-        connected_cluster = get_connectedk8s_2024_07_01(cmd, client, resource_group_name, cluster_name)
+            storage_space_available = troubleshootutils.get_kubeaadproxy_cr_snapshot(
+                corev1_api_instance,
+                kubectl_client_location,
+                kube_config,
+                kube_context,
+                filepath_with_timestamp,
+                storage_space_available,
+            )
+
+        connected_cluster = get_connectedk8s_2024_07_01(
+            cmd, client, resource_group_name, cluster_name
+        )
         # saving signing key CR snapshot only if oidc issuer prfile is enabled
         if connected_cluster.oidc_issuer_profile.enabled:
-            storage_space_available = \
-                troubleshootutils.get_signingkey_cr_snapshot(corev1_api_instance, kubectl_client_location, kube_config,
-                                                            kube_context, filepath_with_timestamp, storage_space_available)
+            storage_space_available = troubleshootutils.get_signingkey_cr_snapshot(
+                corev1_api_instance,
+                kubectl_client_location,
+                kube_config,
+                kube_context,
+                filepath_with_timestamp,
+                storage_space_available,
+            )
 
         # saving all other workload identity related information if enabled
-        if connected_cluster.oidc_issuer_profile.enabled or connected_cluster.security_profile.workload_identity.enabled:
+        if (
+            connected_cluster.oidc_issuer_profile.enabled
+            or connected_cluster.security_profile.workload_identity.enabled
+        ):
             # saving helm values of wiextension release
-            storage_space_available = \
-                troubleshootutils.get_helm_values_arc_workload_identity(corev1_api_instance, helm_client_location, release_namespace,
-                                                            kube_config, kube_context, filepath_with_timestamp,
-                                                            storage_space_available)
+            storage_space_available = (
+                troubleshootutils.get_helm_values_arc_workload_identity(
+                    corev1_api_instance,
+                    helm_client_location,
+                    release_namespace,
+                    kube_config,
+                    kube_context,
+                    filepath_with_timestamp,
+                    storage_space_available,
+                )
+            )
 
             # saving arc-workload-identity logs
-            diagnostic_checks[consts.Retrieve_Arc_Workload_Identity_Pod_Logs], storage_space_available = \
-                troubleshootutils.retrieve_arc_workload_identity_pod_logs(corev1_api_instance,
-                                                           filepath_with_timestamp,
-                                                           storage_space_available)
+            (
+                diagnostic_checks[consts.Retrieve_Arc_Workload_Identity_Pod_Logs],
+                storage_space_available,
+            ) = troubleshootutils.retrieve_arc_workload_identity_pod_logs(
+                corev1_api_instance, filepath_with_timestamp, storage_space_available
+            )
 
             # saving arc-workload-identity event logs
-            diagnostic_checks[consts.Retrieve_Arc_Workload_Identity_Events_Logs], storage_space_available = \
-                troubleshootutils.retrieve_arc_workload_identity_event_logs(filepath_with_timestamp,
-                                                                 storage_space_available,
-                                                                 kubectl_client_location,
-                                                                 kube_config, kube_context)
+            (
+                diagnostic_checks[consts.Retrieve_Arc_Workload_Identity_Events_Logs],
+                storage_space_available,
+            ) = troubleshootutils.retrieve_arc_workload_identity_event_logs(
+                filepath_with_timestamp,
+                storage_space_available,
+                kubectl_client_location,
+                kube_config,
+                kube_context,
+            )
 
             # saving arc-workload-identity deployment logs
             appv1_api_instance = kube_client.AppsV1Api()
-            diagnostic_checks[consts.Retrieve_Arc_Workload_Identity_Deployments_Logs], storage_space_available = \
-                troubleshootutils.retrieve_arc_workload_identity_deployments_logs(appv1_api_instance,
-                                                            filepath_with_timestamp,
-                                                            storage_space_available)
+            (
+                diagnostic_checks[
+                    consts.Retrieve_Arc_Workload_Identity_Deployments_Logs
+                ],
+                storage_space_available,
+            ) = troubleshootutils.retrieve_arc_workload_identity_deployments_logs(
+                appv1_api_instance, filepath_with_timestamp, storage_space_available
+            )
 
         # checking cluster connectivity status
         cluster_connectivity_status = connected_cluster.connectivity_status
@@ -3103,11 +4596,15 @@ def troubleshoot(cmd, client, resource_group_name, cluster_name, kube_config=Non
         if cluster_connectivity_status != "Connected":
             logger.warning(
                 "Cluster connectivity status is not connected. The current state of the cluster is : %s",
-                cluster_connectivity_status)
+                cluster_connectivity_status,
+            )
 
         # Adding cli output to the logs
-        diagnostic_checks[consts.Storing_Diagnoser_Results_Logs] = troubleshootutils.fetching_cli_output_logs(
-            filepath_with_timestamp, storage_space_available, 1)
+        diagnostic_checks[consts.Storing_Diagnoser_Results_Logs] = (
+            troubleshootutils.fetching_cli_output_logs(
+                filepath_with_timestamp, storage_space_available, 1
+            )
+        )
 
         # If all the checks passed then display no error found
         all_checks_passed = True
@@ -3120,36 +4617,44 @@ def troubleshoot(cmd, client, resource_group_name, cluster_name, kube_config=Non
                 logger.warning(
                     "The diagnoser didn't find any issues on the cluster.\nThe diagnoser logs have been saved at this"
                     " path: %s.\nThese logs can be attached while filing a support ticket for further assistance.\n",
-                    filepath_with_timestamp)
+                    filepath_with_timestamp,
+                )
             else:
                 logger.warning(
                     "The diagnoser logs have been saved at this path: %s.\nThese logs can be attached while filing a "
                     "support ticket for further assistance.\n",
-                    filepath_with_timestamp)
+                    filepath_with_timestamp,
+                )
         else:
             if all_checks_passed:
                 logger.warning("The diagnoser didn't find any issues on the cluster.\n")
             logger.warning(
                 "The diagnoser was unable to save logs to your machine. Please check whether sufficient storage is "
-                "available and run the troubleshoot command again.")
+                "available and run the troubleshoot command again."
+            )
 
     # Handling the user manual interrupt
     except KeyboardInterrupt:
         try:
-            troubleshootutils.fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, 0)
+            troubleshootutils.fetching_cli_output_logs(
+                filepath_with_timestamp, storage_space_available, 0
+            )
         except Exception:
             pass
-        raise ManualInterrupt('Process terminated externally.')
+        raise ManualInterrupt("Process terminated externally.")
 
 
 def install_kubectl_client():
-    print("Step: {}: Install Kubectl client if it does not exist".format(utils.get_utctimestring()))
+    print(
+        "Step: {}: Install Kubectl client if it does not exist".format(
+            utils.get_utctimestring()
+        )
+    )
     # Return kubectl client path set by user
     try:
-
         # Fetching the current directory where the cli installs the kubectl executable
-        home_dir = os.path.expanduser('~')
-        kubectl_filepath = os.path.join(home_dir, '.azure', 'kubectl-client')
+        home_dir = os.path.expanduser("~")
+        kubectl_filepath = os.path.join(home_dir, ".azure", "kubectl-client")
 
         try:
             os.makedirs(kubectl_filepath)
@@ -3158,26 +4663,33 @@ def install_kubectl_client():
 
         operating_system = platform.system().lower()
         # Setting path depending on the OS being used
-        if operating_system == 'windows':
-            kubectl_path = os.path.join(kubectl_filepath, 'kubectl.exe')
-        elif operating_system == 'linux' or operating_system == 'darwin':
-            kubectl_path = os.path.join(kubectl_filepath, 'kubectl')
+        if operating_system == "windows":
+            kubectl_path = os.path.join(kubectl_filepath, "kubectl.exe")
+        elif operating_system == "linux" or operating_system == "darwin":
+            kubectl_path = os.path.join(kubectl_filepath, "kubectl")
 
         if os.path.isfile(kubectl_path):
             return kubectl_path
 
         # Downloading kubectl executable if its not present in the machine
-        logger.warning("Downloading kubectl client for first time. This can take few minutes...")
+        logger.warning(
+            "Downloading kubectl client for first time. This can take few minutes..."
+        )
         logging.disable(logging.CRITICAL)
-        get_default_cli().invoke(['aks', 'install-cli', '--install-location', kubectl_path])
+        get_default_cli().invoke(
+            ["aks", "install-cli", "--install-location", kubectl_path]
+        )
         logging.disable(logging.NOTSET)
         logger.warning("\n")
         # Return the path of the kubectl executable
         return kubectl_path
 
     except Exception as e:
-        telemetry.set_exception(exception=e, fault_type=consts.Download_And_Install_Kubectl_Fault_Type,
-                                summary="Failed to download and install kubectl")
+        telemetry.set_exception(
+            exception=e,
+            fault_type=consts.Download_And_Install_Kubectl_Fault_Type,
+            summary="Failed to download and install kubectl",
+        )
         raise CLIInternalError("Unable to install kubectl. Error: ", str(e))
 
 
@@ -3185,8 +4697,16 @@ def crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
     print("Step: {}: Deleting Arc CRDs".format(utils.get_utctimestring()))
     timeout_for_crd_deletion = "20s"
     for crds in consts.CRD_FOR_FORCE_DELETE:
-        cmd_helm_delete = [kubectl_client_location, "delete", "crds", crds,
-                           "--ignore-not-found", "--wait", "--timeout", "{}".format(timeout_for_crd_deletion)]
+        cmd_helm_delete = [
+            kubectl_client_location,
+            "delete",
+            "crds",
+            crds,
+            "--ignore-not-found",
+            "--wait",
+            "--timeout",
+            "{}".format(timeout_for_crd_deletion),
+        ]
         if kube_config:
             cmd_helm_delete.extend(["--kubeconfig", kube_config])
         if kube_context:
@@ -3204,7 +4724,6 @@ def crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
 
     # Patch if CRD is in Terminating state
     for crds in consts.CRD_FOR_FORCE_DELETE:
-
         cmd = [kubectl_client_location, "get", "crd", crds, "-ojson"]
         if kube_config:
             cmd.extend(["--kubeconfig", kube_config])
@@ -3213,13 +4732,20 @@ def crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
         cmd_output = Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, _ = cmd_output.communicate()
 
-        if (cmd_output.returncode == 0):
+        if cmd_output.returncode == 0:
             changed_cmd = json.loads(cmd_output.communicate()[0].strip())
-            status = changed_cmd['status']['conditions'][-1]['type']
+            status = changed_cmd["status"]["conditions"][-1]["type"]
 
-            if (status == "Terminating"):
-                patch_cmd = [kubectl_client_location, "patch", "crd",
-                             crds, "--type=merge", "--patch-file", yaml_file_path]
+            if status == "Terminating":
+                patch_cmd = [
+                    kubectl_client_location,
+                    "patch",
+                    "crd",
+                    crds,
+                    "--type=merge",
+                    "--patch-file",
+                    yaml_file_path,
+                ]
                 if kube_config:
                     patch_cmd.extend(["--kubeconfig", kube_config])
                 if kube_context:
@@ -3229,28 +4755,48 @@ def crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
 
 
 def check_operation_support(operation_name, agent_version):
-    error_summary = 'This CLI version does not support {} for Agents older than v1.14'.format(operation_name)
+    error_summary = (
+        "This CLI version does not support {} for Agents older than v1.14".format(
+            operation_name
+        )
+    )
     # Version check for stable release train (agent_version will be in X.Y.Z format as opposed to X.Y.Z-NONSTABLE)
-    if '-' not in agent_version and (version.parse(agent_version) < version.parse("1.14.0")):
-        telemetry.set_exception(exception='Operation not supported on older Agents',
-                                fault_type=consts.Operation_Not_Supported_Fault_Type, summary=error_summary)
+    if "-" not in agent_version and (
+        version.parse(agent_version) < version.parse("1.14.0")
+    ):
+        telemetry.set_exception(
+            exception="Operation not supported on older Agents",
+            fault_type=consts.Operation_Not_Supported_Fault_Type,
+            summary=error_summary,
+        )
         raise ClientRequestError(
             error_summary,
-            recommendation="Please upgrade to the latest version of the Agents using 'az connectedk8s upgrade -g " +
-                           "<rg_name> -n <cluster_name>'.")
+            recommendation="Please upgrade to the latest version of the Agents using 'az connectedk8s upgrade -g "
+            + "<rg_name> -n <cluster_name>'.",
+        )
 
 
-def add_config_protected_settings(https_proxy, http_proxy, no_proxy, proxy_cert, container_log_path, configuration_settings, configuration_protected_settings):
+def add_config_protected_settings(
+    https_proxy,
+    http_proxy,
+    no_proxy,
+    proxy_cert,
+    container_log_path,
+    configuration_settings,
+    configuration_protected_settings,
+):
     redacted_protected_values = {}
     # Initialize configuration_protected_settings if it is None
     if configuration_protected_settings is None:
         configuration_protected_settings = {}
-    
+
     if configuration_settings is None:
         configuration_settings = {}
 
     if container_log_path:
-        configuration_settings.setdefault("logging", {"container_log_path": container_log_path})
+        configuration_settings.setdefault(
+            "logging", {"container_log_path": container_log_path}
+        )
     if any([https_proxy, http_proxy, no_proxy, proxy_cert]):
         configuration_protected_settings.setdefault("proxy", {})
         configuration_settings.setdefault("proxy", {})
@@ -3267,6 +4813,12 @@ def add_config_protected_settings(https_proxy, http_proxy, no_proxy, proxy_cert,
         for setting, _ in protected_settings.items():
             if feature not in redacted_protected_values:
                 redacted_protected_values[feature] = {}
-            redacted_protected_values[feature][setting] = f"redacted-{feature}-{setting}"
+            redacted_protected_values[feature][setting] = (
+                f"redacted-{feature}-{setting}"
+            )
 
-    return configuration_settings, configuration_protected_settings, redacted_protected_values
+    return (
+        configuration_settings,
+        configuration_protected_settings,
+        redacted_protected_values,
+    )

--- a/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
+++ b/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
@@ -18,10 +18,10 @@ from knack.log import get_logger
 from azure.cli.core import get_default_cli
 import subprocess
 from subprocess import PIPE
-from azure.cli.testsdk import (LiveScenarioTest, ResourceGroupPreparer, live_only)  # pylint: disable=import-error
+from azure.cli.testsdk import LiveScenarioTest, ResourceGroupPreparer, live_only  # pylint: disable=import-error
 from azure.cli.core.azclierror import RequiredArgumentMissingError, ValidationError
 
-TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
+TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), ".."))
 logger = get_logger(__name__)
 
 # Set up configuration file. If configuration file is not found, then auto-populate with fake values where allowed.
@@ -31,7 +31,7 @@ if not os.path.isfile(config_path):
     CONFIG["customLocationsOid"] = ""
     CONFIG["location"] = "eastus2euap"
 else:
-    with open(config_path, 'r') as f:
+    with open(config_path, "r") as f:
         CONFIG = json.load(f)
     for key in CONFIG:
         if not CONFIG[key]:
@@ -42,34 +42,46 @@ properties are populated.")
 def _get_test_data_file(filename):
     # Don't output temporary test data to "**/azext_connectedk8s/tests/latest/data/" as that location
     # is for re-usable test data files by Azure CLI repositories convention.
-    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
-        os.path.realpath(__file__)))))))
-    return os.path.join(root, "temp", filename).replace('\\', '\\\\')
+    root = os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+                )
+            )
+        )
+    )
+    return os.path.join(root, "temp", filename).replace("\\", "\\\\")
 
 
 def install_helm_client():
-
     # Fetch system related info
     operating_system = platform.system().lower()
 
     # Set helm binary download & install locations
-    if (operating_system == 'windows'):
-        download_location_string = f'.azure\\helm\\{consts.HELM_VERSION}\\helm-{consts.HELM_VERSION}-\
-            {operating_system}-amd64.zip'
-        install_location_string = f'.azure\\helm\\{consts.HELM_VERSION}\\{operating_system}-amd64\\helm.exe'
-        requestUri = f'{consts.HELM_STORAGE_URL}/helm/helm-{consts.HELM_VERSION}-{operating_system}-amd64.zip'
-    elif (operating_system == 'linux' or operating_system == 'darwin'):
-        download_location_string = f'.azure/helm/{consts.HELM_VERSION}/helm-{consts.HELM_VERSION}-\
-            {operating_system}-amd64.tar.gz'
-        install_location_string = f'.azure/helm/{consts.HELM_VERSION}/{operating_system}-amd64/helm'
-        requestUri = f'{consts.HELM_STORAGE_URL}/helm/helm-{consts.HELM_VERSION}-{operating_system}-amd64.tar.gz'
+    if operating_system == "windows":
+        download_location_string = f".azure\\helm\\{consts.HELM_VERSION}\\helm-{consts.HELM_VERSION}-\
+            {operating_system}-amd64.zip"
+        install_location_string = (
+            f".azure\\helm\\{consts.HELM_VERSION}\\{operating_system}-amd64\\helm.exe"
+        )
+        requestUri = f"{consts.HELM_STORAGE_URL}/helm/helm-{consts.HELM_VERSION}-{operating_system}-amd64.zip"
+    elif operating_system == "linux" or operating_system == "darwin":
+        download_location_string = f".azure/helm/{consts.HELM_VERSION}/helm-{consts.HELM_VERSION}-\
+            {operating_system}-amd64.tar.gz"
+        install_location_string = (
+            f".azure/helm/{consts.HELM_VERSION}/{operating_system}-amd64/helm"
+        )
+        requestUri = f"{consts.HELM_STORAGE_URL}/helm/helm-{consts.HELM_VERSION}-{operating_system}-amd64.tar.gz"
     else:
-        logger.warning(f'The {operating_system} platform is not currently supported for installing helm client.')
+        logger.warning(
+            f"The {operating_system} platform is not currently supported for installing helm client."
+        )
         return
 
-    download_location = os.path.expanduser(os.path.join('~', download_location_string))
+    download_location = os.path.expanduser(os.path.join("~", download_location_string))
     download_dir = os.path.dirname(download_location)
-    install_location = os.path.expanduser(os.path.join('~', install_location_string))
+    install_location = os.path.expanduser(os.path.join("~", install_location_string))
 
     # Download compressed helm binary if not already present
     if not os.path.isfile(download_location):
@@ -93,7 +105,7 @@ def install_helm_client():
 
         # Creating the compressed helm binaries
         try:
-            with open(download_location, 'wb') as f:
+            with open(download_location, "wb") as f:
                 f.write(responseContent)
         except Exception as e:
             logger.warning("Failed to extract helm executable" + str(e))
@@ -114,10 +126,9 @@ def install_helm_client():
 def install_kubectl_client():
     # Return kubectl client path set by user
     try:
-
         # Fetching the current directory where the cli installs the kubectl executable
-        home_dir = os.path.expanduser('~')
-        kubectl_filepath = os.path.join(home_dir, '.azure', 'kubectl-client')
+        home_dir = os.path.expanduser("~")
+        kubectl_filepath = os.path.join(home_dir, ".azure", "kubectl-client")
 
         try:
             os.mkdir(kubectl_filepath)
@@ -126,20 +137,22 @@ def install_kubectl_client():
 
         operating_system = platform.system().lower()
         # Setting path depending on the OS being used
-        if operating_system == 'windows':
-            kubectl_path = os.path.join(kubectl_filepath, 'kubectl.exe')
-        elif operating_system == 'linux' or operating_system == 'darwin':
-            kubectl_path = os.path.join(kubectl_filepath, 'kubectl')
+        if operating_system == "windows":
+            kubectl_path = os.path.join(kubectl_filepath, "kubectl.exe")
+        elif operating_system == "linux" or operating_system == "darwin":
+            kubectl_path = os.path.join(kubectl_filepath, "kubectl")
         else:
-            logger.warning(f'The {operating_system} platform is not currently supported for installing kubectl \
-client.')
+            logger.warning(f"The {operating_system} platform is not currently supported for installing kubectl \
+client.")
             return
 
         if os.path.isfile(kubectl_path):
             return kubectl_path
 
         # Downloading kubectl executable if its not present in the machine
-        get_default_cli().invoke(['aks', 'install-cli', '--install-location', kubectl_path])
+        get_default_cli().invoke(
+            ["aks", "install-cli", "--install-location", kubectl_path]
+        )
         # Return the path of the kubectl executable
         return kubectl_path
 
@@ -149,553 +162,788 @@ client.')
 
 
 class Connectedk8sScenarioTest(LiveScenarioTest):
-
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
-    def test_connect(self,resource_group):
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
+    def test_connect(self, resource_group):
         # os.environ.setdefault('HELMREGISTRY', 'mcr.microsoft.com/azurearck8s/batch1/preview/azure-arc-k8sagents:\
-            # 1.1.59-preview')
-        
-        managed_cluster_name = self.create_random_name(prefix='test-connect', length=24)
-        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
-        self.kwargs.update({
-            'rg': resource_group,
-            'name': self.create_random_name(prefix='cc-', length=12),
-            'kubeconfig': kubeconfig,
-            'managed_cluster_name': managed_cluster_name,
-            'location': CONFIG['location']
-        })
+        # 1.1.59-preview')
 
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('name', '{name}')
-        ])
+        managed_cluster_name = self.create_random_name(prefix="test-connect", length=24)
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
+        self.kwargs.update(
+            {
+                "rg": resource_group,
+                "name": self.create_random_name(prefix="cc-", length=12),
+                "kubeconfig": kubeconfig,
+                "managed_cluster_name": managed_cluster_name,
+                "location": CONFIG["location"],
+            }
+        )
 
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin",
+            checks=[
+                self.check("tags.foo", "doo"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("name", "{name}"),
+            ],
+        )
+
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
-        
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))
+
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
-    def test_connect_withoidcandworkloadidentity(self,resource_group):
-        managed_cluster_name = self.create_random_name(prefix='test-connect', length=24)
-        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
-        self.kwargs.update({
-            'rg': resource_group,
-            'name': self.create_random_name(prefix='cc-', length=12),
-            'kubeconfig': kubeconfig,
-            'managed_cluster_name': managed_cluster_name,
-            'location': CONFIG['location']
-        })
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
+    def test_connect_withoidcandworkloadidentity(self, resource_group):
+        managed_cluster_name = self.create_random_name(prefix="test-connect", length=24)
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
+        self.kwargs.update(
+            {
+                "rg": resource_group,
+                "name": self.create_random_name(prefix="cc-", length=12),
+                "kubeconfig": kubeconfig,
+                "managed_cluster_name": managed_cluster_name,
+                "location": CONFIG["location"],
+            }
+        )
 
         # scenario - oidc issuer and workload identity enabled
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -n {name} -g {rg} -l {location} --tags foo=doo --enable-oidc-issuer \
-            --enable-workload-identity --kube-config {kubeconfig} --kube-context {managed_cluster_name}-admin')
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('oidcIssuerProfile.enabled', True),
-            self.check('securityProfile.workloadIndentity.enabled', True)
-        ])
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -n {name} -g {rg} -l {location} --tags foo=doo --enable-oidc-issuer \
+            --enable-workload-identity --kube-config {kubeconfig} --kube-context {managed_cluster_name}-admin"
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("tags.foo", "doo"),
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("oidcIssuerProfile.enabled", True),
+                self.check("securityProfile.workloadIndentity.enabled", True),
+            ],
+        )
 
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
-        
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))
+
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
-    def test_connect_withoidcandselfhostedissuer(self,resource_group):
-        managed_cluster_name = self.create_random_name(prefix='test-connect', length=24)
-        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
-        self.kwargs.update({
-            'rg': resource_group,
-            'name': self.create_random_name(prefix='cc-', length=12),
-            'kubeconfig': kubeconfig,
-            'managed_cluster_name': managed_cluster_name,
-            'location': CONFIG['location']
-        })
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
+    def test_connect_withoidcandselfhostedissuer(self, resource_group):
+        managed_cluster_name = self.create_random_name(prefix="test-connect", length=24)
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
+        self.kwargs.update(
+            {
+                "rg": resource_group,
+                "name": self.create_random_name(prefix="cc-", length=12),
+                "kubeconfig": kubeconfig,
+                "managed_cluster_name": managed_cluster_name,
+                "location": CONFIG["location"],
+            }
+        )
 
         # scenario - oidc issuer enabled and self hosted issuer url set
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -n {name} -g {rg} -l {location} --tags foo=doo --enable-oidc-issuer \
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            'connectedk8s connect -n {name} -g {rg} -l {location} --tags foo=doo --enable-oidc-issuer \
             --self-hosted-issuer "https://oidcissuer-selfhosted.azure.net/" --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin')
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('oidcIssuerProfile.enabled', True),
-            self.check('oidcIssuerProfile.selfHostedIssuerUrl', 'https://oidcissuer-selfhosted.azure.net/')
-        ])
+            --kube-context {managed_cluster_name}-admin'
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("tags.foo", "doo"),
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("oidcIssuerProfile.enabled", True),
+                self.check(
+                    "oidcIssuerProfile.selfHostedIssuerUrl",
+                    "https://oidcissuer-selfhosted.azure.net/",
+                ),
+            ],
+        )
 
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))
 
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
-    def test_forcedelete(self,resource_group):
-        managed_cluster_name = self.create_random_name(prefix='test-force-delete', length=24)
-        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
-        self.kwargs.update({
-            'rg': resource_group,
-            'name': self.create_random_name(prefix = 'cc-', length = 12),
-            'kubeconfig': kubeconfig,
-            'managed_cluster_name': managed_cluster_name,
-            'location': CONFIG['location']
-        })
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
+    def test_forcedelete(self, resource_group):
+        managed_cluster_name = self.create_random_name(
+            prefix="test-force-delete", length=24
+        )
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
+        self.kwargs.update(
+            {
+                "rg": resource_group,
+                "name": self.create_random_name(prefix="cc-", length=12),
+                "kubeconfig": kubeconfig,
+                "managed_cluster_name": managed_cluster_name,
+                "location": CONFIG["location"],
+            }
+        )
 
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}')
-        ])
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('tags.foo', 'doo')
-        ])
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin",
+            checks=[self.check("tags.foo", "doo"), self.check("name", "{name}")],
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("tags.foo", "doo"),
+            ],
+        )
 
         # Simulating the condition in which the azure-arc namespace got deleted
         # connectedk8s delete command fails in this case
         kubectl_client_location = install_kubectl_client()
-        subprocess.run([kubectl_client_location, "delete", "namespace", "azure-arc", "--kube-config", kubeconfig])
+        subprocess.run(
+            [
+                kubectl_client_location,
+                "delete",
+                "namespace",
+                "azure-arc",
+                "--kube-config",
+                kubeconfig,
+            ]
+        )
 
         # Using the force delete command
         # -y to supress the prompts
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin --force -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin --force -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
-
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))
 
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
-    def test_enable_disable_features(self,resource_group):
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
+    def test_enable_disable_features(self, resource_group):
         # os.environ.setdefault('HELMREGISTRY', 'mcr.microsoft.com/azurearck8s/batch1/preview/azure-arc-k8sagents:\
-            # 1.1.59-preview')
+        # 1.1.59-preview')
 
-        managed_cluster_name = self.create_random_name(prefix='test-enable-disable', length=24)
-        kubeconfig="%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
+        managed_cluster_name = self.create_random_name(
+            prefix="test-enable-disable", length=24
+        )
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
 
-        if CONFIG['customLocationsOid'] is None or CONFIG['customLocationsOid'] == "":
+        if CONFIG["customLocationsOid"] is None or CONFIG["customLocationsOid"] == "":
             cli = get_default_cli()
-            cli.invoke(["ad", "sp", "list", "--filter", "displayName eq 'Custom Locations RP'"])
+            cli.invoke(
+                ["ad", "sp", "list", "--filter", "displayName eq 'Custom Locations RP'"]
+            )
             if cli.result.exit_code != 0:
                 raise cli.result.error
-            CONFIG['customLocationsOid'] = cli.result.result[0]["id"]
+            CONFIG["customLocationsOid"] = cli.result.result[0]["id"]
 
-        self.kwargs.update({
-            'rg': resource_group,
-            'name': self.create_random_name(prefix='cc-', length=12),
-            'kubeconfig': kubeconfig,
-            'managed_cluster_name': managed_cluster_name,
-            'custom_locations_oid': CONFIG['customLocationsOid'],
-            'location': CONFIG['location']
-        })
+        self.kwargs.update(
+            {
+                "rg": resource_group,
+                "name": self.create_random_name(prefix="cc-", length=12),
+                "kubeconfig": kubeconfig,
+                "managed_cluster_name": managed_cluster_name,
+                "custom_locations_oid": CONFIG["customLocationsOid"],
+                "location": CONFIG["location"],
+            }
+        )
 
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}')
-        ])
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('tags.foo', 'doo')
-        ])
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin",
+            checks=[self.check("tags.foo", "doo"), self.check("name", "{name}")],
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("tags.foo", "doo"),
+            ],
+        )
 
-        os.environ.setdefault('KUBECONFIG', kubeconfig)
+        os.environ.setdefault("KUBECONFIG", kubeconfig)
         helm_client_location = install_helm_client()
-        cmd = [helm_client_location, 'get', 'values', 'azure-arc', "--namespace", "azure-arc-release", "-ojson"]
+        cmd = [
+            helm_client_location,
+            "get",
+            "values",
+            "azure-arc",
+            "--namespace",
+            "azure-arc-release",
+            "-ojson",
+        ]
 
         # scenario-1 : custom loc disabled and custom loc enabled (should be successfull as there is no dependency)
-        self.cmd('connectedk8s disable-features -n {name} -g {rg} --features custom-locations --kube-config \
-            {kubeconfig} --kube-context {managed_cluster_name}-admin -y')
+        self.cmd(
+            "connectedk8s disable-features -n {name} -g {rg} --features custom-locations --kube-config \
+            {kubeconfig} --kube-context {managed_cluster_name}-admin -y"
+        )
         cmd_output = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, error_helm_delete = cmd_output.communicate()
-        assert(cmd_output.returncode == 0)
+        assert cmd_output.returncode == 0
         changed_cmd = json.loads(cmd_output.communicate()[0].strip())
-        assert(changed_cmd["systemDefaultValues"]['customLocations']['enabled'] == bool(0))
+        assert changed_cmd["systemDefaultValues"]["customLocations"]["enabled"] == bool(
+            0
+        )
 
-        self.cmd('connectedk8s enable-features -n {name} -g {rg} --features custom-locations --kube-config \
-            {kubeconfig} --kube-context {managed_cluster_name}-admin --custom-locations-oid {custom_locations_oid}')
+        self.cmd(
+            "connectedk8s enable-features -n {name} -g {rg} --features custom-locations --kube-config \
+            {kubeconfig} --kube-context {managed_cluster_name}-admin --custom-locations-oid {custom_locations_oid}"
+        )
         cmd_output1 = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, error_helm_delete = cmd_output1.communicate()
-        assert(cmd_output1.returncode == 0)
+        assert cmd_output1.returncode == 0
         enabled_cmd1 = json.loads(cmd_output1.communicate()[0].strip())
-        assert(enabled_cmd1["systemDefaultValues"]['customLocations']['enabled'] == bool(1))
+        assert enabled_cmd1["systemDefaultValues"]["customLocations"][
+            "enabled"
+        ] == bool(1)
 
         # scenario-2 : custom loc is enabled , check if disabling cluster connect results in an error
-        with self.assertRaisesRegexp(CLIError, "Disabling 'cluster-connect' feature is not allowed when \
-'custom-locations' feature is enabled."):
-            self.cmd('connectedk8s disable-features -n {name} -g {rg} --features cluster-connect --kube-config \
-                {kubeconfig} --kube-context {managed_cluster_name}-admin -y')
+        with self.assertRaisesRegexp(
+            CLIError,
+            "Disabling 'cluster-connect' feature is not allowed when \
+'custom-locations' feature is enabled.",
+        ):
+            self.cmd(
+                "connectedk8s disable-features -n {name} -g {rg} --features cluster-connect --kube-config \
+                {kubeconfig} --kube-context {managed_cluster_name}-admin -y"
+            )
 
         # scenario-3 : disable custom location and cluster connect , then enable custom loc and check if cluster \
-            # connect also gets on
-        self.cmd('connectedk8s disable-features -n {name} -g {rg} --features custom-locations --kube-config \
-            {kubeconfig} --kube-context {managed_cluster_name}-admin -y')
+        # connect also gets on
+        self.cmd(
+            "connectedk8s disable-features -n {name} -g {rg} --features custom-locations --kube-config \
+            {kubeconfig} --kube-context {managed_cluster_name}-admin -y"
+        )
         cmd_output1 = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, error_helm_delete = cmd_output1.communicate()
-        assert(cmd_output1.returncode == 0)
+        assert cmd_output1.returncode == 0
         disabled_cmd1 = json.loads(cmd_output1.communicate()[0].strip())
-        assert(disabled_cmd1["systemDefaultValues"]['customLocations']['enabled'] == bool(0))
+        assert disabled_cmd1["systemDefaultValues"]["customLocations"][
+            "enabled"
+        ] == bool(0)
 
-        self.cmd('connectedk8s disable-features -n {name} -g {rg} --features cluster-connect --kube-config \
-            {kubeconfig} --kube-context {managed_cluster_name}-admin -y')
+        self.cmd(
+            "connectedk8s disable-features -n {name} -g {rg} --features cluster-connect --kube-config \
+            {kubeconfig} --kube-context {managed_cluster_name}-admin -y"
+        )
         cmd_output1 = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, error_helm_delete = cmd_output1.communicate()
-        assert(cmd_output1.returncode == 0)
+        assert cmd_output1.returncode == 0
         disabled_cmd1 = json.loads(cmd_output1.communicate()[0].strip())
-        assert(disabled_cmd1["systemDefaultValues"]['clusterconnect-agent']['enabled'] == bool(0))
+        assert disabled_cmd1["systemDefaultValues"]["clusterconnect-agent"][
+            "enabled"
+        ] == bool(0)
 
-        self.cmd('connectedk8s enable-features -n {name} -g {rg} --features custom-locations --kube-config \
-            {kubeconfig} --kube-context {managed_cluster_name}-admin --custom-locations-oid {custom_locations_oid}')
+        self.cmd(
+            "connectedk8s enable-features -n {name} -g {rg} --features custom-locations --kube-config \
+            {kubeconfig} --kube-context {managed_cluster_name}-admin --custom-locations-oid {custom_locations_oid}"
+        )
         cmd_output1 = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, error_helm_delete = cmd_output1.communicate()
-        assert(cmd_output1.returncode == 0)
+        assert cmd_output1.returncode == 0
         enabled_cmd1 = json.loads(cmd_output1.communicate()[0].strip())
-        assert(enabled_cmd1["systemDefaultValues"]['customLocations']['enabled'] == bool(1))
-        assert(enabled_cmd1["systemDefaultValues"]['clusterconnect-agent']['enabled'] == bool(1))
+        assert enabled_cmd1["systemDefaultValues"]["customLocations"][
+            "enabled"
+        ] == bool(1)
+        assert enabled_cmd1["systemDefaultValues"]["clusterconnect-agent"][
+            "enabled"
+        ] == bool(1)
 
         # scenario-4: azure rbac turned off and turning azure rbac on again using 1P
-        self.cmd('connectedk8s disable-features -n {name} -g {rg} --features azure-rbac --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin -y')
+        self.cmd(
+            "connectedk8s disable-features -n {name} -g {rg} --features azure-rbac --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin -y"
+        )
         cmd_output1 = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, error_helm_delete = cmd_output1.communicate()
-        assert(cmd_output1.returncode == 0)
+        assert cmd_output1.returncode == 0
         disabled_cmd1 = json.loads(cmd_output1.communicate()[0].strip())
-        assert(disabled_cmd1["systemDefaultValues"]['guard']['enabled'] == bool(0))
+        assert disabled_cmd1["systemDefaultValues"]["guard"]["enabled"] == bool(0)
 
-        self.cmd('az connectedk8s enable-features -n {name} -g {rg} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin --features azure-rbac')
+        self.cmd(
+            "az connectedk8s enable-features -n {name} -g {rg} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin --features azure-rbac"
+        )
 
         # deleting the cluster
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
-
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))
 
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
-    def test_connectedk8s_list(self,resource_group):
-        managed_cluster_name = self.create_random_name(prefix='first', length=24)
-        managed_cluster_name_second = self.create_random_name(prefix='second', length=24)
-        kubeconfig="%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
-        kubeconfigpls="%s" % (_get_test_data_file('pls-config.yaml'))
-        name = self.create_random_name(prefix='cc-', length=12)
-        name_second = self.create_random_name(prefix='cc-', length=12)
-        managed_cluster_list=[]
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
+    def test_connectedk8s_list(self, resource_group):
+        managed_cluster_name = self.create_random_name(prefix="first", length=24)
+        managed_cluster_name_second = self.create_random_name(
+            prefix="second", length=24
+        )
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
+        kubeconfigpls = "%s" % (_get_test_data_file("pls-config.yaml"))
+        name = self.create_random_name(prefix="cc-", length=12)
+        name_second = self.create_random_name(prefix="cc-", length=12)
+        managed_cluster_list = []
         managed_cluster_list.append(name)
         managed_cluster_list.append(name_second)
         managed_cluster_list.sort()
-        self.kwargs.update({
-            'rg': resource_group,
-            'name': name,
-            'name_second': name_second,
-            'kubeconfig': kubeconfig,
-            'kubeconfigpls': kubeconfigpls,
-            'managed_cluster_name': managed_cluster_name,
-            'managed_cluster_name_second': managed_cluster_name_second,
-            'location': CONFIG['location']
-        })
+        self.kwargs.update(
+            {
+                "rg": resource_group,
+                "name": name,
+                "name_second": name_second,
+                "kubeconfig": kubeconfig,
+                "kubeconfigpls": kubeconfigpls,
+                "managed_cluster_name": managed_cluster_name,
+                "managed_cluster_name_second": managed_cluster_name_second,
+                "location": CONFIG["location"],
+            }
+        )
         # create two clusters and then list the cluster names
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}')
-        ])
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('tags.foo', 'doo')
-        ])
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin",
+            checks=[self.check("tags.foo", "doo"), self.check("name", "{name}")],
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("tags.foo", "doo"),
+            ],
+        )
 
-        self.cmd('aks create -g {rg} -n {managed_cluster_name_second} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name_second} -f {kubeconfigpls} --admin')
-        self.cmd('connectedk8s connect -g {rg} -n {name_second} -l {location} --tags foo=doo --kube-config \
-            {kubeconfigpls} --kube-context {managed_cluster_name_second}-admin', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name_second}')
-        ])
-        self.cmd('connectedk8s show -g {rg} -n {name_second}', checks=[
-            self.check('name', '{name_second}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('tags.foo', 'doo')
-        ])
+        self.cmd(
+            "aks create -g {rg} -n {managed_cluster_name_second} --generate-ssh-keys"
+        )
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name_second} -f {kubeconfigpls} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name_second} -l {location} --tags foo=doo --kube-config \
+            {kubeconfigpls} --kube-context {managed_cluster_name_second}-admin",
+            checks=[self.check("tags.foo", "doo"), self.check("name", "{name_second}")],
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name_second}",
+            checks=[
+                self.check("name", "{name_second}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("tags.foo", "doo"),
+            ],
+        )
 
-        clusters_list = self.cmd('az connectedk8s list -g {rg}').get_output_in_json()
+        clusters_list = self.cmd("az connectedk8s list -g {rg}").get_output_in_json()
         # fetching names of all clusters
-        cluster_name_list=[]
+        cluster_name_list = []
         for clusterdesc in clusters_list:
-            cluster_name_list.append(clusterdesc['name'])
+            cluster_name_list.append(clusterdesc["name"])
 
-        assert(len(cluster_name_list) == len(managed_cluster_list))
+        assert len(cluster_name_list) == len(managed_cluster_list)
 
         # checking if the output is correct with original list of cluster names
         cluster_name_list.sort()
-        for i in range(0,len(cluster_name_list)):
-            assert(cluster_name_list[i] == managed_cluster_list[i])
+        for i in range(0, len(cluster_name_list)):
+            assert cluster_name_list[i] == managed_cluster_list[i]
 
         # deleting the clusters
-        self.cmd('connectedk8s delete -g {rg} -n {name_second} --kube-config {kubeconfigpls} --kube-context \
-            {managed_cluster_name_second}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name_second} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name_second} --kube-config {kubeconfigpls} --kube-context \
+            {managed_cluster_name_second}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name_second} -y")
 
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
-        os.remove("%s" % (_get_test_data_file('pls-config.yaml')))
-
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))
+        os.remove("%s" % (_get_test_data_file("pls-config.yaml")))
 
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
-    def test_upgrade(self,resource_group):
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
+    def test_upgrade(self, resource_group):
         # os.environ.setdefault('HELMREGISTRY', 'mcr.microsoft.com/azurearck8s/batch1/preview/azure-arc-k8sagents:\
-            # 1.1.59-preview')
+        # 1.1.59-preview')
 
-        managed_cluster_name = self.create_random_name(prefix='test-upgrade', length=24)
-        kubeconfig="%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
-        self.kwargs.update({
-            'name': self.create_random_name(prefix='cc-', length=12),
-            'rg': resource_group,
-            'kubeconfig': kubeconfig,
-            'managed_cluster_name': managed_cluster_name,
-            'location': CONFIG['location']
-        })
+        managed_cluster_name = self.create_random_name(prefix="test-upgrade", length=24)
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
+        self.kwargs.update(
+            {
+                "name": self.create_random_name(prefix="cc-", length=12),
+                "rg": resource_group,
+                "kubeconfig": kubeconfig,
+                "managed_cluster_name": managed_cluster_name,
+                "location": CONFIG["location"],
+            }
+        )
 
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
 
-        self.cmd('connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}')
-        ])
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('tags.foo', 'doo')
-        ])
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin",
+            checks=[self.check("tags.foo", "doo"), self.check("name", "{name}")],
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("tags.foo", "doo"),
+            ],
+        )
 
-        os.environ.setdefault('KUBECONFIG', kubeconfig)
+        os.environ.setdefault("KUBECONFIG", kubeconfig)
         helm_client_location = install_helm_client()
-        cmd = [helm_client_location, 'get', 'values', 'azure-arc', "--namespace", "azure-arc-release", "-ojson"]
+        cmd = [
+            helm_client_location,
+            "get",
+            "values",
+            "azure-arc",
+            "--namespace",
+            "azure-arc-release",
+            "-ojson",
+        ]
 
-        with self.assertRaisesRegexp(CLIError, "az connectedk8s upgrade to manually upgrade agents and extensions is \
-only supported when auto-upgrade is set to false"):
-            self.cmd('connectedk8s upgrade -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-                {managed_cluster_name}-admin')
+        with self.assertRaisesRegexp(
+            CLIError,
+            "az connectedk8s upgrade to manually upgrade agents and extensions is \
+only supported when auto-upgrade is set to false",
+        ):
+            self.cmd(
+                "connectedk8s upgrade -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+                {managed_cluster_name}-admin"
+            )
 
         # scenario - Turning off auto upgrade ,then updating agnets to latest and check if the version of agents \
-            # matches with latest version
-        self.cmd('connectedk8s update -n {name} -g {rg} --auto-upgrade false --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin')
+        # matches with latest version
+        self.cmd(
+            "connectedk8s update -n {name} -g {rg} --auto-upgrade false --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin"
+        )
         cmd_output1 = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, error_helm_delete = cmd_output1.communicate()
-        assert(cmd_output1.returncode == 0)
+        assert cmd_output1.returncode == 0
         updated_cmd1 = json.loads(cmd_output1.communicate()[0].strip())
-        assert(updated_cmd1["systemDefaultValues"]['azureArcAgents']['autoUpdate'] == bool(0))
+        assert updated_cmd1["systemDefaultValues"]["azureArcAgents"][
+            "autoUpdate"
+        ] == bool(0)
 
-        self.cmd('connectedk8s upgrade -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin')
+        self.cmd(
+            "connectedk8s upgrade -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin"
+        )
         response = requests.post(f'https://{CONFIG["location"]}.dp.kubernetesconfiguration.azure.com/azure-\
             arc-k8sagents/GetLatestHelmPackagePath?api-version=2019-11-01-preview&releaseTrain=stable')
         jsonData = json.loads(response.text)
-        repo_path = jsonData['repositoryPath']
+        repo_path = jsonData["repositoryPath"]
         index_value = 0
         for ind in range(0, len(repo_path)):
-            if repo_path[ind] == ':':
+            if repo_path[ind] == ":":
                 break
             index_value += 1
 
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('agentVersion', jsonData['repositoryPath'][index_value + 1:]),
-        ])
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check(
+                    "agentVersion", jsonData["repositoryPath"][index_value + 1 :]
+                ),
+            ],
+        )
 
         # scenario : changing the upgrade timeout
-        self.cmd('connectedk8s upgrade -g {rg} -n {name} --upgrade-timeout 650 --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin')
+        self.cmd(
+            "connectedk8s upgrade -g {rg} -n {name} --upgrade-timeout 650 --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin"
+        )
 
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))
 
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
     def test_update(self, resource_group):
         # os.environ.setdefault('HELMREGISTRY', 'mcr.microsoft.com/azurearck8s/batch1/preview/azure-arc-k8sagents:\
-            # 1.1.59-preview')
+        # 1.1.59-preview')
 
-        managed_cluster_name = self.create_random_name(prefix='test-update', length=24)
-        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
-        self.kwargs.update({
-            'name': self.create_random_name(prefix='cc-', length=12),
-            'kubeconfig': kubeconfig,
-            'rg': resource_group,
-            'managed_cluster_name': managed_cluster_name,
-            'location': CONFIG['location']
-        })
+        managed_cluster_name = self.create_random_name(prefix="test-update", length=24)
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
+        self.kwargs.update(
+            {
+                "name": self.create_random_name(prefix="cc-", length=12),
+                "kubeconfig": kubeconfig,
+                "rg": resource_group,
+                "managed_cluster_name": managed_cluster_name,
+                "location": CONFIG["location"],
+            }
+        )
 
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}')
-        ])
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('tags.foo', 'doo')
-        ])
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin",
+            checks=[self.check("tags.foo", "doo"), self.check("name", "{name}")],
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("tags.foo", "doo"),
+            ],
+        )
 
-        os.environ.setdefault('KUBECONFIG', kubeconfig)
+        os.environ.setdefault("KUBECONFIG", kubeconfig)
         helm_client_location = install_helm_client()
-        cmd = [helm_client_location, 'get', 'values', 'azure-arc', "--namespace", "azure-arc-release", "-ojson"]
+        cmd = [
+            helm_client_location,
+            "get",
+            "values",
+            "azure-arc",
+            "--namespace",
+            "azure-arc-release",
+            "-ojson",
+        ]
 
         # scenario - auto-upgrade is turned on
-        self.cmd('connectedk8s update -n {name} -g {rg} --auto-upgrade true --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin')
+        self.cmd(
+            "connectedk8s update -n {name} -g {rg} --auto-upgrade true --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin"
+        )
         cmd_output1 = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, error_helm_delete = cmd_output1.communicate()
-        assert (cmd_output1.returncode == 0)
+        assert cmd_output1.returncode == 0
         updated_cmd1 = json.loads(cmd_output1.communicate()[0].strip())
-        assert (updated_cmd1["systemDefaultValues"]['azureArcAgents']['autoUpdate'] == bool(1))
+        assert updated_cmd1["systemDefaultValues"]["azureArcAgents"][
+            "autoUpdate"
+        ] == bool(1)
 
         # scenario - auto-upgrade is turned off
-        self.cmd('connectedk8s update -n {name} -g {rg} --auto-upgrade false --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin')
+        self.cmd(
+            "connectedk8s update -n {name} -g {rg} --auto-upgrade false --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin"
+        )
         cmd_output1 = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
         _, error_helm_delete = cmd_output1.communicate()
-        assert (cmd_output1.returncode == 0)
+        assert cmd_output1.returncode == 0
         updated_cmd1 = json.loads(cmd_output1.communicate()[0].strip())
-        assert (updated_cmd1["systemDefaultValues"]['azureArcAgents']['autoUpdate'] == bool(0))
+        assert updated_cmd1["systemDefaultValues"]["azureArcAgents"][
+            "autoUpdate"
+        ] == bool(0)
 
         # scenario - updating the tags
-        self.cmd('connectedk8s update -n {name} -g {rg} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin --tags foo=moo')
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('tags.foo', 'moo')
-        ])
-        
+        self.cmd(
+            "connectedk8s update -n {name} -g {rg} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin --tags foo=moo"
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("tags.foo", "moo"),
+            ],
+        )
+
         # scenario - oidc issuer and workload identity enabled
-        self.cmd('connectedk8s update -n {name} -g {rg} --enable-oidc-issuer \
+        self.cmd(
+            "connectedk8s update -n {name} -g {rg} --enable-oidc-issuer \
             --enable-workload-identity --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin')
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('oidcIssuerProfile.enabled', True),
-            self.check('securityProfile.workloadIndentity.enabled', True)
-        ])
-        
+            --kube-context {managed_cluster_name}-admin"
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("oidcIssuerProfile.enabled", True),
+                self.check("securityProfile.workloadIndentity.enabled", True),
+            ],
+        )
+
         # scenario - oidc issuer enabled and self hosted issuer url set
-        self.cmd('connectedk8s update -n {name} -g {rg} --enable-oidc-issuer \
+        self.cmd(
+            'connectedk8s update -n {name} -g {rg} --enable-oidc-issuer \
             --self-hosted-issuer "https://oidcissuer-selfhosted.azure.net/" --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin')
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('oidcIssuerProfile.enabled', True),
-            self.check('oidcIssuerProfile.selfHostedIssuerUrl', 'https://oidcissuer-selfhosted.azure.net/')
-        ])
+            --kube-context {managed_cluster_name}-admin'
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("oidcIssuerProfile.enabled", True),
+                self.check(
+                    "oidcIssuerProfile.selfHostedIssuerUrl",
+                    "https://oidcissuer-selfhosted.azure.net/",
+                ),
+            ],
+        )
 
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))
 
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
     def test_troubleshoot(self, resource_group):
-        managed_cluster_name = self.create_random_name(prefix='test-troubleshoot', length=24)
-        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
-        self.kwargs.update({
-            'name': self.create_random_name(prefix='cc-', length=12),
-            'kubeconfig': kubeconfig,
-            'rg': resource_group,
-            'managed_cluster_name': managed_cluster_name,
-            'location': CONFIG['location']
-        })
+        managed_cluster_name = self.create_random_name(
+            prefix="test-troubleshoot", length=24
+        )
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
+        self.kwargs.update(
+            {
+                "name": self.create_random_name(prefix="cc-", length=12),
+                "kubeconfig": kubeconfig,
+                "rg": resource_group,
+                "managed_cluster_name": managed_cluster_name,
+                "location": CONFIG["location"],
+            }
+        )
 
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}')
-        ])
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('tags.foo', 'doo')
-        ])
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin",
+            checks=[self.check("tags.foo", "doo"), self.check("name", "{name}")],
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("tags.foo", "doo"),
+            ],
+        )
 
-        self.cmd('connectedk8s troubleshoot -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin')
+        self.cmd(
+            "connectedk8s troubleshoot -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin"
+        )
 
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))
 
     @live_only()
-    @ResourceGroupPreparer(name_prefix='conk8stest', location=CONFIG['location'], random_name_length=16)
+    @ResourceGroupPreparer(
+        name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
+    )
     def test_proxy(self, resource_group):
-        managed_cluster_name = self.create_random_name(prefix='test-proxy', length=24)
-        kubeconfig = _get_test_data_file(managed_cluster_name + '-config.yaml')
-        kubeconfig2 = _get_test_data_file(managed_cluster_name + '-config2.yaml')
-        name = self.create_random_name(prefix='cc-', length=12)
-        self.kwargs.update({
-            'name': name,
-            'kubeconfig': kubeconfig,
-            'kubeconfig2': kubeconfig2,
-            'rg': resource_group,
-            'managed_cluster_name': managed_cluster_name,
-            'location': CONFIG['location']
-        })
+        managed_cluster_name = self.create_random_name(prefix="test-proxy", length=24)
+        kubeconfig = _get_test_data_file(managed_cluster_name + "-config.yaml")
+        kubeconfig2 = _get_test_data_file(managed_cluster_name + "-config2.yaml")
+        name = self.create_random_name(prefix="cc-", length=12)
+        self.kwargs.update(
+            {
+                "name": name,
+                "kubeconfig": kubeconfig,
+                "kubeconfig2": kubeconfig2,
+                "rg": resource_group,
+                "managed_cluster_name": managed_cluster_name,
+                "location": CONFIG["location"],
+            }
+        )
 
         # Check for existing process using the required ports for the proxy test.
         # Commands to check which process is using the required ports:
@@ -709,12 +957,15 @@ only supported when auto-upgrade is set to false"):
         for proc in psutil.process_iter():
             try:
                 for conn in proc.connections():
-                    if conn.laddr.port == consts.API_SERVER_PORT or conn.laddr.port == consts.CLIENT_PROXY_PORT:
+                    if (
+                        conn.laddr.port == consts.API_SERVER_PORT
+                        or conn.laddr.port == consts.CLIENT_PROXY_PORT
+                    ):
                         raise ValidationError(f"""Ports {consts.API_SERVER_PORT} or {consts.CLIENT_PROXY_PORT} are in \
 use by process named {proc.name()}. Please kill it before proceeding with the live test.
 Process currently using the ports: {proc}""")
             # Might get AccessDenied in Unix environments. This is because elevated privilege is required to view \
-                # system and root processes.
+            # system and root processes.
             # The proxy process is not a system or root process, so we ignore the AccessDenied exceptions.
             except psutil.AccessDenied:
                 access_denied = True
@@ -724,51 +975,82 @@ Process currently using the ports: {proc}""")
 they are not using the ports required by the proxy process.
 If there are any issues with the test, please verify manually that there are no processes using ports \
 {consts.API_SERVER_PORT} and {consts.CLIENT_PROXY_PORT}.""")
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}')
-        ])
-        self.cmd('connectedk8s show -g {rg} -n {name}', checks=[
-            self.check('name', '{name}'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('tags.foo', 'doo')
-        ])
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin",
+            checks=[self.check("tags.foo", "doo"), self.check("name", "{name}")],
+        )
+        self.cmd(
+            "connectedk8s show -g {rg} -n {name}",
+            checks=[
+                self.check("name", "{name}"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("tags.foo", "doo"),
+            ],
+        )
 
         expected_status = "LISTEN"
         operating_system = platform.system()
         windows_os = "Windows"
         proxy_process_name = None
         if operating_system == windows_os:
-            proxy_process_name = f"arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}.exe"
+            proxy_process_name = (
+                f"arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}.exe"
+            )
         else:
-            proxy_process_name = f"arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}"
+            proxy_process_name = (
+                f"arcProxy{operating_system}{consts.CLIENT_PROXY_VERSION}"
+            )
 
         # There cannot be more than one connectedk8s proxy running, since they would use the same port.
-        script = ['az', 'connectedk8s', 'proxy', '-n', name, '-g', resource_group, '-f', kubeconfig2]
+        script = [
+            "az",
+            "connectedk8s",
+            "proxy",
+            "-n",
+            name,
+            "-g",
+            resource_group,
+            "-f",
+            kubeconfig2,
+        ]
 
         # Subprocesses functions sometimes don't work as expected on Windows. Try to limit their usage in the tests.
         # The proxy command requires creating a new process since it creates an infinite loop until user exits \
-            # with CTRL + C.
+        # with CTRL + C.
         parent_process = None
         if operating_system == windows_os:
-            parent_process = subprocess.Popen(script, shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
-                                              stderr=subprocess.STDOUT, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+            parent_process = subprocess.Popen(
+                script,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+            )
         else:
-            parent_process = subprocess.Popen(script, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
-                                              stderr=subprocess.STDOUT)
+            parent_process = subprocess.Popen(
+                script,
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
 
         # Time to let the kubeconfig merge in current context. No way to detect when exactly the merge is done \
-            # because the
+        # because the
         # "az connectedk8s proxy" command creates an infinite loop that requires CTRL+C to exit.
         time.sleep(15)
         # Note that the found_proxy_process is the actual child proxy process.
         found_proxy_process = None
         for proc in psutil.process_iter():
-            if proc.name() == proxy_process_name and (proc.connections()[0].laddr.port in {consts.API_SERVER_PORT,
-                                                                                           consts.CLIENT_PROXY_PORT}):
+            if proc.name() == proxy_process_name and (
+                proc.connections()[0].laddr.port
+                in {consts.API_SERVER_PORT, consts.CLIENT_PROXY_PORT}
+            ):
                 found_proxy_process = proc
         wait_interval = 5
         timeout = 60
@@ -778,13 +1060,19 @@ If there are any issues with the test, please verify manually that there are no 
             time.sleep(wait_interval)
             cur += wait_interval
             for proc in psutil.process_iter():
-                if proc.name() == proxy_process_name and (proc.connections()[0].laddr.port in 
-                                                          {consts.API_SERVER_PORT, consts.CLIENT_PROXY_PORT}):
+                if proc.name() == proxy_process_name and (
+                    proc.connections()[0].laddr.port
+                    in {consts.API_SERVER_PORT, consts.CLIENT_PROXY_PORT}
+                ):
                     found_proxy_process = proc
         if cur > timeout:
             proxy_process_stdout, proxy_process_stderr = parent_process.communicate()
-            proxy_process_stdout = proxy_process_stdout.decode("utf-8") if proxy_process_stdout else None
-            proxy_process_stderr = proxy_process_stderr.decode("utf-8") if proxy_process_stderr else None
+            proxy_process_stdout = (
+                proxy_process_stdout.decode("utf-8") if proxy_process_stdout else None
+            )
+            proxy_process_stderr = (
+                proxy_process_stderr.decode("utf-8") if proxy_process_stderr else None
+            )
             raise ValidationError(f"""Timed out waiting for creation of {proxy_process_name} process.
 Proxy process stdout retrieval attempt:\n{proxy_process_stdout}
 Proxy process stderr retrieval attempt:\n{proxy_process_stderr}""")
@@ -801,12 +1089,22 @@ Proxy process stderr retrieval attempt:\n{proxy_process_stderr}""")
             elif conn.laddr.port == consts.API_SERVER_PORT:
                 api_server_port = conn.laddr.port
                 proxy_port_status = conn.status
-        if (api_server_port_status != expected_status and proxy_port_status != expected_status) \
-            or not api_server_port or not proxy_port:
+        if (
+            (
+                api_server_port_status != expected_status
+                and proxy_port_status != expected_status
+            )
+            or not api_server_port
+            or not proxy_port
+        ):
             found_proxy_process.terminate()
             proxy_process_stdout, proxy_process_stderr = parent_process.communicate()
-            proxy_process_stdout = proxy_process_stdout.decode("utf-8") if proxy_process_stdout else None
-            proxy_process_stderr = proxy_process_stderr.decode("utf-8") if proxy_process_stderr else None
+            proxy_process_stdout = (
+                proxy_process_stdout.decode("utf-8") if proxy_process_stdout else None
+            )
+            proxy_process_stderr = (
+                proxy_process_stderr.decode("utf-8") if proxy_process_stderr else None
+            )
             raise ValidationError(f"""Connectedk8s proxy process is in an unexpected state.
 Expected status 'LISTEN' on ports '{consts.API_SERVER_PORT}' and '{consts.CLIENT_PROXY_PORT}'.
 Current proxy process status: {found_proxy_process}.
@@ -814,7 +1112,7 @@ Proxy process stdout retrieval attempt:\n{proxy_process_stdout}
 Proxy process stderr retrieval attempt:\n{proxy_process_stderr}""")
 
         # Wait for kubeconfig file to be merged into kube kubeconfig2
-        kubeconfig2_fixed_path = kubeconfig2.replace(os.sep, '/')
+        kubeconfig2_fixed_path = kubeconfig2.replace(os.sep, "/")
         cur = 0
         while not (os.path.isfile(kubeconfig2_fixed_path)) and not (cur > timeout):
             time.sleep(wait_interval)
@@ -830,48 +1128,64 @@ Proxy process stderr retrieval attempt:\n{proxy_process_stderr}""")
 
         # Subprocess' communicate() can also be used to send stdin to its child process that is our proxy process.
         proxy_process_stdout, proxy_process_stderr = parent_process.communicate()
-        proxy_process_stdout = proxy_process_stdout.decode("utf-8") if proxy_process_stdout else None
-        proxy_process_stderr = proxy_process_stderr.decode("utf-8") if proxy_process_stderr else None
+        proxy_process_stdout = (
+            proxy_process_stdout.decode("utf-8") if proxy_process_stdout else None
+        )
+        proxy_process_stderr = (
+            proxy_process_stderr.decode("utf-8") if proxy_process_stderr else None
+        )
         # For some reason logger.info doesn't output to stdout during the test.
         print(f"""Output received while exiting proxy process:
 stdout: {proxy_process_stdout}
 stderr: {proxy_process_stderr}""")
 
         # Clean up the cluster.
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # Delete the kube config files.
         os.remove(kubeconfig)
         os.remove(kubeconfig2)
-        
+
     @live_only()
-    @ResourceGroupPreparer(name_prefix='sslk8stest', location=CONFIG['location'], random_name_length=16)
-    def test_skipping_ssl_verification(self,resource_group):
-       
-        managed_cluster_name = self.create_random_name(prefix='test-ssl', length=24)
-        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml'))
-        self.kwargs.update({
-            'rg': resource_group,
-            'name': self.create_random_name(prefix='cc-', length=12),
-            'kubeconfig': kubeconfig,
-            'managed_cluster_name': managed_cluster_name,
-            'location': CONFIG['location']
-        })
+    @ResourceGroupPreparer(
+        name_prefix="sslk8stest", location=CONFIG["location"], random_name_length=16
+    )
+    def test_skipping_ssl_verification(self, resource_group):
+        managed_cluster_name = self.create_random_name(prefix="test-ssl", length=24)
+        kubeconfig = "%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml"))
+        self.kwargs.update(
+            {
+                "rg": resource_group,
+                "name": self.create_random_name(prefix="cc-", length=12),
+                "kubeconfig": kubeconfig,
+                "managed_cluster_name": managed_cluster_name,
+                "location": CONFIG["location"],
+            }
+        )
 
-        self.cmd('aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys')
-        self.cmd('aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin')
-        self.cmd('connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
-            --kube-context {managed_cluster_name}-admin --skip-ssl-verification', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('resourceGroup', '{rg}'),
-            self.check('name', '{name}')
-        ])
+        self.cmd("aks create -g {rg} -n {managed_cluster_name} --generate-ssh-keys")
+        self.cmd(
+            "aks get-credentials -g {rg} -n {managed_cluster_name} -f {kubeconfig} --admin"
+        )
+        self.cmd(
+            "connectedk8s connect -g {rg} -n {name} -l {location} --tags foo=doo --kube-config {kubeconfig} \
+            --kube-context {managed_cluster_name}-admin --skip-ssl-verification",
+            checks=[
+                self.check("tags.foo", "doo"),
+                self.check("resourceGroup", "{rg}"),
+                self.check("name", "{name}"),
+            ],
+        )
 
-        self.cmd('connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
-            {managed_cluster_name}-admin -y')
-        self.cmd('aks delete -g {rg} -n {managed_cluster_name} -y')
+        self.cmd(
+            "connectedk8s delete -g {rg} -n {name} --kube-config {kubeconfig} --kube-context \
+            {managed_cluster_name}-admin -y"
+        )
+        self.cmd("aks delete -g {rg} -n {managed_cluster_name} -y")
 
         # delete the kube config
-        os.remove("%s" % (_get_test_data_file(managed_cluster_name + '-config.yaml')))
+        os.remove("%s" % (_get_test_data_file(managed_cluster_name + "-config.yaml")))

--- a/src/connectedk8s/pyproject.toml
+++ b/src/connectedk8s/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.ruff]
+extend-exclude = [
+  "azext_connectedk8s/vendored_sdks",
+]

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -8,56 +8,64 @@
 
 from codecs import open
 from setuptools import setup, find_packages
+
 try:
     from azure_bdist_wheel import cmdclass
 except ImportError:
     from distutils import log as logger
+
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.10.0'
+VERSION = "1.10.0"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [
-    'Development Status :: 4 - Beta',
-    'Intended Audience :: Developers',
-    'Intended Audience :: System Administrators',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'License :: OSI Approved :: MIT License',
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "License :: OSI Approved :: MIT License",
 ]
 
 # TODO: Add any additional SDK dependencies here
 DEPENDENCIES = [
-    'kubernetes==24.2.0',
-    'pycryptodome==3.14.1',
-    'azure-mgmt-hybridcompute==7.0.0'
+    "kubernetes==24.2.0",
+    "pycryptodome==3.14.1",
+    "azure-mgmt-hybridcompute==7.0.0",
 ]
 
-with open('README.md', 'r', encoding='utf-8') as f:
+with open("README.md", "r", encoding="utf-8") as f:
     README = f.read()
-with open('HISTORY.rst', 'r', encoding='utf-8') as f:
+with open("HISTORY.rst", "r", encoding="utf-8") as f:
     HISTORY = f.read()
 
 setup(
-    name='connectedk8s',
+    name="connectedk8s",
     version=VERSION,
-    description='Microsoft Azure Command-Line Tools Connectedk8s Extension',
+    description="Microsoft Azure Command-Line Tools Connectedk8s Extension",
     # TODO: Update author and email, if applicable
-    author='Microsoft Corporation',
-    author_email='k8connect@microsoft.com',
-    url='https://github.com/Azure/azure-cli-extensions/tree/main/src/connectedk8s',
-    long_description=README + '\n\n' + HISTORY,
+    author="Microsoft Corporation",
+    author_email="k8connect@microsoft.com",
+    url="https://github.com/Azure/azure-cli-extensions/tree/main/src/connectedk8s",
+    long_description=README + "\n\n" + HISTORY,
     long_description_content_type="text/markdown",
-    license='MIT',
+    license="MIT",
     classifiers=CLASSIFIERS,
     packages=find_packages(),
     install_requires=DEPENDENCIES,
-    package_data={'azext_connectedk8s': ['azext_metadata.json', 'troubleshoot_diagnoser_job_with_proxycert_mount.yaml', 'troubleshoot_diagnoser_job_without_proxycert.yaml']},
+    package_data={
+        "azext_connectedk8s": [
+            "azext_metadata.json",
+            "troubleshoot_diagnoser_job_with_proxycert_mount.yaml",
+            "troubleshoot_diagnoser_job_without_proxycert.yaml",
+        ]
+    },
 )

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -9,12 +9,6 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-try:
-    from azure_bdist_wheel import cmdclass
-except ImportError:
-    from distutils import log as logger
-
-    logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.


### PR DESCRIPTION
some mostly automatic formatting and linting, using https://docs.astral.sh/ruff/

- the first commit is ruff's automatic formatting, I am confident in trusting ruff to have made only cosmetic changes here
- the second commit is ruff's automatic fixes for the default set of its own lints - where ruff considers them "safe" to make
  - looks like this is entirely removing unused imports, again I am confident in the tool to have done the right thing
- the third commit is done manually, and therefore should be considered more likely to contain errors
  - the interesting ones IMO are (i) removing code that gets the unused `onboarding_tenant_id` (should this have been used?) and (ii) _using_ the previously unused `protected_settings` when constructing `ArcAgentryConfigurations`