### PR TITLE
add_config_protected_settings parameters in wrong order

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -4764,8 +4764,8 @@ def check_operation_support(operation_name, agent_version):
 
 
 def add_config_protected_settings(
-    https_proxy,
     http_proxy,
+    https_proxy,
     no_proxy,
     proxy_cert,
     container_log_path,


### PR DESCRIPTION
callers of `add_config_protected_settings()` pass parameters in the order `http_proxy`, `https_proxy`

so let's expect to receive them in that order too!