### PR TITLE
Relax RP registration checks

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/_constants.py
+++ b/src/connectedk8s/azext_connectedk8s/_constants.py
@@ -505,3 +505,9 @@ Doc_Provisioned_Cluster_Delete_Url = "https://learn.microsoft.com/en-us/cli/azur
 Doc_Provisioned_Cluster_Update_Url = "https://learn.microsoft.com/en-us/cli/azure/aksarc?view=azure-cli-latest#az-aksarc-update"
 Doc_Provisioned_Cluster_Upgrade_Url = "https://learn.microsoft.com/en-us/cli/azure/aksarc?view=azure-cli-latest#az-aksarc-upgrade"
 Doc_Agent_Version_Support_Policy_Url = "https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/agent-upgrade#version-support-policy"
+
+# Acceptable states for required RP registrations to be in
+#
+# "Application code shouldn't block the creation of resources for a resource provider that is in the registering state."
+# See https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider
+allowed_rp_registration_states = ["Registering", "Registered"]

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -1480,7 +1480,7 @@ def check_provider_registrations(
         cc_registration_state = rp_client.get(
             consts.Connected_Cluster_Provider_Namespace
         ).registration_state
-        if cc_registration_state != "Registered":
+        if cc_registration_state not in consts.allowed_rp_registration_states:
             telemetry.set_exception(
                 exception="{} provider is not registered".format(
                     consts.Connected_Cluster_Provider_Namespace
@@ -1500,7 +1500,7 @@ def check_provider_registrations(
         kc_registration_state = rp_client.get(
             consts.Kubernetes_Configuration_Provider_Namespace
         ).registration_state
-        if kc_registration_state != "Registered":
+        if kc_registration_state not in consts.allowed_rp_registration_states:
             if is_workload_identity_enabled:
                 telemetry.set_exception(
                     exception="{} provider is not registered".format(
@@ -1529,7 +1529,7 @@ def check_provider_registrations(
             hc_registration_state = rp_client.get(
                 consts.Hybrid_Compute_Provider_Namespace
             ).registration_state
-            if hc_registration_state != "Registered":
+            if hc_registration_state not in consts.allowed_rp_registration_states:
                 telemetry.set_exception(
                     exception="{} provider is not registered".format(
                         consts.Hybrid_Compute_Provider_Namespace


### PR DESCRIPTION
Fixes https://msazure.visualstudio.com/AzureArcPlatform/_workitems/edit/29389897

We noticed this bug because the end-to-end gateway tests suddenly stopped working, where they were working fine before.

> "Application code shouldn't block the creation of resources for a resource provider that is in the registering state."

[source](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider)
